### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Before filling this issue, please read the manual (http://glances.readthedocs.org/en/latest/) and search if the bug do not already exists in the database (https://github.com/nicolargo/glances/issues).
+Before filling this issue, please read the manual (https://glances.readthedocs.io/en/latest/) and search if the bug do not already exists in the database (https://github.com/nicolargo/glances/issues).
 
 #### Description
 
@@ -14,4 +14,4 @@ For an enhancement or new feature: Describe your needs.
 
 #### Logs
 
-You can also pastebin the Glances logs file (http://glances.readthedocs.org/en/latest/config.html#logging)
+You can also pastebin the Glances logs file (https://glances.readthedocs.io/en/latest/config.html#logging)

--- a/NEWS
+++ b/NEWS
@@ -67,7 +67,7 @@ Bugs corrected:
 
 Others:
     * A new Glances docker container to monitor your Docker infrastructure is available here (issue #728): https://hub.docker.com/r/nicolargo/glances/
-    * Documentation is now generated automatically thanks to Sphinx and the Alessio Sergi patch (http://glances.readthedocs.org/en/latest/)
+    * Documentation is now generated automatically thanks to Sphinx and the Alessio Sergi patch (https://glances.readthedocs.io/en/latest/)
 
 Contributors summary:
     * Nicolas Hennion: 112 commits

--- a/README.rst
+++ b/README.rst
@@ -322,6 +322,6 @@ LGPL. See ``COPYING`` for more details.
 .. _@nicolargo: https://twitter.com/nicolargo
 .. _@glances_system: https://twitter.com/glances_system
 .. _Python: https://www.python.org/getit/
-.. _readthedocs: https://glances.readthedocs.org/
+.. _readthedocs: https://glances.readthedocs.io/
 .. _forum: https://groups.google.com/forum/?hl=en#!forum/glances-users
 .. _wiki: https://github.com/nicolargo/glances/wiki/How-to-contribute-to-Glances-%3F

--- a/glances/exports/glances_elasticsearch.py
+++ b/glances/exports/glances_elasticsearch.py
@@ -96,7 +96,7 @@ class Export(GlancesExport):
         logger.debug("Export {0} stats to ElasticSearch".format(name))
 
         # Create DB input
-        # http://elasticsearch-py.readthedocs.org/en/master/helpers.html
+        # https://elasticsearch-py.readthedocs.io/en/master/helpers.html
         actions = []
         for c, p in zip(columns, points):
             action = {


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.