### PR TITLE
[WebUI] Fix layout of the help page

### DIFF
--- a/glances/outputs/static/html/help.html
+++ b/glances/outputs/static/html/help.html
@@ -1,64 +1,64 @@
 <div class="row">
-    <div class="col-sm-12 col-lg-12">{{help.version}} {{help.psutil_version}}</div>
+    <div class="col-sm-12 col-lg-24">{{help.version}} {{help.psutil_version}}</div>
 </div>
 <div class="row">&nbsp;</div>
 <div class="row">
-    <div class="col-sm-12 col-lg-12">{{help.configuration_file}}</div>
+    <div class="col-sm-12 col-lg-24">{{help.configuration_file}}</div>
 </div>
 <div class="row">&nbsp;</div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.sort_auto}}</div>
-    <div class="col-sm-6 col-lg-3">{{help.sort_network}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_auto}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_network}}</div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.sort_cpu}}</div>
-    <div class="col-sm-6 col-lg-3">{{help.show_hide_alert}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_cpu}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.show_hide_alert}}</div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.sort_mem}}</div>
-    <div class="col-sm-6 col-lg-3">{{help.percpu}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_mem}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.percpu}}</div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.sort_user}}</div>
-    <div class="col-sm-6 col-lg-3">{{help.enable_disable_docker}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_user}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.enable_disable_docker}}</div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.sort_proc}}</div>
-    <div class="col-sm-6 col-lg-3">{{help.view_network_io_combination}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_proc}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.view_network_io_combination}}</div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.sort_io}}</div>
-    <div class="col-sm-6 col-lg-3">{{help.view_cumulative_network}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_io}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.view_cumulative_network}}</div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.sort_cpu_times}}</div>
-    <div class="col-sm-6 col-lg-3">{{help.show_hide_help}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.sort_cpu_times}}</div>
+    <div class="col-sm-12 col-lg-6">{{help.show_hide_help}}</div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.show_hide_diskio}}</div>
-    <div class="col-sm-6 col-lg-3"></div>
+    <div class="col-sm-12 col-lg-6">{{help.show_hide_diskio}}</div>
+    <div class="col-sm-12 col-lg-6"></div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.show_hide_filesystem}}</div>
-    <div class="col-sm-6 col-lg-3"></div>
+    <div class="col-sm-12 col-lg-6">{{help.show_hide_filesystem}}</div>
+    <div class="col-sm-12 col-lg-6"></div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.show_hide_network}}</div>
-    <div class="col-sm-6 col-lg-3"></div>
+    <div class="col-sm-12 col-lg-6">{{help.show_hide_network}}</div>
+    <div class="col-sm-12 col-lg-6"></div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.show_hide_sensors}}</div>
-    <div class="col-sm-6 col-lg-3"></div>
+    <div class="col-sm-12 col-lg-6">{{help.show_hide_sensors}}</div>
+    <div class="col-sm-12 col-lg-6"></div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.show_hide_left_sidebar}}</div>
-    <div class="col-sm-6 col-lg-3"></div>
+    <div class="col-sm-12 col-lg-6">{{help.show_hide_left_sidebar}}</div>
+    <div class="col-sm-12 col-lg-6"></div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.enable_disable_process_stats}}</div>
-    <div class="col-sm-6 col-lg-3"></div>
+    <div class="col-sm-12 col-lg-6">{{help.enable_disable_process_stats}}</div>
+    <div class="col-sm-12 col-lg-6"></div>
 </div>
 <div class="row">
-    <div class="col-sm-6 col-lg-3">{{help.enable_disable_short_processname}}</div>
-    <div class="col-sm-6 col-lg-3"></div>
+    <div class="col-sm-12 col-lg-6">{{help.enable_disable_short_processname}}</div>
+    <div class="col-sm-12 col-lg-6"></div>
 </div>


### PR DESCRIPTION
Since the PR #664 we use 24 columns layout but the help page was still on 12 columns.

Before : 
<img width="416" alt="capture d ecran 2015-09-08 a 21 58 54" src="https://cloud.githubusercontent.com/assets/523981/9745970/2c2dbfc0-5675-11e5-8dac-075d7a0cd68a.png">

After : 
<img width="695" alt="capture d ecran 2015-09-08 a 21 57 55" src="https://cloud.githubusercontent.com/assets/523981/9745977/306e68be-5675-11e5-9590-63b17d71099a.png">
