### PR TITLE
README: note that docker plugin works on Mac

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Optional dependencies:
 - ``bottle`` (for Web server mode)
 - ``cassandra-driver`` (for the Cassandra export module)
 - ``couchdb`` (for the CouchDB export module)
-- ``docker`` (for the Docker monitoring support) [Linux-only]
+- ``docker`` (for the Docker monitoring support) [Linux/macOS-only]
 - ``elasticsearch`` (for the Elastic Search export module)
 - ``hddtemp`` (for HDD temperature monitoring support) [Linux-only]
 - ``influxdb`` (for the InfluxDB export module)


### PR DESCRIPTION
#### Description

The docker plugin sure seems to work on macOS, not just Linux. I tested it locally on macOS 10.13.6. Should the README be updated to note that it works there too?

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: none
