### PR TITLE
Deprecation warnings - psutil 0.6.0 version

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -565,11 +565,6 @@ class glancesStats:
             self.load = {}
 
         # MEM
-        # !!! TODO
-        # To be replaced by: psutil.virtual_memory() et psutil.swap_memory()
-        # In the PsUtil version 0.6 or higher
-        # !!!
-        #
         try:
             # Only for Linux
             cachemem = psutil.cached_phymem() + psutil.phymem_buffers()
@@ -577,7 +572,7 @@ class glancesStats:
             cachemem = 0
 
         try:
-            phymem = psutil.phymem_usage()
+            phymem = psutil.virtual_memory()
             self.mem = {'cache': cachemem,
                         'total': phymem.total,
                         'used': phymem.used,


### PR DESCRIPTION
This will solve deprecation warnings for psutil 0.6.0 version. 

More information: http://goo.gl/47Bys

Warnings (debian squeeze 6.0.5):

/usr/local/lib/python2.6/dist-packages/glances/glances.py:89: DeprecationWarning: psutil.phymem_usage is deprecated
  psutil.phymem_usage()
/usr/local/lib/python2.6/dist-packages/glances/glances.py:90: DeprecationWarning: psutil.virtmem_usage is deprecated; use psutil.swap_memory() instead
  psutil.virtmem_usage()
