### PR TITLE
Add a command line option to hide kernel threads

### DIFF
--- a/glances/core/glances_main.py
+++ b/glances/core/glances_main.py
@@ -27,7 +27,7 @@ import tempfile
 
 # Import Glances libs
 from glances.core.glances_config import Config
-from glances.core.glances_globals import appname, psutil_version, version, logger
+from glances.core.glances_globals import appname, psutil_version, version, logger, is_windows
 
 
 class GlancesMain(object):
@@ -125,6 +125,9 @@ class GlancesMain(object):
                             dest='process_filter', help=_('set the process filter patern (regular expression)'))
         parser.add_argument('--process-short-name', action='store_true', default=False,
                             dest='process_short_name', help=_('force short name for processes name'))
+        if not is_windows:
+            parser.add_argument('--hide-kernel-threads', action='store_true', default=False,
+                                dest='no_kernel_threads', help=_('hide kernel threads in process list'))
         parser.add_argument('-b', '--byte', action='store_true', default=False,
                             dest='byte', help=_('display network rate in byte per second'))
         parser.add_argument('-1', '--percpu', action='store_true', default=False,

--- a/glances/core/glances_standalone.py
+++ b/glances/core/glances_standalone.py
@@ -49,6 +49,10 @@ class GlancesStandalone(object):
         if args.process_filter is not None:
             glances_processes.set_process_filter(args.process_filter)
 
+        # Ignore kernel threads in process list
+        if args.no_kernel_threads:
+            glances_processes.disable_kernel_threads()
+
         # Initial system informations update
         self.stats.update()
 


### PR DESCRIPTION
This adds a command line option to ignore kernel threads in process list, which in my opinion clutter the display.
This only applies to Unix systems.
A nice side effect is that the CPU usage of Glances goes down a bit (-0.5 et -1% on my machine, as measured by Glances of course).
We should also maybe consider making this the default, as the kernel task on Mac is already ignored.
