### PR TITLE
Python 2.6.6 glances_docker array fix

### DIFF
--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -181,7 +181,7 @@ class Plugin(GlancesPlugin):
                     try:
                         self.docker_stats[c['Id']] = self.docker_client.stats(c['Id'], decode=True)
                         #logger.debug("Create Docker stats object for container {}".format(c['Id']))
-						logger.debug("Create Docker stats object for container {0!r}".format(c['Id']))
+                        logger.debug("Create Docker stats object for container {0!r}".format(c['Id']))
                    except Exception as e:
                         # Correct Issue #602
                         logger.error("Can not call Docker stats method {}".format(e))

--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -180,8 +180,9 @@ class Plugin(GlancesPlugin):
                     # Create the stats instance for the current container
                     try:
                         self.docker_stats[c['Id']] = self.docker_client.stats(c['Id'], decode=True)
-                        logger.debug("Create Docker stats object for container {}".format(c['Id']))
-                    except Exception as e:
+                        #logger.debug("Create Docker stats object for container {}".format(c['Id']))
+						logger.debug("Create Docker stats object for container {0!r}".format(c['Id']))
+                   except Exception as e:
                         # Correct Issue #602
                         logger.error("Can not call Docker stats method {}".format(e))
 

--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -182,7 +182,7 @@ class Plugin(GlancesPlugin):
                         self.docker_stats[c['Id']] = self.docker_client.stats(c['Id'], decode=True)
                         #logger.debug("Create Docker stats object for container {}".format(c['Id']))
                         logger.debug("Create Docker stats object for container {0!r}".format(c['Id']))
-                   except Exception as e:
+                    except Exception as e:
                         # Correct Issue #602
                         logger.error("Can not call Docker stats method {}".format(e))
 


### PR DESCRIPTION
When running Python 2.6.6 with Glances v2.4.2 with psutil v3.1.1 on CentOS-6.6

When you attempt to start the web-server, you receive the noted error. This simply assigned 0 or the provided value and resolves the anomaly

glances -w
Traceback (most recent call last):
  File "/usr/bin/glances", line 9, in <module>
    load_entry_point('Glances==2.4.2', 'console_scripts', 'glances')()
  File "/usr/lib/python2.6/site-packages/Glances-2.4.2-py2.6.egg/glances/__init__.py", line 190, in main
    args=core.get_args())
  File "/usr/lib/python2.6/site-packages/Glances-2.4.2-py2.6.egg/glances/core/glances_webserver.py", line 42, in __init__
    self.stats.update()
  File "/usr/lib/python2.6/site-packages/Glances-2.4.2-py2.6.egg/glances/core/glances_stats.py", line 156, in update
    self._plugins[p].update()
  File "/usr/lib/python2.6/site-packages/Glances-2.4.2-py2.6.egg/glances/plugins/glances_plugin.py", line 646, in wrapper
    ret = fct(*args, **kw)
  File "/usr/lib/python2.6/site-packages/Glances-2.4.2-py2.6.egg/glances/plugins/glances_docker.py", line 171, in update
    logger.error("Can not call Docker stats method {}".format(e))
ValueError: zero length field name in format