### PR TITLE
make doco a little bit more discoverable

### DIFF
--- a/docs/glances-doc.html
+++ b/docs/glances-doc.html
@@ -415,7 +415,7 @@ file</td></tr>
 <tr><td>&nbsp;</td><td>display FS free space instead of used</td></tr>
 <tr><td class="option-group">
 <kbd><span class="option">--theme-white</span></kbd></td>
-<td>optimize display for white background</td></tr>
+<td>optimize display colours for white background</td></tr>
 </tbody>
 </table>
 </blockquote>

--- a/glances/core/glances_main.py
+++ b/glances/core/glances_main.py
@@ -183,7 +183,7 @@ Start the client browser (browser mode):\n\
         parser.add_argument('--fs-free-space', action='store_false', default=False,
                             dest='fs_free_space', help=_('display FS free space instead of used'))
         parser.add_argument('--theme-white', action='store_true', default=False,
-                            dest='theme_white', help=_('optimize display for white background'))
+                            dest='theme_white', help=_('optimize display colours for white background'))
 
         return parser
 


### PR DESCRIPTION
A teeny-tiny patch to make it easier to find the --theme-white option. I expect I'm not the only one who searched for a keyword instead of reading the whole man-page.