### PR TITLE
Support processes with uids unknown to pwd lib.

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -630,7 +630,10 @@ class GlancesGrabProcesses:
 
         procstat['name'] = proc.name
         procstat['pid'] = proc.pid
-        procstat['username'] = proc.username
+        try:
+            procstat['username'] = proc.username
+        except KeyError:
+            procstat['username'] = proc.uids.real
         procstat['cmdline'] = " ".join(proc.cmdline)
         procstat['memory_info'] = proc.get_memory_info()
         procstat['memory_percent'] = proc.get_memory_percent()


### PR DESCRIPTION
If You have processes unknown to pwd library (e.g. entry removed from /etc/passwd) - glances have unhandled exception.

This little patch handles this exception.
