### PR TITLE
Change percentage bars to use an explicit exception for value checks

### DIFF
--- a/glances/outputs/glances_bars.py
+++ b/glances/outputs/glances_bars.py
@@ -69,8 +69,9 @@ class Bar(object):
 
     @percent.setter
     def percent(self, value):
-        assert value >= 0
-        assert value <= 100
+        if value < 0 or value > 100:
+            raise AssertionError('The percent must be between 0 and 100.')
+
         self.__percent = value
 
     @property

--- a/unitest.py
+++ b/unitest.py
@@ -24,6 +24,7 @@ import sys
 import time
 import unittest
 
+from glances.outputs.glances_bars import Bar
 from glances.core.glances_globals import (
     appname,
     is_linux,
@@ -185,6 +186,17 @@ class TestGlances(unittest.TestCase):
         print('INFO: PROCESS list stats: %s items in the list' % len(stats_grab))
         # Check if number of processes in the list equal counter
         # self.assertEqual(total, len(stats_grab))
+
+    def test_011_output_bars_must_be_between_0_and_100_percent(self):
+        bar = Bar(size=1)
+        with self.assertRaises(AssertionError):
+            bar.percent = -1
+            bar.percent = 101
+
+        # 0 - 100 is an inclusive range, so these should not error.
+        bar.percent = 0
+        bar.percent = 100
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The percentage bars will now use an AssertionError directly if the provided values are outside of the expected range (0-100 inclusive). 

I was using [Bandit](https://github.com/openstack/bandit) to check for potential vulnerabilities in a few popular Python projects and this came up as a warning:

```
>> Issue: Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.
    Severity: Low   Confidence: High
    Location: glances/glances/outputs/glances_bars.py:72
 70      @percent.setter
 71      def percent(self, value):
 72          assert value >= 0
 73          assert value <= 100
 74          self.__percent = value
```

As per the warning, `assert` statements are stripped out if compiling with optimized bytecode (-O option) in Python. Here's a [StackOverflow question](http://stackoverflow.com/questions/2830358/what-are-the-implications-of-running-python-with-the-optimize-flag) with a little discussion and the original [Python docs](https://docs.python.org/2/reference/simple_stmts.html#the-assert-statement). 

Oh, as a quick postscript, these tests run fine on OSX, so perhaps the Linux checks could be made to include OSX when running the tests?