### PR TITLE
Fix issue #453

### DIFF
--- a/glances/core/glances_processes.py
+++ b/glances/core/glances_processes.py
@@ -96,6 +96,8 @@ class ProcessTreeNode(object):
             elif self.sort_key == "io_counters":
                 stats = current_node.stats[self.sort_key]
                 total += stats[0] - stats[2] + stats[1] - stats[3]
+            elif self.sort_key == "cpu_times":
+                total += sum(current_node.stats[self.sort_key])
             else:
                 total += current_node.stats[self.sort_key]
             nodes_to_sum.extend(current_node.children)


### PR DESCRIPTION
This fixes issue #453.

When sorting by 'cpu_times', stats are returned as a `pcputimes` namedtuple, with user and system CPU time, so they must be summed before numerical comparison.
