### PR TITLE
Support --hide-kernel-threads option for web interface

### DIFF
--- a/glances/core/glances_webserver.py
+++ b/glances/core/glances_webserver.py
@@ -20,6 +20,8 @@
 """Glances Web Interface (Bottle based)."""
 
 # Import Glances libs
+from glances.core.glances_globals import is_windows
+from glances.core.glances_processes import glances_processes
 from glances.core.glances_stats import GlancesStats
 from glances.outputs.glances_bottle import GlancesBottle
 
@@ -31,6 +33,10 @@ class GlancesWebServer(object):
     def __init__(self, config=None, args=None):
         # Init stats
         self.stats = GlancesStats(config)
+
+        if (not is_windows) and args.no_kernel_threads:
+            # Ignore kernel threads in process list
+            glances_processes.disable_kernel_threads()
 
         # Initial system informations update
         self.stats.update()


### PR DESCRIPTION
This adds support for the `--hide-kernel-threads` option in web mode.

I tried also enabling the `--tree` option for the web UI, with:

```
diff --git a/glances/core/glances_webserver.py b/glances/core/glances_webserver.py
index f83793a..4a9e63b 100644
--- a/glances/core/glances_webserver.py
+++ b/glances/core/glances_webserver.py
@@ -38,6 +38,10 @@ class GlancesWebServer(object):
             # Ignore kernel threads in process list
             glances_processes.disable_kernel_threads()

+        if args.process_tree:
+            # Enable process tree view
+            glances_processes.enable_tree()
+
         # Initial system informations update
         self.stats.update()
```

However the process list is built using a table, so each tree level on the right becomes as large as the biggest one, which is ugly even when aligning on the left.

I don't know if there is a way to fix this without rewriting the template to not use a table, so I am giving up the tree view in web mode for now.
