### PR TITLE
Remove extra } in format string

### DIFF
--- a/glances/stats.py
+++ b/glances/stats.py
@@ -106,7 +106,7 @@ class GlancesStats(object):
         except Exception as e:
             # If a plugin can not be log, display a critical message
             # on the console but do not crash
-            logger.critical("Error while initializing the {} plugin ({}})".format(name, e))
+            logger.critical("Error while initializing the {} plugin ({})".format(name, e))
             logger.error(traceback.format_exc())
 
     def load_plugins(self, args=None):


### PR DESCRIPTION
#### Description

From a fresh pip install I was getting the following error. Removing the extra } fixed the issue and allowed glances to run.
```python
Traceback (most recent call last):
  File "/bin/glances", line 11, in <module>
    load_entry_point('Glances==2.9.0', 'console_scripts', 'glances')()
  File "/usr/lib/python2.7/site-packages/glances/__init__.py", line 134, in main
    start(config=config, args=args)
  File "/usr/lib/python2.7/site-packages/glances/__init__.py", line 100, in start
    mode = GlancesMode(config=config, args=args)
  File "/usr/lib/python2.7/site-packages/glances/standalone.py", line 43, in __init__
    self.stats = GlancesStats(config=config, args=args)
  File "/usr/lib/python2.7/site-packages/glances/stats.py", line 47, in __init__
    self.load_modules(self.args)
  File "/usr/lib/python2.7/site-packages/glances/stats.py", line 81, in load_modules
    self.load_plugins(args=args)
  File "/usr/lib/python2.7/site-packages/glances/stats.py", line 120, in load_plugins
    args=args, config=self.config)
  File "/usr/lib/python2.7/site-packages/glances/stats.py", line 109, in _load_plugin
    logger.critical("Error while initializing the {} plugin ({}})".format(name, e))
ValueError: Single '}' encountered in format string
```

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: None
