### PR TITLE
Fix Python 3 detection

### DIFF
--- a/glances/core/glances_globals.py
+++ b/glances/core/glances_globals.py
@@ -28,7 +28,7 @@ version = __import__('glances').__version__
 psutil_version = __import__('glances').__psutil_version
 
 # PY3?
-is_py3 = sys.version_info >= (3, 3)
+is_py3 = sys.version_info >= (3, 0)
 
 # Operating system flag
 # Note: Somes libs depends of OS


### PR DESCRIPTION
This fixes the code that detects whether it is running on Python 3. This prevents errors on Python 3.2 or other older versions of Python 3.