### PR TITLE
[WebUI] Fix auto unit helper

### DIFF
--- a/glances/outputs/static/js/filters.js
+++ b/glances/outputs/static/js/filters.js
@@ -66,7 +66,7 @@ glancesApp.filter('bytes', function() {
           }
         }
 
-        return bytes;
+        return bytes.toFixed(0);
     }
 });
 


### PR DESCRIPTION
When value < 1024, the helper displayed the full value. Now the helper show the value without precision.

Before : 
<img width="434" alt="capture d ecran 2015-09-23 a 20 49 50" src="https://cloud.githubusercontent.com/assets/523981/10055557/3bfabd54-6237-11e5-8b8f-8ba617f98e8a.png">


After : 
<img width="424" alt="capture d ecran 2015-09-23 a 21 05 51" src="https://cloud.githubusercontent.com/assets/523981/10055560/40d78c76-6237-11e5-9ccf-faacfc13361e.png">
