### PR TITLE
Dockerfile rebase to bitnami/minideb

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -7,10 +7,6 @@
 # Pull base image.
 FROM bitnami/minideb:stretch
 
-# Install Glances (develop branch)
-#RUN apt-get update && apt-get -y install curl && rm -rf /var/lib/apt/lists/*
-#RUN curl -L https://raw.githubusercontent.com/nicolargo/glancesautoinstall/master/install.sh | /bin/bash && rm -rf /var/lib/apt/lists/*
-
 # Install run dependencies
 RUN install_packages \
     ca-certificates \

--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -5,15 +5,30 @@
 #
 
 # Pull base image.
-FROM ubuntu
+FROM bitnami/minideb:stretch
 
 # Install Glances (develop branch)
-RUN apt-get update && apt-get -y install curl && rm -rf /var/lib/apt/lists/*
-RUN curl -L https://raw.githubusercontent.com/nicolargo/glancesautoinstall/master/install.sh | /bin/bash && rm -rf /var/lib/apt/lists/*
+#RUN apt-get update && apt-get -y install curl && rm -rf /var/lib/apt/lists/*
+#RUN curl -L https://raw.githubusercontent.com/nicolargo/glancesautoinstall/master/install.sh | /bin/bash && rm -rf /var/lib/apt/lists/*
 
+# Install run dependencies
+RUN install_packages \
+    ca-certificates \
+    lm-sensors \
+    python-psutil \
+    python-setuptools \
+    wget \
+    wireless-tools
 
 # Define working directory.
 WORKDIR /glances
+
+# Get master branch python files to build
+RUN wget -qO - https://api.github.com/repos/nicolargo/glances/tarball | \
+    tar -xz --strip-components=1
+
+# Install glances - temp test to see if this installs, remove for build environment
+RUN python setup.py install
 
 # EXPOSE PORT (For XMLRPC)
 EXPOSE 61209


### PR DESCRIPTION
#### Description

The docker image now weighs in at a decent 600M. Basing off of Bitnami's Minideb and getting a tarball image of Master from the GitHub api reduces the size to a light 150M. Might be able to reduce that even more by freezing the python into a bin and using just the 50M Minideb base. 

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: None