### PR TITLE
Fix percpu when stats are missing

### DIFF
--- a/glances/outputs/static/html/plugins/per_cpu.html
+++ b/glances/outputs/static/html/plugins/per_cpu.html
@@ -19,13 +19,13 @@
         <div class="table-cell text-left">idle:</div>
         <div class="table-cell" ng-repeat="percpu in statsPerCpu.cpus">{{ percpu.idle }}%</div>
     </div>
-    <div class="table-row">
+    <div class="table-row" ng-show="statsPerCpu.cpus[0].iowait">
         <div class="table-cell text-left">iowait:</div>
         <div class="table-cell" ng-repeat="percpu in statsPerCpu.cpus" ng-class="statsPerCpu.getSystemAlert(percpu)">
             {{ percpu.iowait }}%
         </div>
     </div>
-    <div class="table-row">
+    <div class="table-row" ng-show="statsPerCpu.cpus[0].steal">
         <div class="table-cell text-left">steal:</div>
         <div class="table-cell" ng-repeat="percpu in statsPerCpu.cpus" ng-class="statsPerCpu.getSystemAlert(percpu)">
             {{ percpu.steal }}%

--- a/glances/plugins/glances_percpu.py
+++ b/glances/plugins/glances_percpu.py
@@ -95,6 +95,9 @@ class Plugin(GlancesPlugin):
 
         # Stats per-CPU
         for stat in ['user', 'system', 'idle', 'iowait', 'steal']:
+            if not stat in self.stats[0]:
+                continue
+
             ret.append(self.curse_new_line())
             msg = '{0:8}'.format(stat + ':')
             ret.append(self.curse_add_line(msg))


### PR DESCRIPTION
Since the commit 1945db14fce4259758bc1a34c2aaf4de90f6a204, I have the following error with per cpu : 
```
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/f.brutel/dev/octey/dev/glances/glances/__main__.py", line 38, in <module>
    glances.main()
Per CPU : test if stat exists for the cpu
  File "glances/__init__.py", line 125, in main
    standalone.serve_forever()
  File "glances/core/glances_standalone.py", line 108, in serve_forever
    return self.__serve_forever()
  File "glances/core/glances_standalone.py", line 93, in __serve_forever
    self.screen.update(self.stats)
  File "glances/outputs/glances_curses.py", line 926, in update
    self.flush(stats, cs_status=cs_status)
  File "glances/outputs/glances_curses.py", line 892, in flush
    self.display(stats, cs_status=cs_status)
  File "glances/outputs/glances_curses.py", line 455, in display
    stats_cpu = stats.get_plugin('percpu').get_stats_display(args=self.args)
  File "glances/plugins/glances_plugin.py", line 551, in get_stats_display
    'msgdict': self.msg_curse(args),
  File "/Users/f.brutel/dev/octey/dev/glances/glances/plugins/glances_percpu.py", line 102, in msg_curse
    msg = '{0:>6}%'.format(cpu[stat])
KeyError: 'iowait'
```

The PR fix the bug in curse and the webUI.

**WebUI** : 

Before : 
<img width="410" alt="capture d ecran 2015-09-12 a 10 34 00" src="https://cloud.githubusercontent.com/assets/523981/9830787/ed2e0248-593b-11e5-945f-64b2686b737d.png">

After : 
<img width="403" alt="capture d ecran 2015-09-12 a 10 48 15" src="https://cloud.githubusercontent.com/assets/523981/9830788/f5e1749c-593b-11e5-8b48-b9ad504bb6cf.png">

