### PR TITLE
check cpu_info

### DIFF
--- a/glances/plugins/glances_quicklook.py
+++ b/glances/plugins/glances_quicklook.py
@@ -80,9 +80,10 @@ class Plugin(GlancesPlugin):
         # thanks to the cpuinfo lib: https://github.com/workhorsy/py-cpuinfo
         if cpuinfo_tag:
             cpu_info = cpuinfo.get_cpu_info()
-            self.stats['cpu_name'] = cpu_info['brand']
-            self.stats['cpu_hz_current'] = cpu_info['hz_actual_raw'][0]
-            self.stats['cpu_hz'] = cpu_info['hz_advertised_raw'][0]
+            if cpu_info:
+                self.stats['cpu_name'] = cpu_info['brand']
+                self.stats['cpu_hz_current'] = cpu_info['hz_actual_raw'][0]
+                self.stats['cpu_hz'] = cpu_info['hz_advertised_raw'][0]
 
         # Update the view
         self.update_views()


### PR DESCRIPTION
#### Description
Check if the methode get_cpu_info effectively return something to avoid following error.

Traceback (most recent call last):
  File "/usr/local/bin/glances", line 9, in <module>
    load_entry_point('Glances==2.6.2', 'console_scripts', 'glances')()
  File "/usr/local/lib/python2.7/dist-packages/glances/__init__.py", line 130, in main
    args=core.get_args())
  File "/usr/local/lib/python2.7/dist-packages/glances/standalone.py", line 67, in __init__
    self.stats.update()
  File "/usr/local/lib/python2.7/dist-packages/glances/stats.py", line 154, in update
    self._plugins[p].update()
  File "/usr/local/lib/python2.7/dist-packages/glances/plugins/glances_plugin.py", line 658, in wrapper
    ret = fct(*args, **kw)
  File "/usr/local/lib/python2.7/dist-packages/glances/plugins/glances_quicklook.py", line 83, in update
    self.stats['cpu_name'] = cpu_info['brand']
TypeError: 'NoneType' object has no attribute '__getitem__'

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:

