### PR TITLE
Test: python3 compatibility fix

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -2127,17 +2127,17 @@ class glancesScreen:
                 self.term_window.addnstr(
                     self.process_y + 2, process_x + process_name_x,
                     format(_("TIME+"), '>8'), 8)
-                process_name_x += 10
+                process_name_x += 9
             # IO
             if tag_io:
                 self.term_window.addnstr(
                     self.process_y + 2, process_x + process_name_x,
-                    format(_("IO_R"), '>4'), 4)
+                    format(_("IO_R"), '>5'), 5)
                 process_name_x += 6
                 self.term_window.addnstr(
                     self.process_y + 2, process_x + process_name_x,
-                    format(_("IO_W"), '>4'), 4)
-                process_name_x += 6
+                    format(_("IO_W"), '>5'), 5)
+                process_name_x += 7
             # PROCESS NAME
             self.term_window.addnstr(
                 self.process_y + 2, process_x + process_name_x,
@@ -2227,22 +2227,22 @@ class glancesScreen:
                     try:
                         if  processlist[processes]['io_counters'] == {}:
                             self.term_window.addnstr(
-                                self.process_y + 3 + processes, process_x + 57,
-                                "   ?", 4)
+                                self.process_y + 3 + processes, process_x + 56,
+                                format("?", '>5'), 5)
                             self.term_window.addnstr(
-                                self.process_y + 3 + processes, process_x + 63,
-                                "   ?", 4)
+                                self.process_y + 3 + processes, process_x + 62,
+                                format("?", '>5'), 5)
                         else:
                             # Processes are only refresh every 2 refresh_time
                             #~ elapsed_time = max(1, self.__refresh_time) * 2
                             io_read = processlist[processes]['io_counters'][2]
                             self.term_window.addnstr(
-                                self.process_y + 3 + processes, process_x + 57,
-                                format(self.__autoUnit(io_read), '>4'), 4)
+                                self.process_y + 3 + processes, process_x + 56,
+                                format(self.__autoUnit(io_read), '>5'), 5)
                             io_write = processlist[processes]['io_counters'][3]
                             self.term_window.addnstr(
-                                self.process_y + 3 + processes, process_x + 63,
-                                format(self.__autoUnit(io_write), '>4'), 4)
+                                self.process_y + 3 + processes, process_x + 62,
+                                format(self.__autoUnit(io_write), '>5'), 5)
                     except:
                         pass
 

--- a/glances/unitest.py
+++ b/glances/unitest.py
@@ -24,9 +24,8 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-import glances
 import multiprocessing
-# import time
+import glances
 
 
 class TestGlancesStat(unittest.TestCase):
@@ -38,45 +37,45 @@ class TestGlancesStat(unittest.TestCase):
     def test_Glances_getSystem(self):
         self.stats.update()
         system = self.stats.getSystem()
-        print "System info: %s" % system
+        print("System info: %s" % system)
         self.assertTrue(len(system) > 1)
 
     def test_Glances_getCore(self):
         self.stats.update()
         core = self.stats.getCore()
-        print "CPU Core number: %s" % core
+        print("CPU Core number: %s" % core)
         self.assertEqual(core, multiprocessing.cpu_count())
 
     def test_Glances_getCpu(self):
         self.stats.update()
         cpu = self.stats.getCpu()
-        print "CPU stat %s:" % cpu
+        print("CPU stat %s:" % cpu)
         self.assertTrue(len(cpu) > 1)
 
     def test_Glances_getPerCpu(self):
         self.stats.update()
         percpu = self.stats.getPerCpu()
-        print "PerCPU stat %s:" % percpu
+        print("PerCPU stat %s:" % percpu)
         self.assertEqual(len(percpu), multiprocessing.cpu_count())
 
     def test_Glances_getMem(self):
         self.stats.update()
         mem = self.stats.getMem()
-        print "Mem stat %s:" % mem
+        print("Mem stat %s:" % mem)
         self.assertTrue(len(mem) > 2)
 
     def test_Glances_getMemSwap(self):
         self.stats.update()
         memswap = self.stats.getMemSwap()
-        print "MemSwap stat %s:" % memswap
+        print("MemSwap stat %s:" % memswap)
         self.assertTrue(len(memswap) > 2)
-        
+
     def test_Glances_getNetwork(self):
         self.stats.update()
         net = self.stats.getNetwork()
-        print "Network stat %s:" % net
+        print("Network stat %s:" % net)
         self.assertTrue(len(net) > 1)
-        
-        
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- test: add python3 compatibility in order to fix a bug that causes installation to fail
- fix a bug in IO R/W to show more than 4 chars (e.g. 1024M)

P.S. pysensors is python2-only, so it's not possible to use glances + sensors with python3.
