### PR TITLE
 Prevent data truncation when receiving data from hddtemp server

### DIFF
--- a/glances/plugins/glances_hddtemp.py
+++ b/glances/plugins/glances_hddtemp.py
@@ -140,7 +140,12 @@ class GlancesGrabHDDTemp(object):
         try:
             sck = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sck.connect((self.host, self.port))
-            data = sck.recv(4096)
+            data = b''
+            while True:
+                received = sck.recv(4096)
+                if not received:
+                    break
+                data += received
         except socket.error as e:
             logger.debug("Cannot connect to an HDDtemp server ({}:{} => {})".format(self.host, self.port, e))
             logger.debug("Disable the HDDtemp module. Use the --disable-hddtemp to hide the previous message.")
@@ -149,6 +154,8 @@ class GlancesGrabHDDTemp(object):
             data = ""
         finally:
             sck.close()
+            if data != "":
+                logger.debug("Received data from the HDDtemp server: {}".format(data))
 
         return data
 


### PR DESCRIPTION
#### Description

~~It looks like hddtemp is a very non-deterministic piece of software and
does not grant that every connection will receive data for all devices
that were in the previous one, thus making a device and its temperature
disappear and reappear in the list once in a while.~~

Since the first implementation of the hddtemp plugin, Glances wasn't retrieving
all data from the hddtemp server, making the device disappear and reappear
in the list once in a while.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none
