### PR TITLE
IndexError in browser mode

### DIFF
--- a/glances/client_browser.py
+++ b/glances/client_browser.py
@@ -160,7 +160,7 @@ class GlancesClientBrowser(object):
                     "Server list dictionnary change inside the loop (wait next update)")
 
             # Update the screen (list or Glances client)
-            if self.screen.active_server is None:
+            if not self.screen.active_server:
                 #  Display the Glances browser
                 self.screen.update(self.get_servers_list())
             else:


### PR DESCRIPTION
**New pull request to address fix in develop**

I was trying to run glances in browser mode and got below `IndexError`. This happens only when there is no server available. On probing further I found that the problem was comparison of active_server with `NoneType` with `is`. In failure case `active_server` is 0, hence the condition failed. I grep'd through the code and found that `active_server` holds the current cursor position and its an integer. Hope this fix helps. BTW, awesome project. I am still learning new stuff from glances!

```
(env)rkadam@rkadam-vbox:~/github/glances$ glances --browser
Traceback (most recent call last):
  File "/home/rkadam/github/glances/env/bin/glances", line 9, in <module>
    load_entry_point('Glances==2.5.1', 'console_scripts', 'glances')()
  File "/home/rkadam/github/glances/env/local/lib/python2.7/site-packages/Glances-2.5.1-py2.7.egg/glances/__init__.py", line 154, in main
    client.serve_forever()
  File "/home/rkadam/github/glances/env/local/lib/python2.7/site-packages/Glances-2.5.1-py2.7.egg/glances/core/glances_client_browser.py", line 246, in serve_forever
    return self.__serve_forever()
  File "/home/rkadam/github/glances/env/local/lib/python2.7/site-packages/Glances-2.5.1-py2.7.egg/glances/core/glances_client_browser.py", line 175, in __serve_forever
    logger.debug("Selected server: {0}".format(self.get_servers_list()[self.screen.active_server]))
IndexError: list index out of range

```