### PR TITLE
unittest: start server in a modified environment.

### DIFF
--- a/unitest-restful.py
+++ b/unitest-restful.py
@@ -79,7 +79,7 @@ class TestGlances(unittest.TestCase):
 
         global pid
 
-        cmdline = "/usr/bin/python -m glances -w -p %s" % SERVER_PORT
+        cmdline = "/usr/bin/env python -m glances -w -p %s" % SERVER_PORT
         print("Run the Glances Web Server on port %s" % SERVER_PORT)
         args = shlex.split(cmdline)
         pid = subprocess.Popen(args)

--- a/unitest-xmlrpc.py
+++ b/unitest-xmlrpc.py
@@ -86,7 +86,7 @@ class TestGlances(unittest.TestCase):
 
         global pid
 
-        cmdline = "/usr/bin/python -m glances -s -p %s" % SERVER_PORT
+        cmdline = "/usr/bin/env python -m glances -s -p %s" % SERVER_PORT
         print("Run the Glances Server on port %s" % SERVER_PORT)
         args = shlex.split(cmdline)
         pid = subprocess.Popen(args)


### PR DESCRIPTION
This changes allows the user to run the unittests properly in
a virtualenv setup. Once the venv activated, /usr/bin/env
will point the python executable within the venv instead of
the system one.