### PR TITLE
Curses's browser server list sorting added. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ _build
 # web ui
 node_modules/
 bower_components/
+
+.vscode/

--- a/glances/outputs/glances_curses_browser.py
+++ b/glances/outputs/glances_curses_browser.py
@@ -340,7 +340,7 @@ class GlancesCursesBrowser(_GlancesCurses):
             self.cursor = len(stats) - 1
 
         stats_list = None
-        if self._sort_order_list is not None:
+        if self._sort_order_list is not None and self._stats_list is not None:
             stats_list = self._stats_list
             stats_list.sort(key=self._sort_by_status)
         else:

--- a/glances/outputs/glances_curses_browser.py
+++ b/glances/outputs/glances_curses_browser.py
@@ -124,6 +124,8 @@ class GlancesCursesBrowser(_GlancesCurses):
         """Set next page."""
         if self._current_page + 1 < self._page_max:
             self._current_page += 1
+        else:
+            self._current_page = 0
         self.cursor_position = 0
 
     def __catch_key(self, stats):
@@ -288,9 +290,7 @@ class GlancesCursesBrowser(_GlancesCurses):
             self.cursor = len(stats) - 1
 
         start_line = self._page_max_lines * self._current_page 
-        end_line = start_line + self._page_max_lines
-        if end_line > stats_len:
-            end_line = stats_len
+        end_line = start_line + self.get_pagelines(stats)
 
         current_page = stats[start_line:end_line]
         

--- a/glances/outputs/glances_curses_browser.py
+++ b/glances/outputs/glances_curses_browser.py
@@ -90,6 +90,18 @@ class GlancesCursesBrowser(_GlancesCurses):
             page_lines = self._page_max_lines
         return page_lines
 
+    def _get_status_count(self, stats):
+        counts = {}
+        for item in stats:
+            color = item['status']
+            counts[color] = counts.get(color, 0) + 1
+    
+        result = ''
+        for key in counts.keys():
+            result += key + ': ' + str(counts[key]) + ' '
+   
+        return result
+    
     def cursor_up(self, stats):
         """Set the cursor to position N-1 in the list."""
         if 0 <= self.cursor_position - 1:
@@ -249,11 +261,14 @@ class GlancesCursesBrowser(_GlancesCurses):
                                      screen_x - x,
                                      self.colors_list['TITLE'])
         if stats_len > stats_max and screen_y > 2:
-            msg = '{} servers displayed.({}/{})'.format(self.get_pagelines(stats), self._current_page + 1, self._page_max)
+            msg = '{} servers displayed.({}/{}) {}'.format(self.get_pagelines(stats),
+                                                            self._current_page + 1, 
+                                                            self._page_max, 
+                                                            self._get_status_count(stats))
             self.term_window.addnstr(y + 1, x,
                                      msg,
                                      screen_x - x)
-
+        
         if stats_len == 0:
             return False
 


### PR DESCRIPTION
#### Description
* Curses's browser server list sorting added.
using key '1', '2' , '3'.
key '1' is normal. (don't use sorting)
key '2' is using sorting with ascending order. 
ONLINE > SNMP > PROTECTED > OFFLINE  > UNKNOWN
key '3' is using sorting with descending order.

*  Curses's browser server status count added. 
 


#### Resume

* Bug fix: yes/no
* New feature: yes/no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
