### PR TITLE
Docker build can't install packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@
 FROM ubuntu
 
 # Install Glances (develop branch)
-RUN apt-get -y install curl && \
-    curl -L https://raw.githubusercontent.com/nicolargo/glancesautoinstall/master/install-develop.sh | /bin/bash
+RUN apt-get update && apt-get -y install curl && rm -rf /var/lib/apt/lists/*
+RUN curl -L https://raw.githubusercontent.com/nicolargo/glancesautoinstall/master/install-develop.sh | /bin/bash && rm -rf /var/lib/apt/lists/*
+
 
 # Define working directory.
 WORKDIR /glances


### PR DESCRIPTION
#### Description

Fixing the dockerfile for your automatic builds, which have been broken for 5 months.
https://hub.docker.com/r/nicolargo/glances/builds/

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: didn't see an issue

Need to initialize the apt repos with `apt-get update`. Since you're maintaining your own install script and not installing cleanly here, we should break the system apart so that we're clearing the apt cache properly.