### PR TITLE
Support InfluxDB 0.9.x

### DIFF
--- a/docs/glances-doc.rst
+++ b/docs/glances-doc.rst
@@ -812,6 +812,20 @@ and run Glances with:
 
     $ glances --export-influxdb
 
+InfluxDB 0.9.x also supports an optional tags configuration parameter 
+specified as comma separated, key:value pairs. For example:
+
+.. code-block::
+
+    [influxdb]
+    host=localhost
+    port=8086
+    user=root
+    password=root
+    db=glances
+    tags=foo:bar,spam:eggs
+
+
 For Grafana users, Glances provides a dedicated `dashboard`_. Just import
 the file in your ``Grafana`` web interface.
 


### PR DESCRIPTION
This adds support for the JSON payload schema used in 0.9.x. This
also adds support for the tags feature available in 0.9.x via the
config option tags. Tags is a comma separated list of colon
separated key:value pairs. An example:

```
[influxdb]
tags = foo:bar,spam:eggs,region:us-east-1
```