### PR TITLE
Add option to disable ANSI background colours (2)

### DIFF
--- a/docs/glances-doc.rst
+++ b/docs/glances-doc.rst
@@ -169,6 +169,7 @@ Command-Line Options
                         sensors modules (py3sensors needed)
   --disable-process     disable process module
   --disable-log         disable log module
+  --disable-bg          disable background colors in the terminal
   --disable-bold        disable bold mode in the terminal
   --enable-process-extended
                         enable extended stats on top process

--- a/glances/main.py
+++ b/glances/main.py
@@ -137,6 +137,8 @@ Start the client browser (browser mode):\n\
                             dest='disable_log', help='disable log module')
         parser.add_argument('--disable-bold', action='store_false', default=True,
                             dest='disable_bold', help='disable bold mode in the terminal')
+        parser.add_argument('--disable-bg', action='store_false', default=True,
+                            dest='disable_bg', help='disable background colors in the terminal')
         parser.add_argument('--enable-process-extended', action='store_true', default=False,
                             dest='enable_process_extended', help='enable extended stats on top process')
         parser.add_argument('--enable-history', action='store_true', default=False,

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -145,10 +145,16 @@ class _GlancesCurses(object):
                 curses.init_pair(1, curses.COLOR_BLACK, -1)
             else:
                 curses.init_pair(1, curses.COLOR_WHITE, -1)
-            curses.init_pair(2, curses.COLOR_WHITE, curses.COLOR_RED)
-            curses.init_pair(3, curses.COLOR_WHITE, curses.COLOR_GREEN)
-            curses.init_pair(4, curses.COLOR_WHITE, curses.COLOR_BLUE)
-            curses.init_pair(5, curses.COLOR_WHITE, curses.COLOR_MAGENTA)
+            if args.disable_bg:
+                curses.init_pair(2, curses.COLOR_WHITE, curses.COLOR_RED)
+                curses.init_pair(3, curses.COLOR_WHITE, curses.COLOR_GREEN)
+                curses.init_pair(4, curses.COLOR_WHITE, curses.COLOR_BLUE)
+                curses.init_pair(5, curses.COLOR_WHITE, curses.COLOR_MAGENTA)
+            else:
+                curses.init_pair(2, curses.COLOR_RED, -1)
+                curses.init_pair(3, curses.COLOR_GREEN, -1)
+                curses.init_pair(4, curses.COLOR_BLUE, -1)
+                curses.init_pair(5, curses.COLOR_MAGENTA, -1)
             curses.init_pair(6, curses.COLOR_RED, -1)
             curses.init_pair(7, curses.COLOR_GREEN, -1)
             curses.init_pair(8, curses.COLOR_BLUE, -1)

--- a/man/glances.1
+++ b/man/glances.1
@@ -87,6 +87,9 @@ disable process module
 .B \-\-disable-log
 disable log module
 .TP
+.B \-\-disable-bg
+disable background colors in the terminal
+.TP
 .B \-\-disable-bold
 disable bold mode in the terminal
 .TP


### PR DESCRIPTION
This replaces PR #735, which was:

> I've just found Glances, and i really like it, but i've had the same issue described in #68 — the ANSI background colours (especially green) clash with my terminal colour scheme, making the CPU percentages unreadable.

> This PR adds an option `--disable-bg` which turns off the ANSI background colours: white-on-green becomes standard green, white-on-magenta becomes standard magenta, &c.

> I modelled the new option after the `--disable-bold` one, whose variable seems to be stored backwards from what i'd expect (`args.disable_bold == True` actually means bold is *not* disabled). I don't get why it's like that, but i copied the same behaviour for the new option.