### PR TITLE
[Web UI] Fix display issue in fs plugin with long device name

### DIFF
--- a/glances/outputs/static/html/plugins/fs.html
+++ b/glances/outputs/static/html/plugins/fs.html
@@ -7,7 +7,7 @@
     <div class="table-cell">Total</div>
 </div>
 <div class="table-row" ng-repeat="fs in statsFs.fileSystems | orderBy:  'mnt_point'">
-    <div class="table-cell text-left">{{ fs.mountPoint }} ({{ fs.name }})</div>
+    <div class="table-cell text-left">{{ fs.mountPoint }} <span class="visible-lg-inline" ng-show="fs.name.length <= 20">({{ fs.name }})<span></div>
     <div class="table-cell" ng-class="statsFs.getDecoration(fs.mountPoint, 'used')">
         <span ng-show="!arguments.fs_free_space">{{ fs.used | bytes }}</span>
         <span ng-show="arguments.fs_free_space">{{ fs.free | bytes }}</span>


### PR DESCRIPTION
Before : 

![selection_007](https://cloud.githubusercontent.com/assets/833625/13555562/d8467c3a-e3c3-11e5-856a-b3f734f787e4.png)

After :

![selection_006](https://cloud.githubusercontent.com/assets/833625/13555560/d13b2c60-e3c3-11e5-8c9b-e44bcada0e36.png)

The device name is now displayed only on large screen. Long device names are no longer displayed at all. 

Fix #731.