### PR TITLE
Don't load public IP address if module disabled

### DIFF
--- a/glances/plugins/glances_ip.py
+++ b/glances/plugins/glances_ip.py
@@ -65,7 +65,8 @@ class Plugin(GlancesPlugin):
         self.display_curse = True
 
         # Get the public IP address once
-        self.public_address = PublicIpAddress().get()
+        if not self.is_disable():
+            self.public_address = PublicIpAddress().get()
 
         # Init the stats
         self.reset()


### PR DESCRIPTION
#### Description

glances shouldn't hit the network if there's no need to. This is especially annoying for me because I monitor outgoing network traffic and get an alert every time I run glances, even with `--disable-ip`.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any