### PR TITLE
Add per-user settings support

### DIFF
--- a/README
+++ b/README
@@ -106,7 +106,20 @@ No configuration is needed to use Glances.
 
 Furthermore, the release 1.6 introduces a configuration file to setup limits.
 
-The default configuration file is under the /etc/glances/glances.conf file.
+The default configuration file is under:
+
+    /etc/glances/glances.conf (Linux)
+or
+
+    /usr/local/etc/glances.conf (*BSD and OS X)
+
+To override the default configuration, you can copy the `glances.conf` file to
+your `$XDG_CONFIG_HOME` directory (e.g. Linux):
+
+    mkdir -p $XDG_CONFIG_HOME/glances
+    cp /etc/glances/glances.conf $XDG_CONFIG_HOME/glances/
+
+On OS X, you should copy the configuration file to `~/Library/Application Support/glances/`.
 
 ## Running
 
@@ -138,7 +151,7 @@ In client mode, you can set the TCP port of the server (-p port).
 
 Default binding address is 0.0.0.0 (Glances will listen on all the networks interfaces) and TCP port is 61209.
 
-In client/server mode, limits are set by the server side. 
+In client/server mode, limits are set by the server side.
 
 The version 1.6 introduces a optionnal password to access to the server (-P password).
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,20 @@ No configuration is needed to use Glances.
 
 Furthermore, the release 1.6 introduces a configuration file to setup limits.
 
-The default configuration file is under the /etc/glances/glances.conf file.
+The default configuration file is under:
+
+    /etc/glances/glances.conf (Linux)
+or
+
+    /usr/local/etc/glances.conf (*BSD and OS X)
+
+To override the default configuration, you can copy the `glances.conf` file to
+your `$XDG_CONFIG_HOME` directory (e.g. Linux):
+
+    mkdir -p $XDG_CONFIG_HOME/glances
+    cp /etc/glances/glances.conf $XDG_CONFIG_HOME/glances/
+
+On OS X, you should copy the configuration file to `~/Library/Application Support/glances/`.
 
 ## Running
 
@@ -138,7 +151,7 @@ In client mode, you can set the TCP port of the server (-p port).
 
 Default binding address is 0.0.0.0 (Glances will listen on all the networks interfaces) and TCP port is 61209.
 
-In client/server mode, limits are set by the server side. 
+In client/server mode, limits are set by the server side.
 
 The version 1.6 introduces a optionnal password to access to the server (-P password).
 

--- a/man/glances.1
+++ b/man/glances.1
@@ -6,7 +6,7 @@ glances \- CLI curses based monitoring tool
 [\-bdehmnsv] [\-C conffile] [\-t refresh] [\-B bind] [\-c server] [\-p port] [\-P password] [\-o output] [\-f file]
 .SH DESCRIPTION
 Glances is a free (LGPL) curses-based  monitoring tool which aims to present a maximum of information
-in a minimum of space, ideally to fit in a classical 80x24 terminal or higher to have additionnal information. 
+in a minimum of space, ideally to fit in a classical 80x24 terminal or higher to have additionnal information.
 Glances can adapt dynamicaly the displayed information depending on the terminal size.
 It can also work in a client/server mode (for remote monitoring).
 .PP
@@ -61,7 +61,7 @@ Bind server to the given IP or host NAME
 Connect to a Glances server (IP address or hostname)
 .TP
 \-C conffile
-Use a configuration file (default is /etc/glances/glances.conf)
+Use a configuration file (default: {/usr/local,}/etc/glances/glances.conf)
 .TP
 \-d
 Disable disk I/O module

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from glob import glob
-from os.path import dirname
+import os
+import sys
+import glob
 
 from setuptools import setup
 
@@ -13,15 +14,20 @@ data_files = [
                            'NEWS',
                            'screenshot.png',
                            'glances/conf/glances.conf']),
-    ('share/doc/glances/doc', glob('doc/*.png')),
-    ('etc/glances', ['glances/conf/glances.conf']),
-    ('share/glances/html', glob('glances/html/*.html')),
-    ('share/glances/css', glob('glances/css/*.css')),
-    ('share/glances/img', glob('glances/img/*.png')),
+    ('share/doc/glances/doc', glob.glob('doc/*.png')),
+    ('share/glances/html', glob.glob('glances/html/*.html')),
+    ('share/glances/css', glob.glob('glances/css/*.css')),
+    ('share/glances/img', glob.glob('glances/img/*.png')),
 ]
 
-for mo in glob('i18n/*/LC_MESSAGES/*.mo'):
-    data_files.append((dirname(mo).replace('i18n/', 'share/locale/'), [mo]))
+if hasattr(sys, 'real_prefix') or ('bsd' or 'darwin' in sys.platform):
+    etc_path = os.path.join(sys.prefix, 'etc', 'glances')
+if not hasattr(sys, 'real_prefix') and 'linux' in sys.platform:
+    etc_path = os.path.join('/etc', 'glances')
+data_files.append((etc_path, ['glances/conf/glances.conf']))
+
+for mo in glob.glob('i18n/*/LC_MESSAGES/*.mo'):
+    data_files.append((os.path.dirname(mo).replace('i18n/', 'share/locale/'), [mo]))
 
 setup(
     name='Glances',


### PR DESCRIPTION
- Add per-user settings support: just copy the `glances.conf` configuration file to `$XDG_CONFIG_HOME/glances` directory (Linux and *BSD) or `~/Library/Application Support/glances` (OS X). Per-user configuration override the default system-wide, if it exists.
- Fix location of default configuration file: `/etc/glances` (Linux), `/usr/local/etc/glances` (*BSD and OS X)
- Bonus: Fix installation under virtualenv
