### PR TITLE
Feature/gpu nvidia - curses interface bugfix

### DIFF
--- a/glances/plugins/glances_gpu.py
+++ b/glances/plugins/glances_gpu.py
@@ -154,7 +154,7 @@ class Plugin(GlancesPlugin):
             if gpu_stats['mem'] is None:
                 msg = '{:>8}'.format('N/A')
             else:
-                msg = '{:>7d%}'.format(int(gpu_stats['mem']))
+                msg = '{:>7d}%'.format(int(gpu_stats['mem']))
             ret.append(self.curse_add_line(
                 msg, self.get_views(item=gpu_stats[self.get_key()],
                                     key='mem',


### PR DESCRIPTION
#### Description

A small typo prevented GPU stats reporting in the glances interface.  This fixes it.  The curses interface now looks like this:

<img width="758" alt="gpu glances" src="https://cloud.githubusercontent.com/assets/1323521/21296779/721f4cd0-c530-11e6-8500-910aea87f07b.PNG">

Notice the `GPU GRID K520` area.  😄 

#### Resume

* Bug fix: yes
* New feature: yes
* Fixed tickets: 170
