### PR TITLE
Fix hddtemp drive label for devices not directly under /dev

### DIFF
--- a/glances/plugins/glances_hddtemp.py
+++ b/glances/plugins/glances_hddtemp.py
@@ -20,6 +20,7 @@
 """HDD temperature plugin."""
 
 # Import system libs
+import os.path
 import socket
 
 # Import Glances libs
@@ -109,9 +110,10 @@ class GlancesGrabHDDTemp(object):
         for item in range(devices):
             offset = item * 5
             hddtemp_current = {}
-            device = fields[offset + 1].split(b'/dev/')[-1]
+            device = fields[offset + 1].decode('utf-8')
+            device = os.path.basename(device)
             temperature = fields[offset + 3]
-            hddtemp_current['label'] = device.decode('utf-8')
+            hddtemp_current['label'] = device
             hddtemp_current['value'] = temperature.decode('utf-8')
             self.hddtemp_list.append(hddtemp_current)
 


### PR DESCRIPTION
This is a small fix to the display of hddtemp drive label.

Before the code was assuming the drive name was directly in `/dev` (ie. `/dev/sda1`), but if hddtemp daemon was started with a drive path like `/dev/disk/by-id/ata-XXXXXXXXXXXX`, the label was truncated like this (last line in the screenshot):
![hddtemp label example before the fix](http://i.imgur.com/8gxR5ZI.png)

After the fix, we take the last path component, which looks a lot nicer:
![hddtemp label example after the fix](http://i.imgur.com/54E9OlV.png)
