### PR TITLE
change time parameter from int to float

### DIFF
--- a/glances/core/glances_main.py
+++ b/glances/core/glances_main.py
@@ -100,7 +100,7 @@ class GlancesMain(object):
                             help=_('SNMP username (only for SNMPv3)'))
         parser.add_argument('--snmp-auth', default='password', dest='snmp_auth',
                             help=_('SNMP authentication key (only for SNMPv3)'))
-        parser.add_argument('-t', '--time', default=self.refresh_time, type=int,
+        parser.add_argument('-t', '--time', default=self.refresh_time, type=float,
                             dest='time', help=_('set refresh time in seconds [default: {0} sec]').format(self.refresh_time))
         parser.add_argument('-w', '--webserver', action='store_true', default=False,
                             dest='webserver', help=_('run Glances in web server mode'))


### PR DESCRIPTION
Hi, 

Great program, thanks a lot! I changed to input argument for the time interval from int to float. Sometimes this can be handy, top also takes floats as an argument. Your unittest passed, so i hope i didn't break something.
best regards,

Erik

---

<pre>
rabshakeh@lycianode:~/build/glances$ python unitest.py
Unitary tests for glances 2.0.1

==============================================================================
INFO: [TEST_000] Test the stats update function
.
==============================================================================
INFO: [TEST_001] Check the mandatory plugins list: system, cpu, load, mem, memswap, network, diskio, fs
.
==============================================================================
INFO: [TEST_002] Check SYSTEM stats: hostname, os_name
INFO: SYSTEM stats: {'linux_distro': 'debian 7.5', 'platform': '64bit', 'os_name': 'Linux', 'hostname': 'lycianode', 'os_version': '3.2.0-4-amd64'}
.
==============================================================================
INFO: [TEST_003] Check mandatory CPU stats: system, user, idle
INFO: CPU stats: {'softirq': 0.0, 'iowait': 0.0, 'system': 0.4, 'guest': 0.0, 'idle': 99.3, 'user': 0.4, 'guest_nice': 0.0, 'irq': 0.0, 'steal': 0.0, 'nice': 0.0}
.
==============================================================================
INFO: [TEST_004] Check LOAD stats: cpucore, min1, min5, min15
INFO: LOAD stats: {'cpucore': 8, 'min1': 0.0, 'min5': 0.03, 'min15': 0.08}
.
==============================================================================
INFO: [TEST_005] Check MEM stats: available, used, free, total
INFO: MEM stats: {'available': 3755405312L, 'used': 400130048L, 'cached': 2297790464, 'percent': 9.6, 'free': 3755405312L, 'inactive': 2390921216, 'active': 185626624, 'total': 4155535360L, 'buffers': 10465280L}
.
==============================================================================
INFO: [TEST_006] Check SWAP stats: used, free, total
INFO: SWAP stats: {'used': 0L, 'percent': 0.0, 'free': 2831151104L, 'sout': 0, 'total': 2831151104L, 'sin': 0}
.
==============================================================================
INFO: [TEST_007] Check NETWORK stats
INFO: NETWORK stats: [{'tx': 200, 'cumulative_rx': 74987033, 'rx': 200, 'cumulative_cx': 149974066, 'time_since_update': 1, 'cx': 400, 'cumulative_tx': 74987033, 'interface_name': 'lo'}, {'tx': 0, 'cumulative_rx': 9305304, 'rx': 120, 'cumulative_cx': 10306433, 'time_since_update': 1, 'cx': 120, 'cumulative_tx': 1001129, 'interface_name': 'eth0'}]
.
==============================================================================
INFO: [TEST_008] Check DiskIO stats
INFO: diskio stats: [{'time_since_update': 1, 'read_bytes': 0, 'write_bytes': 0, 'disk_name': 'sr0'}, {'time_since_update': 1, 'read_bytes': 0, 'write_bytes': 0, 'disk_name': 'sda5'}, {'time_since_update': 1, 'read_bytes': 0, 'write_bytes': 0, 'disk_name': 'sda2'}, {'time_since_update': 1, 'read_bytes': 0, 'write_bytes': 0, 'disk_name': 'sda1'}]
.
==============================================================================
INFO: [TEST_009] Check FS stats
INFO: FS stats: [{'mnt_point': '/', 'used': 9234894848, 'percent': 14.2, 'device_name': '/dev/disk/by-uuid/8ad27729-b742-42f3-8dbd-0fafd8d6dd8c', 'fs_type': 'ext4', 'size': 64851185664}]
.
==============================================================================
INFO: [TEST_010] Check PROCESS stats
INFO: PROCESS count stats: {'running': 1, 'total': 108, 'thread': 263, 'sleeping': 107}
INFO: PROCESS list stats: 108 items in the list
.
----------------------------------------------------------------------
Ran 11 tests in 1.100s

OK
</pre>
