### PR TITLE
[WebUI] Dont wait before first loading

### DIFF
--- a/glances/outputs/static/js/stats_controller.js
+++ b/glances/outputs/static/js/stats_controller.js
@@ -101,6 +101,7 @@ glancesApp.controller('statsController', function ($scope, $rootScope, $interval
 
     var stop;
     $scope.configure_refresh = function () {
+        $scope.refreshData();
         if (!angular.isDefined(stop)) {
             stop = $interval(function () {
                 $scope.refreshData();


### PR DESCRIPTION
With this fix, the WebUI makes the first loading of data then refresh the data every x seconds.