### PR TITLE
Remove superfluous content-type headers set automatically by bottle

### DIFF
--- a/glances/outputs/glances_bottle.py
+++ b/glances/outputs/glances_bottle.py
@@ -90,7 +90,6 @@ class GlancesBottle(object):
 
     def _index(self, refresh_time=None):
         """Bottle callback for index.html (/) file."""
-        response.content_type = 'text/html'
         # Manage parameter
         if refresh_time is None:
             refresh_time = self.args.time
@@ -103,13 +102,11 @@ class GlancesBottle(object):
 
     def _css(self, filename):
         """Bottle callback for *.css files."""
-        response.content_type = 'text/html'
         # Return the static file
         return static_file(filename, root=os.path.join(self.STATIC_PATH, 'css'))
 
     def _js(self, filename):
         """Bottle callback for *.js files."""
-        response.content_type = 'text/html'
         # Return the static file
         return static_file(filename, root=os.path.join(self.STATIC_PATH, 'js'))
 


### PR DESCRIPTION
The bottle framework is smart with HTTP headers, and it automatically sets the `content-type` HTTP header (with the right charset too), when rendering templates or [serving static files](http://bottlepy.org/docs/stable/tutorial.html#tutorial-static-files), so setting it explicitely is superfluous or ignored.
