### PR TITLE
Fix incorrectly registered GPU id in gpu plugin

### DIFF
--- a/glances/plugins/glances_gpu.py
+++ b/glances/plugins/glances_gpu.py
@@ -108,7 +108,7 @@ class Plugin(GlancesPlugin):
 
         for index, device_handle in enumerate(self.device_handles):
             device_stats = {}
-            device_stats['key'] = index
+            device_stats['gpu_id'] = index
             device_stats['name'] = self.get_device_name(device_handle)
             device_stats['memory_percent'] = self.get_memory_percent(device_handle)
             device_stats['processor_percent'] = self.get_processor_percent(device_handle)


### PR DESCRIPTION
#### Description

Single line fix to correctly register the gpu plugin key for each device id.  This is a continuation of #170 and #979.

This PR is now tested.  For instance, here is the API output for an **old** card (which does not support the processor utilization query in the Nvidia management library:

1.  No load

```
$ curl http://localhost:61208/api/2/gpu
[{"memory_percent": 0, "processor_percent": null, "gpu_id": 0, "name": "GeForce GTX 560 Ti"}]
```

2. Training a 128 node, single hidden layer recurrent neural net

```
$ curl http://localhost:61208/api/2/gpu
[{"memory_percent": 14, "processor_percent": null, "gpu_id": 0, "name": "GeForce GTX 560 Ti"}]
```

3. Training a 1024 node-per-layer, 3 hidden layer recurrent neural net

```
$ curl http://localhost:61208/api/2/gpu
[{"memory_percent": 98, "processor_percent": null, "gpu_id": 0, "name": "GeForce GTX 560 Ti"}]
```

The important thing to note here is that, despite the card being old and not supporting all of the Nvidia management library API, the gpu plugin does not crash.

Right now I am repeating these tests on a more modern card to make sure that better cards are actually supported.

#### Resume

* Bug fix: yes
* New feature: yes
* Fixed tickets: 170, 979