### PR TITLE
Frame does not support the buffer interface

### DIFF
--- a/glances/exports/glances_zeromq.py
+++ b/glances/exports/glances_zeromq.py
@@ -56,7 +56,7 @@ class Export(GlancesExport):
         self.client = self.init()
 
     def init(self):
-        """Init the connection to the CouchDB server."""
+        """Init the connection to the ZeroMQ server."""
         if not self.export_enable:
             return None
 
@@ -96,8 +96,8 @@ class Export(GlancesExport):
         # - First frame containing the following prefix (STRING)
         # - Second frame with the Glances plugin name (STRING)
         # - Third frame with the Glances plugin stats (JSON)
-        message = [b(self.prefix),
-                   b(name),
+        message = [b(self.prefix).decode('utf-8'),
+                   b(name).decode('utf-8'),
                    asbytes(json.dumps(data))]
 
         # Write data to the ZeroMQ bus


### PR DESCRIPTION
The original code is causing "Frame does not support the buffer interface" error in zeroMQ @ https://github.com/zeromq/pyzmq/blob/master/zmq/sugar/socket.py line 373 in socket.recv_multipart. I looked up the code and find out the function b() in glances.compat is actually returning the same stuff. So it's basically a BUG of str does not support buffer interface, which can be solved by encode str before sending.

#### Description

Please describe the goal of this pull request.

#### Resume

* Bug fix: yes/no
* New feature: yes/no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
