### PR TITLE
Require `requests` on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ def get_install_requires():
     requires = ['psutil>=5.3.0']
     if sys.platform.startswith('win'):
         requires.append('bottle')
+        requires.append('requests')
 
     return requires
 


### PR DESCRIPTION
#### Description

As the web interface is needed on Windows (as there is no Curses interface), make sure all of the web requirements are included on Windows. This includes `bottle` (already listed) and `requests` (now added).

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: https://github.com/nicolargo/glances/issues/1167