### PR TITLE
update readme docker run command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,7 +172,7 @@ Run the container in *console mode*:
 
 .. code-block:: console
 
-    docker run -v /var/run/docker.sock:/var/run/docker.sock:ro --pid host -it docker.io/nicolargo/glances
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro --pid host --network host -it docker.io/nicolargo/glances
 
 Additionally, if you want to use your own glances.conf file, you can
 create your own Dockerfile:


### PR DESCRIPTION
slightly better way which:
 - doesn't leave the container around when finished
 - uses network host mode which then allows glances to show the network devices

#### Description

improve docker run command in readme

