### PR TITLE
[WebUI] Hide additional cpu data if not available

### DIFF
--- a/glances/outputs/static/html/plugins/cpu.html
+++ b/glances/outputs/static/html/plugins/cpu.html
@@ -53,25 +53,25 @@
     </div>
     <div class="hidden-xs hidden-sm hidden-md col-lg-8">
         <div class="table">
-            <div class="table-row">
+            <div class="table-row" ng-if="statsCpu.ctx_switches">
                 <div class="table-cell text-left">ctx_sw:</div>
                 <div class="table-cell" ng-class="statsCpu.getDecoration('ctx_switches')">
                     {{ statsCpu.ctx_switches }}
                 </div>
             </div>
-            <div class="table-row">
+            <div class="table-row" ng-if="statsCpu.interrupts">
                 <div class="table-cell text-left">inter:</div>
                 <div class="table-cell">
                     {{ statsCpu.interrupts }}
                 </div>
             </div>
-            <div class="table-row">
+            <div class="table-row" ng-if="statsCpu.soft_interrupts">
                 <div class="table-cell text-left">sw_int:</div>
                 <div class="table-cell">
                     {{ statsCpu.soft_interrupts }}
                 </div>
             </div>
-            <div class="table-row" ng-show="!statsSystem.isLinux()">
+            <div class="table-row" ng-if="!statsSystem.isLinux() && statsCpu.syscalls">
                 <div class="table-cell text-left">syscal:</div>
                 <div class="table-cell">
                     {{ statsCpu.syscalls }}

--- a/glances/outputs/static/js/services/plugins/glances_cpu.js
+++ b/glances/outputs/static/js/services/plugins/glances_cpu.js
@@ -27,10 +27,22 @@ glancesApp.service('GlancesPluginCpu', function() {
         this.irq = data.irq;
         this.iowait = data.iowait;
         this.steal = data.steal;
-        this.ctx_switches = Math.floor(data.ctx_switches / data.time_since_update);
-        this.interrupts = Math.floor(data.interrupts / data.time_since_update);
-        this.soft_interrupts = Math.floor(data.soft_interrupts / data.time_since_update);
-        this.syscalls = Math.floor(data.syscalls / data.time_since_update);
+
+        if (data.ctx_switches) {
+          this.ctx_switches = Math.floor(data.ctx_switches / data.time_since_update);
+        }
+
+        if (data.interrupts) {
+          this.interrupts = Math.floor(data.interrupts / data.time_since_update);
+        }
+
+        if (data.soft_interrupts) {
+          this.soft_interrupts = Math.floor(data.soft_interrupts / data.time_since_update);
+        }
+
+        if (data.syscalls) {
+          this.syscalls = Math.floor(data.syscalls / data.time_since_update);
+        }
     }
 
     this.getDecoration = function(value) {


### PR DESCRIPTION
#### Description

Hide *ctx_switches*, *interrupts*, *soft_interrupts* and *syscalls* in the WebUI if the data are not available.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: -

#### Screenshots

Before : 

<img width="362" alt="capture d ecran 2016-04-17 a 19 15 22" src="https://cloud.githubusercontent.com/assets/523981/14588736/c64e58da-04d0-11e6-8d14-e45e668377d3.png">

After : 

<img width="375" alt="capture d ecran 2016-04-17 a 19 15 08" src="https://cloud.githubusercontent.com/assets/523981/14588738/cb109a2c-04d0-11e6-83e5-03925c48d2e9.png">