### PR TITLE
Implement toggle of process list display

### DIFF
--- a/glances/glances.py
+++ b/glances/glances.py
@@ -2511,6 +2511,9 @@ class glancesScreen:
         elif self.pressedkey == ord('n') and network_tag:
             # 'n' > Show/hide network stats
             self.network_tag = not self.network_tag
+        elif self.pressedkey == ord('z'):
+            # 'z' > Show/Hide process list
+            self.process_tag = not self.process_tag
         elif self.pressedkey == ord('p'):
             # 'p' > Sort processes by name
             self.setProcessSortedBy('name')


### PR DESCRIPTION
Parsing and displaying the process list takes a sometimes significant
amount of resources.  Since there is already a mechanism in place to run
glances with the process list disabled, it was easy to add a toggle to
the __catchKey function.
