### PR TITLE
Add Windows specific config path

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -401,11 +401,12 @@ class Config:
         * Linux: ~/.config/glances, /etc/glances
         * BSD: ~/.config/glances, /usr/local/etc/glances
         * Mac: ~/Library/Application Support/glances, /usr/local/etc/glances
+        * Win:  %APPDATA%/glances
 
         The config file will be searched in the following order of priority:
             * /path/to/file (via -C flag)
             * /path/to/glances/glances/conf
-            * user's home directory (per-user settings)
+            * user's home directory (per-user settings) ('%HOMEDRIVE%\\Users\\{username}\\AppData\\Roaming' in windows)
             * {/usr/local,}/etc directory (system-wide settings)
         """
         paths = []
@@ -424,6 +425,10 @@ class Config:
         elif is_Mac:
             paths.append(os.path.join(
                 os.path.expanduser('~/Library/Application Support/'),
+                __appname__, self.filename))
+        elif is_Windows:
+            paths.append(os.path.join(
+                os.environ['APPDATA'],
                 __appname__, self.filename))
 
         if is_Linux:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if not hasattr(sys, 'real_prefix') and 'linux' in sys.platform:
 elif 'darwin' in sys.platform:
     etc_path = os.path.join('/usr/local', 'etc', 'glances')
 elif sys.platform.startswith('win'):
-    etc_path = os.path.join(get_python_lib(), 'glances')
+    etc_path = os.path.join(os.environ['APPDATA'], 'glances')
 data_files.append((etc_path, ['glances/conf/glances.conf']))
 
 for mo in glob.glob('i18n/*/LC_MESSAGES/*.mo'):


### PR DESCRIPTION
install psutil
install colorconsole
try: pip install glances
or from source: python setup.py install

Gives a NameError:

Downloading/unpacking glances
Downloading Glances-1.7.1.tar.gz (1.2MB): 1.2MB downloaded
Running setup.py egg_info for package glances
Traceback (most recent call last):
    File "<string>", line 16, in <module>
    File "c:\users\user\appdata\local\temp\pip_build_user\glances\setup.py", line 26, in <module>
        data_files.append((etc_path, ['glances/conf/glances.conf']))
    NameError: name 'etc_path' is not defined
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
  File "<string>", line 16, in <module>
  File "c:\users\user\appdata\local\temp\pip_build_user\glances\setup.py", line 26, in <module>
    data_files.append((etc_path, ['glances/conf/glances.conf']))
NameError: name 'etc_path' is not defined"

System: win7 x64
setuptools: 1.1.5
pip: 1.4.1
