### PR TITLE
`pwd`.conf instead of ./glances.conf for docker run command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -192,9 +192,9 @@ docker run options:
 
 .. code-block:: console
 
-    docker run -v ./glances.conf:/glances/conf/glances.conf -v /var/run/docker.sock:/var/run/docker.sock:ro --pid host -it docker.io/nicolargo/glances
+    docker run -v `pwd`/glances.conf:/glances/conf/glances.conf -v /var/run/docker.sock:/var/run/docker.sock:ro --pid host -it docker.io/nicolargo/glances
 
-Where ./glances.conf is a local directory containing your glances.conf file.
+Where \`pwd\`/glances.conf is a local directory containing your glances.conf file.
 
 Run the container in *Web server mode* (notice the `GLANCES_OPT` environment
 variable setting parameters for the glances startup command):

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -29,9 +29,9 @@ Alternatively, you can specify something along the same lines with docker run op
 
 .. code-block:: console
 
-    docker run -v ./glances.conf:/glances/conf/glances.conf -v /var/run/docker.sock:/var/run/docker.sock:ro --pid host -it docker.io/nicolargo/glances
+    docker run -v `pwd`/glances.conf:/glances/conf/glances.conf -v /var/run/docker.sock:/var/run/docker.sock:ro --pid host -it docker.io/nicolargo/glances
 
-Where ./glances.conf is a local directory containing your glances.conf file.
+Where \`pwd\`/glances.conf is a local directory containing your glances.conf file.
 
 Run the container in *Web server mode* (notice the `GLANCES_OPT` environment variable setting parameters for the glances startup command):
 


### PR DESCRIPTION
#### Description

Please describe the goal of this pull request.

improve documentation of glances with docker.

My Docker version 18.09.0, build 4d60db4

if I run this 
```bash
docker run -v ./glances.conf:/glances/conf/glances.conf -v /var/run/docker.sock:/var/run/docker.sock:ro --pid host -it docker.io/nicolargo/glances
``` 

I have this error `docker: Error response from daemon: create ./glances.conf: "./glances.conf" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.`

So in agreement with docker document https://docs.docker.com/storage/bind-mounts/, we can replace ./ by \`pwd\`

#### Resume

\`pwd\`.conf instead of ./glances.conf for docker run command in documentation

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
