### PR TITLE
Avoid crashing if LC_ALL is not defined by user

### DIFF
--- a/glances/__init__.py
+++ b/glances/__init__.py
@@ -95,7 +95,13 @@ def main():
     Run it...
     """
     # Setup translations
-    locale.setlocale(locale.LC_ALL, '')
+    try:
+        locale.setlocale(locale.LC_ALL, '')
+    except locale.Error:
+        # Setting LC_ALL to '' should not generate an error unless LC_ALL is not
+        # defined in the user environment, which can be the case when used via SSH.
+        # So simply skip this error, as python will use the C locale by default.
+        pass
     gettext.install(gettext_domain, locale_dir)
 
     # Share global var

--- a/glances/plugins/glances_system.py
+++ b/glances/plugins/glances_system.py
@@ -80,7 +80,7 @@ class Plugin(GlancesPlugin):
                     for key in keys:
                         if line.startswith(key):
                             ashtray[key] = line.strip().split('=')[1][1:-1]
-        except OSError:
+        except (OSError, IOError):
             return pretty_name
 
         if ashtray:


### PR DESCRIPTION
When using SSH, my LC_ALL environment variable is not set (sshd configuration).
This seems to be a default configuration on Raspbian (equiv Debian 7.8) and Ubuntu 14.04.2.

The problem is that when launching glances via SSH in this manner, the program crash with a locale.Error exception line 98 in `__init.py__`. I'm no python specialist but as far as I understood the python 2.7 documentation, the statement `locale.setlocale(locale.LC_ALL, '')` try to reset the locale for the python program to the user settings, which in my case are not defined. And I suspect that's the root of the problem.

So I propose a patch (commit `aadb49f`) where I do a try/except and simply pass the error, as anyway from the documentation the statement `locale.setlocale(locale.LC_ALL, '')` should always work.

*Note: after that change, I can successfully run glances via SSH on my Raspberry Pi running Raspbian. See screenshot:*
![glances on raspberry pi](https://cloud.githubusercontent.com/assets/1397088/6382142/906e9da6-bd46-11e4-9691-31545796c3c9.png)
