### PR TITLE
fix min_size to not output string with more than max characters

### DIFF
--- a/glances/outputs/static/js/filters.js
+++ b/glances/outputs/static/js/filters.js
@@ -2,7 +2,7 @@ glancesApp.filter('min_size', function () {
     return function (input, max) {
         var max = max || 8;
         if (input.length > max) {
-            return "_" + input.substring(input.length - max)
+            return "_" + input.substring(input.length - max + 1)
         }
         return input
     };

--- a/glances/outputs/static/public/js/main.min.js
+++ b/glances/outputs/static/public/js/main.min.js
@@ -61,7 +61,7 @@ glancesApp.filter('min_size', function () {
     return function (input, max) {
         var max = max || 8;
         if (input.length > max) {
-            return "_" + input.substring(input.length - max)
+            return "_" + input.substring(input.length - max + 1)
         }
         return input
     };


### PR DESCRIPTION
#### Description
problem: min_size outputs names longer than max
old: min_size('some_name', 8) -> "_ome_name"
solution: add 1 to substring offset
new: min_size('some_name', 8) -> "_me_name"

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:
