### PR TITLE
Don't use 100% CPU in quiet mode

### DIFF
--- a/glances/standalone.py
+++ b/glances/standalone.py
@@ -20,6 +20,7 @@
 """Manage the Glances standalone session."""
 
 import sys
+import time
 
 from glances.globals import WINDOWS
 from glances.logger import logger
@@ -128,6 +129,7 @@ class GlancesStandalone(object):
         else:
             # Nothing is displayed
             # Break should be done via a signal (CTRL-C)
+            time.sleep(self.refresh_time - counter.get())
             ret = True
 
         return ret


### PR DESCRIPTION
#### Description

Before this patch, running `glances -q -t 10` resulted in 100% utilization. After this patch, glances properly wakes up only once every 10 seconds to collect data. This is usable when periodically exporting data to an external service.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: Maybe #1262
