### PR TITLE
Hide virtual devices in the diskio plugin

### DIFF
--- a/docs/cmds.rst
+++ b/docs/cmds.rst
@@ -294,6 +294,10 @@ Command-Line Options
 
     show RAM FS in the DiskIO plugin
 
+.. option:: --diskio-show-virtual-devices
+
+    show virtual devices in the DiskIO plugin
+
 .. option:: --diskio-iops
 
     show I/O per second in the DiskIO plugin

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH "GLANCES" "1" "Apr 10, 2017" "2.9.2_DEVELOP" "Glances"
+.TH "GLANCES" "1" "Apr 15, 2017" "2.9.2_DEVELOP" "Glances"
 .SH NAME
 glances \- An eye on your system
 .

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -408,6 +408,11 @@ show RAM FS in the DiskIO plugin
 .UNINDENT
 .INDENT 0.0
 .TP
+.B \-\-diskio\-show\-virtual\-devices
+show virtual devices in the DiskIO plugin
+.UNINDENT
+.INDENT 0.0
+.TP
 .B \-\-diskio\-iops
 show I/O per second in the DiskIO plugin
 .UNINDENT

--- a/glances/main.py
+++ b/glances/main.py
@@ -249,6 +249,8 @@ Examples of use:
                             dest='byte', help='display network rate in byte per second')
         parser.add_argument('--diskio-show-ramfs', action='store_true', default=False,
                             dest='diskio_show_ramfs', help='show RAM Fs in the DiskIO plugin')
+        parser.add_argument('--diskio-show-virtual-devices', action='store_true', default=False,
+                            dest='diskio_show_virtual_devices', help='show virtual devices in the DiskIO plugin')
         parser.add_argument('--diskio-iops', action='store_true', default=False,
                             dest='diskio_iops', help='show IO per second in the DiskIO plugin')
         parser.add_argument('--fahrenheit', action='store_true', default=False,

--- a/glances/plugins/glances_diskio.py
+++ b/glances/plugins/glances_diskio.py
@@ -105,6 +105,12 @@ class Plugin(GlancesPlugin):
                     if self.args is not None and not self.args.diskio_show_ramfs and disk.startswith('ram'):
                         continue
 
+                    # Full list of virtual devices is in /sys/devices/virtual/block/
+                    if self.args is not None and not self.args.diskio_show_virtual_devices and (
+                                disk.startswith('dm-') or
+                                disk.startswith('loop')):
+                        continue
+
                     # Do not take hide disk into account
                     if self.is_hide(disk):
                         continue


### PR DESCRIPTION
#### Description

Hide virtual devices like dm-0 and loop0 by default in the diskio plugin, because:
* Disk IO from virtual / mapped devices is already accounted for in the real devices.
* Having many raw disks with many virtual devices makes the diskio plugin too tall

![hide_virtual_block_devices](https://cloud.githubusercontent.com/assets/395175/25067845/cd720ca4-221d-11e7-8396-32999c99266c.png)



#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets:
