### PR TITLE
[WebUI] fix io write in the process list

### DIFF
--- a/glances/outputs/static/html/plugins/processlist.html
+++ b/glances/outputs/static/html/plugins/processlist.html
@@ -26,7 +26,7 @@
             <span ng-show="process.timeplus.hours > 0" class="highlight">{{ process.timeplus.hours }}h</span>{{ process.timeplus.minutes | leftPad:2:'0' }}:{{ process.timeplus.seconds | leftPad:2:'0' }}<span ng-show="process.timeplus.hours <= 0">.{{ process.timeplus.milliseconds | leftPad:2:'0' }}</span>
         </div>
         <div class="table-cell hidden-xs hidden-sm">{{process.ioRead}}</div>
-        <div class="table-cell hidden-xs hidden-sm">{{process.iowrite}}</div>
+        <div class="table-cell hidden-xs hidden-sm">{{process.ioWrite}}</div>
         <div class="table-cell text-left" ng-show="show.short_process_name">{{process.name}}</div>
         <div class="table-cell text-left" ng-show="!show.short_process_name">{{process.cmdline}}</div>
     </div>


### PR DESCRIPTION
Since the refactoring of the webUI, the IO Write is missing in the process list.

Before : 
<img width="840" alt="capture d ecran 2015-09-08 a 21 51 36" src="https://cloud.githubusercontent.com/assets/523981/9745744/004f0b62-5674-11e5-9bca-5a1219498565.png">


After :
<img width="872" alt="capture d ecran 2015-09-08 a 21 53 21" src="https://cloud.githubusercontent.com/assets/523981/9745753/116431fc-5674-11e5-9363-daf29f74d350.png">
