### PR TITLE
Correct Grafana dashboard - disk I/O

### DIFF
--- a/conf/glances-grafana.json
+++ b/conf/glances-grafana.json
@@ -1088,7 +1088,7 @@
                 }
               ],
               "measurement": "localhost.diskio",
-              "query": "SELECT mean(\"sda2.read_bytes\") FROM \"localhost.diskio\" WHERE $timeFilter GROUP BY time($interval) fill(null)",
+              "query": "SELECT mean(\"sda2.read_bytes\")/mean(\"sda2.time_since_update\")*8 FROM \"localhost.diskio\" WHERE $timeFilter GROUP BY time($interval) fill(null)",
               "refId": "A",
               "resultFormat": "time_series",
               "select": [
@@ -1130,7 +1130,7 @@
                 }
               ],
               "measurement": "localhost.diskio",
-              "query": "SELECT mean(\"sda2.write_bytes\") FROM \"localhost.diskio\" WHERE $timeFilter GROUP BY time($interval) fill(null)",
+              "query": "SELECT mean(\"sda2.write_bytes\")/mean(\"sda2.time_since_update\")*8 FROM \"localhost.diskio\" WHERE $timeFilter GROUP BY time($interval) fill(null)",
               "refId": "B",
               "resultFormat": "time_series",
               "select": [


### PR DESCRIPTION
#### Description

This modifies the sda2 disk IO section to account for the (default) 3 second gap.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none, but relates to #856 
