### PR TITLE
FreeBSD crash workaround and psutil error check

### DIFF
--- a/glances/core/glances_autodiscover.py
+++ b/glances/core/glances_autodiscover.py
@@ -214,11 +214,14 @@ class GlancesAutoDiscoverClient(object):
     @staticmethod
     def find_active_ip_address():
         """Try to find the active IP addresses."""
-        import netifaces
-        # Interface of the default gateway
-        gateway_itf = netifaces.gateways()['default'][netifaces.AF_INET][1]
-        # IP address for the interface
-        return netifaces.ifaddresses(gateway_itf)[netifaces.AF_INET][0]['addr']
+        if not 'freebsd' in sys.platform:
+            import netifaces
+            # Interface of the default gateway
+            gateway_itf = netifaces.gateways()['default'][netifaces.AF_INET][1]
+            # IP address for the interface
+            return netifaces.ifaddresses(gateway_itf)[netifaces.AF_INET][0]['addr']
+        else:
+            raise KeyError, 'On FreeBSD, this would segfault'
 
     def close(self):
         if zeroconf_tag:

--- a/glances/core/glances_processes.py
+++ b/glances/core/glances_processes.py
@@ -595,9 +595,13 @@ class GlancesProcesses(object):
 
             # If self.max_processes is None: Only retreive mandatory stats
             # Else: retreive mandatory and standard stats
-            s = self.__get_process_stats(proc,
-                                         mandatory_stats=True,
-                                         standard_stats=self.max_processes is None)
+            try:
+                s = self.__get_process_stats(proc, 
+                                             mandatory_stats=True, 
+                                             standard_stats=self.get_max_processes() is None)
+            except psutil.NoSuchProcess:
+                # Can happen if process no longer exists
+                continue
             # Continue to the next process if it has to be filtered
             if s is None or (self.is_filtered(s['cmdline']) and self.is_filtered(s['name'])):
                 continue


### PR DESCRIPTION
This fixes a problem I was having with psutil after running for days or weeks (no more glances exceptions thrown!).  It also fixes the FreeBSD segfault from netifaces.gateways in Issue #670.