### PR TITLE
Fix cpu_stats TypeError

### DIFF
--- a/glances/plugins/glances_cpu.py
+++ b/glances/plugins/glances_cpu.py
@@ -136,7 +136,8 @@ class Plugin(GlancesPlugin):
                 self.cpu_stats_old = cpu_stats
             else:
                 for stat in cpu_stats._fields:
-                    self.stats[stat] = getattr(cpu_stats, stat) - getattr(self.cpu_stats_old, stat)
+                    if getattr(cpu_stats, stat) is not None:
+                        self.stats[stat] = getattr(cpu_stats, stat) - getattr(self.cpu_stats_old, stat)
 
                 self.stats['time_since_update'] = time_since_update
 


### PR DESCRIPTION
#### Description

On an a particular OpenVZ container the soft_interrupts is None and causes a TypeError due to no type check before ```getattr(cpu_stats, stat) - getattr(self.cpu_stats_old, stat)```

#### Resume

* Bug fix: yes

#### Versions

* Glances: v2.7.1 & v2.8_DEVELOP
* PSutil: v4.4.2
* Operating System: Ubuntu 12.04.5 LTS


#### Logs

```
cpustats(ctx_switches=23729700634, interrupts=0, soft_interrupts=None, syscalls=0)

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/Glances-2.8_DEVELOP-py2.7.egg/glances/plugins/glances_cpu.py", line 139, in update_local
    self.stats[stat] = getattr(cpu_stats, stat) - getattr(self.cpu_stats_old, stat)
TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'