### PR TITLE
Add missing mount-observe and system-observe interfaces

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,8 @@ apps:
     command: bin/glances
     plugs:
       - network
+      - mount-observe
+      - system-observe
 
 parts:
   glances:


### PR DESCRIPTION
#### Description

Fix the snap, which was missing the mount-observe and system-observe interfaces.
```
  snapcraft
  sudo snap install *.snap
  sudo snap connect glances:system-observe
  sudo snap connect glances:mount-observe
```
Once we have a revision with this change pushed to the store, I'll volunteer to request auto-connection for those two interfaces so end users just have to type `sudo snap install glances`.

#### Resume

* Bug fix: yes
* New feature: no
