### PR TITLE
Fix process list delay

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -1075,14 +1075,8 @@ class GlancesStats:
 
         # PROCESS
         self.glancesgrabprocesses.update()
-        processcount = self.glancesgrabprocesses.getcount()
-        process = self.glancesgrabprocesses.getlist()
-        if not hasattr(self, 'process'):
-            self.processcount = {}
-            self.process = []
-        else:
-            self.processcount = processcount
-            self.process = process
+        self.processcount = self.glancesgrabprocesses.getcount()
+        self.process = self.glancesgrabprocesses.getlist()
 
         # Get the current date/time
         self.now = datetime.now()


### PR DESCRIPTION
Hi,

I removed the display delay mentioned in #188. The process list now displayed immediately after start which is much better for me than to wait for the first display update for several seconds.
