### PR TITLE
[Web UI] Does not display additional data for cpu and mem plugins on small devices

### DIFF
--- a/glances/outputs/static/html/plugins/system.html
+++ b/glances/outputs/static/html/plugins/system.html
@@ -1,5 +1,3 @@
-<span class="title">
-    {{ result["system"].hostname }}
-</span>
+<span class="title">{{ result["system"].hostname }}</span>
 <span ng-if="is_linux" class="hidden-xs hidden-sm">({{ result["system"].hr_name }} / {{ result["system"].os_name }} {{ result["system"].os_version }})</span>
 <span ng-if="!is_linux" class="hidden-xs hidden-sm">({{ result["system"].os_name }} {{ result["system"].os_version }} {{ result["system"].platform }})</span>

--- a/glances/outputs/static/html/stats.html
+++ b/glances/outputs/static/html/stats.html
@@ -20,22 +20,22 @@
         </div>
     </div>
     <div class="row">
-        <div class="col-sm-3 col-lg-2">
+        <div class="col-sm-3 col-md-2">
             <section id="cpu" class="plugin" ng-include src="'plugins/cpu.html'"></section>
         </div>
-        <div class="col-sm-3 col-lg-2">
-            <section id="cpu_more" class="plugin" ng-show="result['cpu'].nice != undefined" ng-include src="'plugins/cpu_more.html'"></section>
+        <div class="hidden-xs hidden-sm col-md-2">
+            <section id="cpu_more" class="plugin" ng-if="result['cpu'].nice != undefined" ng-include src="'plugins/cpu_more.html'"></section>
         </div>
-        <div class="col-sm-3 col-lg-2">
-            <section id="load" class="plugin" ng-show="result['load'].cpucore != undefined" ng-include src="'plugins/load.html'"></section>
+        <div class="col-sm-3 col-md-2">
+            <section id="load" class="plugin" ng-if="result['load'].cpucore != undefined" ng-include src="'plugins/load.html'"></section>
         </div>
-        <div class="col-sm-3 col-lg-2">
+        <div class="col-sm-3 col-md-2">
             <section id="mem" class="plugin" ng-include src="'plugins/mem.html'"></section>
         </div>
-        <div class="col-sm-3 col-lg-2">
+        <div class="hidden-xs hidden-sm col-md-2">
             <section id="mem_more" class="plugin" ng-include src="'plugins/mem_more.html'"></section>
         </div>
-        <div class="col-sm-3 col-lg-2">
+        <div class="col-sm-3 col-md-2">
             <section id="memswap" class="plugin" ng-include src="'plugins/memswap.html'"></section>
         </div>
     </div>


### PR DESCRIPTION
Fix #556.

This bug was not initially scheduled for this release but this patch will avoid a regression between version 2.3 and 2.4 regarding the responsiveness of the web ui.  