### PR TITLE
fix on macOS when value is NoneType when compute the max values

### DIFF
--- a/glances/processes.py
+++ b/glances/processes.py
@@ -359,7 +359,8 @@ class GlancesProcesses(object):
         # Compute the maximum value for keys in self._max_values_list (CPU, MEM)
         for k in self._max_values_list:
             if self.processlist != []:
-                self.set_max_values(k, max(i[k] for i in self.processlist))
+                self.set_max_values(k, max(i[k] for i in self.processlist
+                if not (i[k] == None)))
 
     def getcount(self):
         """Get the number of processes."""


### PR DESCRIPTION
#### Description

Fix TypeError encountered under macOS and python v3 (works correctly with python v2)

> TypeError: '>' not supported between instances of 'NoneType' and 'float'

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
