### PR TITLE
Change http://bit.ly to https://bit.ly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,13 +61,13 @@ To install both dependencies and latest Glances production ready version
 
 .. code-block:: console
 
-    curl -L http://bit.ly/glances | /bin/bash
+    curl -L https://bit.ly/glances | /bin/bash
 
 or
 
 .. code-block:: console
 
-    wget -O- http://bit.ly/glances | /bin/bash
+    wget -O- https://bit.ly/glances | /bin/bash
 
 *Note*: Only supported on some GNU/Linux distributions. If you want to
 support other distributions, please contribute to `glancesautoinstall`_.


### PR DESCRIPTION
Using HTTP will cause a CONNECTION_RESET error:

```
curl -L http://bit.ly/glances | /bin/bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (56) Recv failure: Connection reset by peer
```