### PR TITLE
Handle IOError exception if no /etc/os-release

### DIFF
--- a/glances/plugins/glances_system.py
+++ b/glances/plugins/glances_system.py
@@ -80,7 +80,7 @@ class Plugin(GlancesPlugin):
                     for key in keys:
                         if line.startswith(key):
                             ashtray[key] = line.strip().split('=')[1][1:-1]
-        except OSError:
+        except (OSError, IOError):
             return pretty_name
 
         if ashtray:


### PR DESCRIPTION
On Synology DSM OS (Linux base), python throws an IOError when open does not find a file.
Previously only OSError was handled, now it handles both the OSError and IOError.
