### PR TITLE
add option to change default username and realm

### DIFF
--- a/glances/main.py
+++ b/glances/main.py
@@ -212,6 +212,10 @@ Examples of use:
                             help='define a client/server username')
         parser.add_argument('--password', action='store_true', default=False, dest='password_prompt',
                             help='define a client/server password')
+        parser.add_argument('--username-default', default=self.username, dest='username_default',
+                            help='this option will be ignored if --username is specified')
+        parser.add_argument('--realm', default='glances', dest='realm',
+                            help='used by Glances in web server mode when authentication is enabled')
         parser.add_argument('--snmp-community', default='public', dest='snmp_community',
                             help='SNMP community')
         parser.add_argument('--snmp-port', default=161, type=int,
@@ -312,7 +316,7 @@ Examples of use:
                     description='Enter the Glances server username: ')
         else:
             # Default user name is 'glances'
-            args.username = self.username
+            args.username = args.username_default
 
         if args.password_prompt:
             # Interactive or file password

--- a/glances/outputs/glances_bottle.py
+++ b/glances/outputs/glances_bottle.py
@@ -65,7 +65,7 @@ class GlancesBottle(object):
         self._app.install(EnableCors())
         # Password
         if args.password != '':
-            self._app.install(auth_basic(self.check_auth))
+            self._app.install(auth_basic(self.check_auth, realm=args.realm))
         # Define routes
         self._route()
 


### PR DESCRIPTION
#### Description

With this PR, glances will be able to read password from ``<any_user>.pwd`` file. Currently it only works for ``glances.pwd``.

This also changes the realm displayed during authentication from ``private`` to ``glances`` as default.

Sample usage:
``glances -w --password --username-default=<any_user> --realm=<any_realm>``

#### Resume

* Bug fix: yes
* New feature: yes
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any