### PR TITLE
Fixes a link rendering problem in load.rst

### DIFF
--- a/docs/aoa/load.rst
+++ b/docs/aoa/load.rst
@@ -15,7 +15,7 @@ on GNU/Linux operating system:
     over 1, 5, and 15 minutes time periods."
 
 Be aware that Load on Linux and BSD are different things, high
-S`load on BSD`_ does not means high CPU load.
+`load on BSD`_ does not means high CPU load.
 
 Glances gets the number of CPU core to adapt the alerts.
 Alerts on load average are only set on 15 minutes time period.


### PR DESCRIPTION
Fixes a typo that prevented 'load on BSD' from rendering properly as a link.

#### Description

In the documentation, 'load on BSD' should render as a link but doesn't, due to a spurious `S` at the start - presumably a typo.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none
