### PR TITLE
Update Homebrew installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,8 +232,7 @@ Homebrew
 
 .. code-block:: console
 
-    $ brew install python
-    $ pip install glances
+    $ brew install glances
 
 MacPorts
 ````````


### PR DESCRIPTION
glances itself is [now](https://github.com/Homebrew/homebrew-core/pull/22538) packaged by Homebrew.