### PR TITLE
missing local variable 'e'

### DIFF
--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -355,7 +355,7 @@ class Plugin(GlancesPlugin):
                 network_new['tx'] = netcounters["eth0"]["tx_bytes"] - self.netcounters_old[container_id]["eth0"]["tx_bytes"]
                 network_new['cumulative_rx'] = netcounters["eth0"]["rx_bytes"]
                 network_new['cumulative_tx'] = netcounters["eth0"]["tx_bytes"]
-            except KeyError:
+            except KeyError as e:
                 # all_stats do not have INTERFACE information
                 logger.debug("Can not grab network interface usage for container {0} ({1})".format(container_id, e))
                 logger.debug(all_stats)


### PR DESCRIPTION
#### Description

Crashes when using glances docker plugin.

Cause: logging with an unbound local variable 'e'

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: 

