### PR TITLE
Fixes #215 changed timer to only reset when an update is run, not just an attempt to update

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -3192,6 +3192,9 @@ class GlancesInstance():
     """
 
     def __init__(self, cached_time=1):
+        # cached_time is the minimum time interval between stats updates
+        # i.e. XML/RPC calls will not retrieve updated info until the time
+        # since last update is passed (will retrieve old cached info instead)
         self.timer = Timer(0)
         self.cached_time = cached_time
 
@@ -3199,7 +3202,7 @@ class GlancesInstance():
         # Never update more than 1 time per cached_time
         if self.timer.finished():
             stats.update()
-        self.timer = Timer(self.cached_time)
+            self.timer = Timer(self.cached_time)
 
     def init(self):
         # Return the Glances version


### PR DESCRIPTION
Before, I could still lock the data forever by calling faster than once per second.
Now, I can call as fast as I want an the number of calls to update is still controlled by cached_time.
I get the following results using java-glances to call every 300ms:

```
Connecting to glances server: 'http://localhost:61209/RPC2'
Time: 10:32:48
Testing getNow()
[current time]: Tue Mar 19 10:32:49 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:49 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:49 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:49 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:50 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:50 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:50 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:50 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:51 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:51 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:51 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:51 CST 2013
Testing getNow()
[current time]: Tue Mar 19 10:32:53 CST 2013
```
