### PR TITLE
Added package name for python sources/headers in SUSE distros

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,8 @@
 
 <p><em>Note</em>: On Fedora/CentOS/RH, you need to install first the <em>python-devel</em> package (from the EPEL repository).</p>
 
+<p><em>Note</em>: On openSUSE/SLES/SLED, you need to install first the <em>python-devel</em> package (from the Oss repository).</p>
+
 <p>To upgrade Glances to the latest version:</p>
 
 <pre><code>pip install --upgrade Glances


### PR DESCRIPTION
Added package name for python sources/headers in SUSE distros in installation instructions.
Also changed EPEP to EPEL
