### PR TITLE
Solve Locale is invalid bug

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -38,7 +38,8 @@ import locale
 import gettext
 import socket
 locale.setlocale(locale.LC_ALL, '')
-gettext.install(__appname__)
+cur_dir = os.path.split(os.path.realpath(__file__))[0]
+gettext.install(__appname__, '{0}/../share/locale'.format(cur_dir))
 
 # Specifics libs
 import json


### PR DESCRIPTION
my system is osx 10.8.4. When I set the LANG and LC_ALL, internationalization does not work, then find there is no right to find the mo files. 
