### PR TITLE
Doc fixes

### DIFF
--- a/docs/glances-doc.rst
+++ b/docs/glances-doc.rst
@@ -117,6 +117,8 @@ and on the client enter the following URL in your favorite web browser:
 
 where ``@server`` is the IP address or hostname of the server.
 
+To change the refresh rate of the page, just add the period in seconds between refreshes at the end of the URL, ie. to refresh every 10s, use ``http://@server:61208/10``.
+
 The Glances web interface follows responsive web design principles.
 
 Screenshot from Chrome on Android

--- a/docs/glances-doc.rst
+++ b/docs/glances-doc.rst
@@ -743,7 +743,7 @@ Glances includes a `XML-RPC server`_ and a `RESTFUL-JSON`_ API which and can be 
 APIs documentations are available at:
 
 - XML-RPC: https://github.com/nicolargo/glances/wiki/The-Glances-2.x-API-How-to
-- RESTFUL-JSON: https://github.com/nicolargo/glances/wiki/The-Glances-RESTFUL-JSON-API
+- RESTFUL-JSON: https://github.com/nicolargo/glances/wiki/The-Glances-RESTFULL-JSON-API
 
 Support
 =======

--- a/docs/glances-doc.rst
+++ b/docs/glances-doc.rst
@@ -226,7 +226,7 @@ The following commands (key pressed) are supported while in Glances:
 ``F``
     Switch between FS used and free space
 ``g``
-    Generate hraphs for current history
+    Generate graphs for current history
 ``h``
     Show/hide the help screen
 ``i``
@@ -240,7 +240,7 @@ The following commands (key pressed) are supported while in Glances:
 ``p``
     Sort processes by name
 ``q`` or ``ESC``
-    Quit the current Glances session 
+    Quit the current Glances session
 ``r``
     Reset history
 ``s``
@@ -273,7 +273,7 @@ In the Glances client browser (accessible through the --browser command line arg
 ``DOWN``
     Down in the servers list
 ``q`` or ``ESC``
-    Quit Glances 
+    Quit Glances
 
 Configuration
 =============
@@ -582,7 +582,7 @@ In standalone mode, additionals informations are provided for the top process:
 * CPU affinity (number of cores used by the process)
 * Extended memory information (swap, shared, text, lib, data and dirty on Linux)
 * Open threads, files and network sessions (TCP and UDP)
-* IO nice level  
+* IO nice level
 
 The extended stats feature could be enabled using the --enable-process-extended option (command line) or the ``e`` key (curses interface).
 

--- a/docs/glances-doc.rst
+++ b/docs/glances-doc.rst
@@ -736,12 +736,12 @@ Glances will generate stats as:
 APIs Documentations
 ===================
 
-Glances includes a `XML-RPC server`_ and a `RESTFULL-JSON`_ API which and can be used by another client software.
+Glances includes a `XML-RPC server`_ and a `RESTFUL-JSON`_ API which and can be used by another client software.
 
 APIs documentations are available at:
 
 - XML-RPC: https://github.com/nicolargo/glances/wiki/The-Glances-2.x-API-How-to
-- RESTFULL-JSON: https://github.com/nicolargo/glances/wiki/The-Glances-RESTFULL-JSON-API
+- RESTFUL-JSON: https://github.com/nicolargo/glances/wiki/The-Glances-RESTFUL-JSON-API
 
 Support
 =======
@@ -759,5 +759,5 @@ Feel free to contribute !
 
 .. _psutil: https://code.google.com/p/psutil/
 .. _XML-RPC server: http://docs.python.org/2/library/simplexmlrpcserver.html
-.. _RESTFULL-JSON: http://jsonapi.org/
+.. _RESTFUL-JSON: http://jsonapi.org/
 .. _forum: https://groups.google.com/forum/?hl=en#!forum/glances-users

--- a/glances/README.txt
+++ b/glances/README.txt
@@ -1,6 +1,6 @@
 You are in the main Glances's source folder. This page is **ONLY** for developpers purposes.
 
-If you are lookink for user manual, please follow this link: https://github.com/nicolargo/glances/blob/master/docs/glances-doc.rst
+If you are looking for the user manual, please follow this link: https://github.com/nicolargo/glances/blob/master/docs/glances-doc.rst
 
 ===
 


### PR DESCRIPTION
Small documentation fixes:
* Fix some typos
*  "*[RESTFUL](https://en.wikipedia.org/wiki/Representational_state_transfer)*" instead of "*RESTFULL*"
* Explain how to change refresh rate for web UI

The wiki also has a few typos (but I can not fix them):
* The page `The-Glances-RESTFULL-JSON-API` should be renamed `The-Glances-RESTFUL-JSON-API`
* *Serveur side* -> *Server side*

Happy new year !