### PR TITLE
tback: docker.containers() can return None

### DIFF
--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -190,7 +190,7 @@ class Plugin(GlancesPlugin):
 
             # Update current containers list
             try:
-                self.stats['containers'] = self.docker_client.containers()
+                self.stats['containers'] = self.docker_client.containers() or []
             except Exception as e:
                 logger.error("{} plugin - Can not get containers list ({})".format(self.plugin_name, e))
                 return self.stats


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/glances", line 9, in <module>
    load_entry_point('Glances==2.3', 'console_scripts', 'glances')()
  File "/usr/lib/python2.7/site-packages/glances/__init__.py", line 119, in main
    args=core.get_args())
  File "/usr/lib/python2.7/site-packages/glances/core/glances_standalone.py", line 62, in __init__
    self.stats.update()
  File "/usr/lib/python2.7/site-packages/glances/core/glances_stats.py", line 156, in update
    self._plugins[p].update()
  File "/usr/lib/python2.7/site-packages/glances/plugins/glances_plugin.py", line 633, in wrapper
    ret = fct(*args, **kw)
  File "/usr/lib/python2.7/site-packages/glances/plugins/glances_docker.py", line 154, in update
    for c in self.stats['containers']:
TypeError: 'NoneType' object is not iterable
```