### PR TITLE
fix crash in docker plugin if cpu usage not available

### DIFF
--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -252,7 +252,7 @@ class Plugin(GlancesPlugin):
         try:
             cpu_new['total'] = all_stats['cpu_stats']['cpu_usage']['total_usage']
             cpu_new['system'] = all_stats['cpu_stats']['system_cpu_usage']
-            cpu_new['nb_core'] = len(all_stats['cpu_stats']['cpu_usage']['percpu_usage'])
+            cpu_new['nb_core'] = len(all_stats['cpu_stats']['cpu_usage']['percpu_usage'] or [])
         except KeyError as e:
             # all_stats do not have CPU information
             logger.debug("Can not grab CPU usage for container {0} ({1})".format(container_id, e))


### PR DESCRIPTION
    Traceback (most recent call last):
      File "/home/grw/src/glances/venv/bin/glances", line 11, in <module>
        sys.exit(main())
      File "/home/grw/src/glances/venv/lib/python3.4/site-packages/glances/__init__.py", line 125, in main
        standalone.serve_forever()
      File "/home/grw/src/glances/venv/lib/python3.4/site-packages/glances/core/glances_standalone.py", line 108, in serve_forever
        return self.__serve_forever()
      File "/home/grw/src/glances/venv/lib/python3.4/site-packages/glances/core/glances_standalone.py", line 89, in __serve_forever
        self.stats.update()
      File "/home/grw/src/glances/venv/lib/python3.4/site-packages/glances/core/glances_stats.py", line 156, in update
        self._plugins[p].update()
      File "/home/grw/src/glances/venv/lib/python3.4/site-packages/glances/plugins/glances_plugin.py", line 654, in wrapper
        ret = fct(*args, **kw)
      File "/home/grw/src/glances/venv/lib/python3.4/site-packages/glances/plugins/glances_docker.py", line 225, in update
        container['cpu'] = self.get_docker_cpu(container['Id'], self.thread_list[container['Id']].stats)
      File "/home/grw/src/glances/venv/lib/python3.4/site-packages/glances/plugins/glances_docker.py", line 255, in get_docker_cpu
        cpu_new['nb_core'] = len(all_stats['cpu_stats']['cpu_usage']['percpu_usage'])
    TypeError: object of type 'NoneType' has no len()

This fix prevents this failure from crashing glances. Perhaps try/catch ``self._plugins[p].update()`` so failed plugins don't crash the application?