### PR TITLE
Solve  when terminal window size is 80 * 24 press "h" error bug

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -3266,7 +3266,10 @@ class glancesScreen:
 
             width = 3
             key_table_x = self.help_x + 2
-            key_table_y = limits_table_y + 1
+            if screen_y > 24:
+                key_table_y = limits_table_y + 1
+            else:
+                key_table_y = limits_table_y
             for key in key_col_left:
                 self.term_window.addnstr(
                     key_table_y, key_table_x,


### PR DESCRIPTION
When I use Glances. I found that when clicking 'h' that you want to display help information will display error（a part）:

```
self.displayHelp(core=stats.getCore())
File "/usr/lib64/python2.7/site-packages/Glances-1.7a-py2.7.egg/glances/glances.py", line 3187, in displayHelp
'{0:{width}}{1}'.format(*key, width=width), 38)
_curses.error: addnstr() returned ERR
```

I modified the source code for this situation made ​​a judgment, and then remove the spacer block above them .... I do not know there is no better way to achieve
