### PR TITLE
Add FILES section to man page

### DIFF
--- a/docs/glances.rst
+++ b/docs/glances.rst
@@ -47,7 +47,7 @@ System Configuration
 User Configuration
 ~~~~~~~~~~~~~~~~~~~~
 
-$HOME/.config/glances.conf
+$HOME/.config/glances/glances.conf
 
     Linux, \*BSD, SunOS
 

--- a/docs/glances.rst
+++ b/docs/glances.rst
@@ -47,7 +47,7 @@ System Configuration
 User Configuration
 ~~~~~~~~~~~~~~~~~~~~
 
-$HOME/.config/glances/glances.conf
+$XDG_CONFIG_HOME/glances/glances.conf $HOME/.config/glances/glances.conf
 
     Linux, \*BSD, SunOS
 

--- a/docs/glances.rst
+++ b/docs/glances.rst
@@ -26,6 +26,33 @@ OPTIONS
 
 .. include:: cmds.rst
 
+FILES
+-----
+
+/etc/glances/glances.conf
+
+    (Linux, SunOS) System configuration file
+
+/usr/local/etc/glances/glances.conf
+
+    (\*BSD, macOS) System configuration file
+
+%APPDATA%\\glances\\glances.conf
+
+    (Windows) System configuration file
+
+$HOME/.config/glances.conf
+
+    (Linux, \*BSD, SunOS) User configuration file
+
+~/Library/Application Support/glances/glances.conf
+
+    (macOS) User configuration file
+
+%APPDATA%\\glances\\glances.conf
+
+    (Windows) User configuration file
+
 EXAMPLES
 --------
 

--- a/docs/glances.rst
+++ b/docs/glances.rst
@@ -29,29 +29,35 @@ OPTIONS
 FILES
 -----
 
+System Configuration
+~~~~~~~~~~~~~~~~~~~~
+
 /etc/glances/glances.conf
 
-    (Linux, SunOS) System configuration file
+    Linux, SunOS
 
 /usr/local/etc/glances/glances.conf
 
-    (\*BSD, macOS) System configuration file
+    \*BSD, macOS
 
 %APPDATA%\\glances\\glances.conf
 
-    (Windows) System configuration file
+    Windows
+
+User Configuration
+~~~~~~~~~~~~~~~~~~~~
 
 $HOME/.config/glances.conf
 
-    (Linux, \*BSD, SunOS) User configuration file
+    Linux, \*BSD, SunOS
 
 ~/Library/Application Support/glances/glances.conf
 
-    (macOS) User configuration file
+    macOS
 
 %APPDATA%\\glances\\glances.conf
 
-    (Windows) User configuration file
+    Windows
 
 EXAMPLES
 --------

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -628,7 +628,7 @@ Windows
 .UNINDENT
 .SS User Configuration
 .sp
-$HOME/.config/glances.conf
+$HOME/.config/glances/glances.conf
 .INDENT 0.0
 .INDENT 3.5
 Linux, *BSD, SunOS

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -628,7 +628,7 @@ Windows
 .UNINDENT
 .SS User Configuration
 .sp
-$HOME/.config/glances/glances.conf
+$XDG_CONFIG_HOME/glances/glances.conf $HOME/.config/glances/glances.conf
 .INDENT 0.0
 .INDENT 3.5
 Linux, *BSD, SunOS

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "GLANCES" "1" "Feb 07, 2017" "2.8.2" "Glances"
+.TH "GLANCES" "1" "February 21, 2017" "2.8.2" "Glances"
 .SH NAME
 glances \- An eye on your system
 .
@@ -602,6 +602,49 @@ Down in the servers list
 .TP
 .B \fBq|ESC\fP
 Quit Glances
+.UNINDENT
+.SH FILES
+.sp
+/etc/glances/glances.conf
+.INDENT 0.0
+.INDENT 3.5
+(Linux, SunOS) System configuration file
+.UNINDENT
+.UNINDENT
+.sp
+/usr/local/etc/glances/glances.conf
+.INDENT 0.0
+.INDENT 3.5
+(*BSD, macOS) System configuration file
+.UNINDENT
+.UNINDENT
+.sp
+%APPDATA%\eglances\eglances.conf
+.INDENT 0.0
+.INDENT 3.5
+(Windows) System configuration file
+.UNINDENT
+.UNINDENT
+.sp
+$HOME/.config/glances.conf
+.INDENT 0.0
+.INDENT 3.5
+(Linux, *BSD, SunOS) User configuration file
+.UNINDENT
+.UNINDENT
+.sp
+~/Library/Application Support/glances/glances.conf
+.INDENT 0.0
+.INDENT 3.5
+(macOS) User configuration file
+.UNINDENT
+.UNINDENT
+.sp
+%APPDATA%\eglances\eglances.conf
+.INDENT 0.0
+.INDENT 3.5
+(Windows) User configuration file
+.UNINDENT
 .UNINDENT
 .SH EXAMPLES
 .sp

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -604,46 +604,48 @@ Down in the servers list
 Quit Glances
 .UNINDENT
 .SH FILES
+.SS System Configuration
 .sp
 /etc/glances/glances.conf
 .INDENT 0.0
 .INDENT 3.5
-(Linux, SunOS) System configuration file
+Linux, SunOS
 .UNINDENT
 .UNINDENT
 .sp
 /usr/local/etc/glances/glances.conf
 .INDENT 0.0
 .INDENT 3.5
-(*BSD, macOS) System configuration file
+*BSD, macOS
 .UNINDENT
 .UNINDENT
 .sp
 %APPDATA%\eglances\eglances.conf
 .INDENT 0.0
 .INDENT 3.5
-(Windows) System configuration file
+Windows
 .UNINDENT
 .UNINDENT
+.SS User Configuration
 .sp
 $HOME/.config/glances.conf
 .INDENT 0.0
 .INDENT 3.5
-(Linux, *BSD, SunOS) User configuration file
+Linux, *BSD, SunOS
 .UNINDENT
 .UNINDENT
 .sp
 ~/Library/Application Support/glances/glances.conf
 .INDENT 0.0
 .INDENT 3.5
-(macOS) User configuration file
+macOS
 .UNINDENT
 .UNINDENT
 .sp
 %APPDATA%\eglances\eglances.conf
 .INDENT 0.0
 .INDENT 3.5
-(Windows) User configuration file
+Windows
 .UNINDENT
 .UNINDENT
 .SH EXAMPLES


### PR DESCRIPTION
#### Description

Add a `FILES` section to the man page, explaining where the config files are/should be located.

I tried having the XDG and hardcoded paths for Linux on different lines, but failed.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: 