### PR TITLE
Python encoding in python2 and python3

### DIFF
--- a/glances/compat.py
+++ b/glances/compat.py
@@ -85,7 +85,9 @@ if PY3:
         return iter(d.values())
 
     def u(s):
-        return s
+        if isinstance(s, text_type):
+            return s
+        return s.decode('utf-8', 'replace')
 
     def b(s):
         if isinstance(s, binary_type):
@@ -143,10 +145,14 @@ else:
         return d.itervalues()
 
     def u(s):
+        if isinstance(s, text_type):
+            return s
         return s.decode('utf-8')
 
     def b(s):
-        return s
+        if isinstance(s, binary_type):
+            return s
+        return s.encode('utf-8', 'replace')
 
     def nativestr(s):
         if isinstance(s, binary_type):


### PR DESCRIPTION
In python2, binary type is native string type, so function b and nativestr should be the same. In python3, unicode is native string and binary is encoded unicode type. Now the question comes, why do we encode unicode string in python3 by encode('latin-1') instead using utf-8?

Note: I fixed the bug for ZeroMQ by modifying the compat file, still needs further test system wide to make sure the type checking and translating is totally correct.

#### Description

The original code is causing "Frame does not support the buffer interface" error in ZeroMQ @ https://github.com/zeromq/pyzmq/blob/master/zmq/sugar/socket.py line 373 in socket.recv_multipart. I looked up the code and find out the function b() in glances.compat is actually returning the unicode object. So it's basically a bug of unicode does not support buffer interface, which can be solved by encode str before sending.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
