### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Resume
+
+| Q             | A
+| ------------- | ---
+| Bug?          | yes/no
+| New feature?  | yes/no
+
+### Description
+
+
+### Versions
+
+<!-- You can use `glances -V` to retrieve Glances and PSutil versions -->
+
+* Glances:
+* PSutil:
+* OS:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Resume
+
+| Q             | A
+| ------------- | ---
+| Bug fix?      | yes/no
+| New feature?  | yes/no
+| BC breaks?    | yes/no
+| Deprecations? | yes/no
+| Fixed tickets | comma-separated list of tickets fixed by the PR, if any
+
+### Description


### PR DESCRIPTION
Implements two new GitHub features: 

* https://help.github.com/articles/creating-an-issue-template-for-your-repository/
* https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/

I push on develop but maybe this feature needs to be pushed in master to be functional.