### PR TITLE
[WebUI] fix process count for stopped

### DIFF
--- a/glances/outputs/static/js/services/plugins/glances_processcount.js
+++ b/glances/outputs/static/js/services/plugins/glances_processcount.js
@@ -10,10 +10,10 @@ glancesApp.service('GlancesPluginProcessCount', function() {
     this.setData = function(data, views) {
         data = data[_pluginName];
 
-        this.total = data['total'];
-        this.running = data['running'];
-        this.sleeping = data['sleeping'];
-        this.stopped = data['stopped'];
-        this.thread = data['thread'];
+        this.total = data['total'] || 0;
+        this.running = data['running'] || 0;
+        this.sleeping = data['sleeping'] || 0;
+        this.stopped = data['stopped'] || 0;
+        this.thread = data['thread'] || 0;
     };
 });


### PR DESCRIPTION
Set default values of processcount plugin to 0.

before : 
<img width="427" alt="capture d ecran 2015-10-21 a 19 50 09" src="https://cloud.githubusercontent.com/assets/523981/10645229/ffdaad5a-782c-11e5-8f4e-92bd0dc53b07.png">

after : 
<img width="794" alt="capture d ecran 2015-10-21 a 19 49 58" src="https://cloud.githubusercontent.com/assets/523981/10645234/04525932-782d-11e5-84ec-f27067b7d4c1.png">
