### PR TITLE
Client Browser's thread management added.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ _build
 # web ui
 node_modules/
 bower_components/
+
+# visual stdio code 
+.vscode/

--- a/glances/client_browser.py
+++ b/glances/client_browser.py
@@ -219,12 +219,16 @@ class GlancesClientBrowser(object):
         # It's done by the GlancesAutoDiscoverListener class (autodiscover.py)
         # Or define staticaly in the configuration file (module static_list.py)
         # For each server in the list, grab elementary stats (CPU, LOAD, MEM, OS...)
-
-        while True:
+        thread_list = {}
+        while self.screen.is_end == False:
             logger.debug("Iter through the following server list: {}".format(self.get_servers_list()))
             for v in self.get_servers_list():
-                thread = threading.Thread(target=self.__update_stats, args=[v])
-                thread.start()
+                key = v["key"]
+                thread = thread_list.get(key, None)
+                if thread is None or thread.is_alive() == False:
+                    thread = threading.Thread(target=self.__update_stats, args=[v])
+                    thread_list[key] = thread
+                    thread.start()
 
             # Update the screen (list or Glances client)
             if self.screen.active_server is None:
@@ -233,6 +237,10 @@ class GlancesClientBrowser(object):
             else:
                 # Display the active server
                 self.__display_server(self.get_servers_list()[self.screen.active_server])
+
+        # exit key pressed
+        for thread in thread_list.values():
+            thread.join()
 
     def serve_forever(self):
         """Wrapper to the serve_forever function.

--- a/glances/outputs/glances_curses_browser.py
+++ b/glances/outputs/glances_curses_browser.py
@@ -61,6 +61,8 @@ class GlancesCursesBrowser(_GlancesCurses):
         self._page_max = 0
         self._page_max_lines = 0
 
+        self.is_end = False
+
     @property
     def active_server(self):
         """Return the active server or None if it's the browser list."""
@@ -124,6 +126,8 @@ class GlancesCursesBrowser(_GlancesCurses):
         """Set next page."""
         if self._current_page + 1 < self._page_max:
             self._current_page += 1
+        else:
+            self._current_page = 0
         self.cursor_position = 0
 
     def __catch_key(self, stats):
@@ -138,7 +142,8 @@ class GlancesCursesBrowser(_GlancesCurses):
             # 'ESC'|'q' > Quit
             self.end()
             logger.info("Stop Glances client browser")
-            sys.exit(0)
+            # sys.exit(0)
+            self.is_end = True
         elif self.pressedkey == 10:
             # 'ENTER' > Run Glances on the selected server
             self.active_server =  self._current_page * self._page_max_lines + self.cursor_position
@@ -288,10 +293,7 @@ class GlancesCursesBrowser(_GlancesCurses):
             self.cursor = len(stats) - 1
 
         start_line = self._page_max_lines * self._current_page 
-        end_line = start_line + self._page_max_lines
-        if end_line > stats_len:
-            end_line = stats_len
-
+        end_line = start_line + self.get_pagelines(stats)
         current_page = stats[start_line:end_line]
         
         # Display table

--- a/glances/plugins/glances_ports.py
+++ b/glances/plugins/glances_ports.py
@@ -272,6 +272,8 @@ class ThreadScanner(threading.Thread):
         try:
             req = requests.head(web['url'],
                                 allow_redirects=True,
+                                verify=web['ssl_verify'],
+                                proxies=web['proxies'],
                                 timeout=web['timeout'])
         except Exception as e:
             logger.debug(e)

--- a/glances/web_list.py
+++ b/glances/web_list.py
@@ -97,6 +97,21 @@ class GlancesWebList(object):
 
                 # Indice
                 new_web['indice'] = 'web_' + str(i)
+                
+                # SSL verify
+                # ssl_verify
+                new_web['ssl_verify'] = config.get_value(self._section, 
+                                                        '%sssl_verify' % postfix,
+                                                         default='True')
+                # Proxy
+                http_proxy = config.get_value(self._section, 
+                                                '%shttp_proxy' % postfix,
+                                                default=None)
+                
+                https_proxy = config.get_value(self._section, 
+                                                '%shttps_proxy' % postfix,
+                                                default=None)
+                
 
                 # Add the server to the list
                 logger.debug("Add Web URL %s to the static list" % new_web['url'])

--- a/glances/web_list.py
+++ b/glances/web_list.py
@@ -98,11 +98,10 @@ class GlancesWebList(object):
                 # Indice
                 new_web['indice'] = 'web_' + str(i)
                 
-                # SSL verify
                 # ssl_verify
                 new_web['ssl_verify'] = config.get_value(self._section, 
                                                         '%sssl_verify' % postfix,
-                                                         default='True')
+                                                         default=True)
                 # Proxy
                 http_proxy = config.get_value(self._section, 
                                                 '%shttp_proxy' % postfix,
@@ -111,7 +110,12 @@ class GlancesWebList(object):
                 https_proxy = config.get_value(self._section, 
                                                 '%shttps_proxy' % postfix,
                                                 default=None)
-                
+
+                if https_proxy is None and http_proxy is None:
+                    new_web['proxies'] = None
+                else:
+                    new_web['proxies'] = {'http' : http_proxy,
+                                          'https' : https_proxy }
 
                 # Add the server to the list
                 logger.debug("Add Web URL %s to the static list" % new_web['url'])


### PR DESCRIPTION
Client Browser's thread management added.
Curses Browser's key bug fixed.

#### Description

1.  Glances browser created too many thread and used too much memories.  
 For example, I added 200 servers, Glances browser created 5000+ threads and used 200+MB memories. 
 
2. PageDown key minor bug fixed. 
   PageDown key didn't work at end of page.

3. port plugin ssl verify and proxy option added. 
 - ssl verify : defualt True, optional False and /path/to/certi.cer 
   ex)  web_1_ssl_verify=False
           web1_ssl_verify="/Users/foo/mycert.cer" 
 - http/https proxy added: default None
  ex) web_1_http_proxy = "192.168.0.1:8080"
        web_2_https_proxy="192.168.0.1:8080"
#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
