### PR TITLE
old version compatible invalid bug

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -3769,7 +3769,7 @@ class GlancesClient():
 
     def client_init(self):
         try:
-            self.client.init()
+            client_version = self.client.init()
         except ProtocolError as err:
             if str(err).find(" 401 ") > 0:
                 print(_("Error: Connection to server failed. Bad password."))
@@ -3777,13 +3777,7 @@ class GlancesClient():
             else:
                 print(_("Error: Connection to server failed. Unknown error."))
                 sys.exit(-1)
-        try:
-            client_version = self.client.init()[:3]
-        except:
-            print(_("Error: Connection to server failed. Can not get the server version."))
-            sys.exit(-1)
-        else:
-            return __version__[:2] == client_version[:2]
+        return __version__[:3] == client_version[:3]
 
     def client_get_limits(self):
         try:


### PR DESCRIPTION
My remote server install from pip, it's version is 1.6.1. The local version is 1.7a. when i use the -c option connect to the remote server and then use the key 'h', display error 

because hddtemp is added after the 1.6.1 support, so this option local has, but the remote server does not. This is have wrong version verification, client_version [: 2]  always has been "1.", there is no effect, so now is client_version [: 3]. 

Moreover self.client.init () returns is the version number, 

```
client_version = self.client.init () [: 3] 
```

meaningless because The results of the above code execution is a string.  
