### PR TITLE
Fix typo in network text

### DIFF
--- a/docs/aoa/network.rst
+++ b/docs/aoa/network.rst
@@ -10,7 +10,7 @@ dynamically (bit/s, kbit/s, Mbit/s, etc).
 
 If the interface speed is detected (not on all systems), the defaults
 thresholds are applied (70% for careful, 80% warning and 90% critical).
-It is possible to define this percents thresholds form the configuration
+It is possible to define this percents thresholds from the configuration
 file. It is also possible to define per interface bit rate thresholds.
 In this case thresholds values are define in bps.
 


### PR DESCRIPTION
form -> from

#### Description

Fix typo in network text. It was writen "form" when I think you meant "from".

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: None
