### PR TITLE
glances: fix crasher

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -728,12 +728,12 @@ class GlancesStats:
             phymem = psutil.virtual_memory()
 
             # buffers and cached (Linux, BSD)
-            buffers = getattr(phymem, 'buffers', lambda: 0)
-            cached = getattr(phymem, 'cached', lambda: 0)
+            buffers = getattr(phymem, 'buffers', lambda: 0)()
+            cached = getattr(phymem, 'cached', lambda: 0)()
 
             # active and inactive not available on Windows
-            active = getattr(phymem, 'active', lambda: 0)
-            inactive = getattr(phymem, 'inactive', lambda: 0)
+            active = getattr(phymem, 'active', lambda: 0)()
+            inactive = getattr(phymem, 'inactive', lambda: 0)()
 
             # phymem free and usage
             total = phymem.total


### PR DESCRIPTION
you need to call the function otherwise you will try running float() on
a function later when you try displaying it

Introduced in eda1cf5ba750ed82700b018b799db2ca31693870
