### PR TITLE
Fix UTF-8 characters being output on latin1 terminals

### DIFF
--- a/glances/plugins/glances_sensors.py
+++ b/glances/plugins/glances_sensors.py
@@ -37,10 +37,9 @@ import locale
 if is_py3:
     SENSOR_TEMP_UNIT = '°C'
 else:
-    SENSOR_TEMP_UNIT = '°C '.decode('utf-8')
+    # ensure UTF-8 characters are in a charset the terminal can understand
+    SENSOR_TEMP_UNIT = '°C '.decode('utf-8').encode(locale.getpreferredencoding())
 
-# ensure UTF-8 characters are in a charset the terminal can understand
-SENSOR_TEMP_UNIT = SENSOR_TEMP_UNIT.encode(locale.getpreferredencoding())
 SENSOR_FAN_UNIT = 'RPM'
 
 

--- a/glances/plugins/glances_sensors.py
+++ b/glances/plugins/glances_sensors.py
@@ -37,10 +37,10 @@ import locale
 if is_py3:
     SENSOR_TEMP_UNIT = '°C'
 else:
-    SENSOR_TEMP_UNIT = '°C '
+    SENSOR_TEMP_UNIT = '°C '.decode('utf-8')
 
 # ensure UTF-8 characters are in a charset the terminal can understand
-SENSOR_TEMP_UNIT = SENSOR_TEMP_UNIT.decode('utf-8').encode(locale.getpreferredencoding())
+SENSOR_TEMP_UNIT = SENSOR_TEMP_UNIT.encode(locale.getpreferredencoding())
 SENSOR_FAN_UNIT = 'RPM'
 
 

--- a/glances/plugins/glances_sensors.py
+++ b/glances/plugins/glances_sensors.py
@@ -32,11 +32,15 @@ from glances.core.glances_logging import logger
 from glances.plugins.glances_batpercent import Plugin as BatPercentPlugin
 from glances.plugins.glances_hddtemp import Plugin as HddTempPlugin
 from glances.plugins.glances_plugin import GlancesPlugin
+import locale
 
 if is_py3:
     SENSOR_TEMP_UNIT = '°C'
 else:
     SENSOR_TEMP_UNIT = '°C '
+
+# ensure UTF-8 characters are in a charset the terminal can understand
+SENSOR_TEMP_UNIT = SENSOR_TEMP_UNIT.decode('utf-8').encode(locale.getpreferredencoding())
 SENSOR_FAN_UNIT = 'RPM'
 
 


### PR DESCRIPTION
This fix translates the characters to an appropriate encoding for the
terminal. "Â°C" (A acute, degrees, C) was being output on latin1
terminals, which is a bug since the LC_CTYPE locale setting should tell
the program whether it's okay to output Unicode.

This follows the recommendation from the official curses library
documentation: https://docs.python.org/2/library/curses.html

Steps to reproduce the issue:

1. Install pysensors, enable any kernel modules necessary to support it
2. Run `LANG=en_US rxvt -e glances`
3. Look in SENSORS section

The corrupt Unicode character sequence will appear.