### PR TITLE
Fixing horizontal scrolling

### DIFF
--- a/glances/outputs/static/css/style.css
+++ b/glances/outputs/static/css/style.css
@@ -20,6 +20,10 @@ body {
     text-align: right;
 }
 
+.row {
+    margin-right: 0px;
+}
+
 .top-plugin {
     margin-bottom: 20px;
 }


### PR DESCRIPTION
The Glances web-interface is scrollable due to bootstraps .row { margin }. I removed the right margin in the style.css file so the web-interface isn't horizontal scrollable.

#### Description

Please describe the goal of this pull request.

#### Resume

* Bug fix: yes/no
* New feature: yes/no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
