### PR TITLE
docs: manpage - Fix spelling typo

### DIFF
--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -74,7 +74,7 @@ display modules (plugins & exports) list and exit
 .INDENT 0.0
 .TP
 .B \-\-disable\-plugin PLUGIN
-disable PLUGIN (comma separed list)
+disable PLUGIN (comma separated list)
 .UNINDENT
 .INDENT 0.0
 .TP
@@ -84,7 +84,7 @@ display stats to stdout (comma separated list of plugins/plugins.attribute)
 .INDENT 0.0
 .TP
 .B \-\-export EXPORT
-enable EXPORT module (comma separed list)
+enable EXPORT module (comma separated list)
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
#### Description

During Debian packaging, `lintian` throw a warning about this typo, here is a little PR in order to fix that :-)

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: -