### PR TITLE
Implement number and alias aware diskio sorting

### DIFF
--- a/glances/plugins/glances_diskio.py
+++ b/glances/plugins/glances_diskio.py
@@ -19,7 +19,7 @@
 
 """Disk I/O plugin."""
 
-import operator
+import re
 
 from glances.timer import getTimeSinceLastUpdate
 from glances.plugins.glances_plugin import GlancesPlugin
@@ -180,7 +180,10 @@ class Plugin(GlancesPlugin):
             msg = '{:>7}'.format('W/s')
             ret.append(self.curse_add_line(msg))
         # Disk list (sorted by name)
-        for i in sorted(self.stats, key=operator.itemgetter(self.get_key())):
+        for i in sorted(self.stats, key=lambda stat: tuple(map(
+                lambda part: int(part) if part.isdigit() else part.lower(),
+                re.split(r"(\d+|\D+)", stat.get('alias') or stat['disk_name'])
+        ))):
             # Is there an alias for the disk name ?
             disk_real_name = i['disk_name']
             disk_name = self.has_alias(i['disk_name'])


### PR DESCRIPTION
#### Description

Sorts Disk I/O by aliases (if present) or device names and treats numbers as numbers.
Prevents situations such as `sda10` being above `sda2` or `alias` between `sda1` and `sda3`.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: none