### PR TITLE
Fix UTF-8 characters being output on latin1 terminals

### DIFF
--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -22,6 +22,7 @@
 # Import system lib
 import re
 import sys
+import locale
 
 # Import Glances lib
 from glances.core.glances_globals import is_mac, is_windows
@@ -765,6 +766,7 @@ class _GlancesCurses(object):
         x = display_x
         x_max = x
         y = display_y
+        term_encoding = locale.getpreferredencoding()
         for m in plugin_stats['msgdict']:
             # New line
             if m['msg'].startswith('\n'):
@@ -790,7 +792,7 @@ class _GlancesCurses(object):
             # !!! Crach if not try/except... Why ???
             try:
                 self.term_window.addnstr(y, x,
-                                         m['msg'],
+                                         m['msg'].decode('utf-8').encode(term_encoding),
                                          # Do not disply outside the screen
                                          screen_x - x,
                                          self.colors_list[m['decoration']])


### PR DESCRIPTION
This fix translates the characters to an appropriate encoding for the
terminal. "Â°C" (A-caret, degrees, C) was being output on latin1 terminals, which is a bug
since the LC_CTYPE locale setting should tell the program whether it's
okay to output Unicode.

This follows the recommendation from the official curses library
documentation: https://docs.python.org/2/library/curses.html

Steps to reproduce the issue:

1. Install pysensors, enable any kernel modules necessary to support it
2. Run `LANG=en_US rxvt -e glances`
3. Look in SENSORS section

The corrupt Unicode character sequence will appear.