### PR TITLE
add authprovider for cassandra export

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -365,6 +365,9 @@ keyspace=glances
 replication_factor=2
 # If not define, table name is set to host key
 table=localhost
+# If not define, username and password will not be used
+#username=cassandra
+#password=password
 
 [opentsdb]
 # Configuration for the --export opentsdb option


### PR DESCRIPTION
#### Description

The goal of the PR is to add the possibility to export throw a Cassandra with authenticator (username/password) 

I follow this https://datastax.github.io/python-driver/api/cassandra/auth.html

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
