### PR TITLE
[Web UI] Fix process list when no I/O

### DIFF
--- a/glances/outputs/static/html/plugins/processlist.html
+++ b/glances/outputs/static/html/plugins/processlist.html
@@ -23,8 +23,8 @@
         <div class="table-cell">{{process.nice | exclamation}}</div>
         <div class="table-cell status">{{process.status}}</div>
         <div class="table-cell hidden-xs hidden-sm">{{process.timeformatted}}</div>
-        <div class="table-cell hidden-xs hidden-sm">{{process.io_read | bytes}}</div>
-        <div class="table-cell hidden-xs hidden-sm">{{process.io_write | bytes}}</div>
+        <div class="table-cell hidden-xs hidden-sm">{{process.io_read}}</div>
+        <div class="table-cell hidden-xs hidden-sm">{{process.io_write}}</div>
         <div class="table-cell text-left" ng-if="show.short_process_name">{{process.name}}</div>
         <div class="table-cell text-left" ng-if="!show.short_process_name">{{process.cmdline}}</div>
     </div>

--- a/glances/outputs/static/js/stats_controller.js
+++ b/glances/outputs/static/js/stats_controller.js
@@ -1,4 +1,4 @@
-glancesApp.controller('statsController', function($scope, $http, $interval, $q, $routeParams) {
+glancesApp.controller('statsController', function($scope, $http, $interval, $q, $routeParams, $filter) {
 
     $scope.limitSuffix = ['critical', 'careful', 'warning'];
     $scope.refreshTime = 3;
@@ -130,8 +130,23 @@ glancesApp.controller('statsController', function($scope, $http, $interval, $q, 
                 process.memres  = process.memory_info[0]
                 process.timeformatted = timedelta(process.cpu_times)
                 process.timemillis = timemillis(process.cpu_times)
-                process.io_read  = (process.io_counters[0] - process.io_counters[2]) / process.time_since_update
-                process.io_write = (process.io_counters[1] - process.io_counters[3]) / process.time_since_update
+
+                process.io_read = '?';
+                process.io_write = '?';
+
+                if (process.io_counters) {
+                  process.io_read  = (process.io_counters[0] - process.io_counters[2]) / process.time_since_update;
+
+                  if (process.io_read != 0) {
+                    process.io_read = $filter('bytes')(process.io_read);
+                  }
+
+                  process.io_write = (process.io_counters[1] - process.io_counters[3]) / process.time_since_update;
+
+                  if (process.io_write != 0) {
+                    process.io_write = $filter('bytes')(process.io_write);
+                  }
+                }
             }
             for (var i = 0; i < response['alert'].length; i++) {
                 var alert = response['alert'][i]


### PR DESCRIPTION
If io_counters is not available in the process list, the Web UI crash.

I tried to reproduce the functioning of https://github.com/nicolargo/glances/blob/develop/glances/plugins/glances_processlist.py#L259