### PR TITLE
Use https URLs for checking external IP

### DIFF
--- a/glances/plugins/glances_ip.py
+++ b/glances/plugins/glances_ip.py
@@ -45,9 +45,9 @@ else:
 # - url: URL of the Web site
 # - json: service return a JSON (True) or string (False)
 # - key: key of the IP addresse in the JSON structure
-urls = [('http://ip.42.pl/raw', False, None),
-        ('http://httpbin.org/ip', True, 'origin'),
-        ('http://jsonip.com', True, 'ip'),
+urls = [('https://ip.42.pl/raw', False, None),
+        ('https://httpbin.org/ip', True, 'origin'),
+        ('https://jsonip.com', True, 'ip'),
         ('https://api.ipify.org/?format=json', True, 'ip')]
 
 


### PR DESCRIPTION
Processing JSON from connection that could be changed by attacker in path sounds scary, and all those services serve over https as well.

#### Description

Check own IP over https. Glances processes output returned, which sometimes is JSON, and doing that over plaintext http which could be transparently modified in flight is scary.

#### Resume

* Bug fix: yes
* New feature: no