### PR TITLE
Fix missing gcc dependency in snap build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,6 +25,8 @@ apps:
 
 parts:
   glances:
+    build-packages:
+    - gcc
     plugin: python
     source: https://github.com/nicolargo/glances.git
   bottle:


### PR DESCRIPTION
#### Description
The cleanbuild complains about the missing `x86_64-linux-gnu-gcc`
command, this patch fixes it by enumerating the gcc build package.

```
  creating build/temp.linux-x86_64-3.5
  creating build/temp.linux-x86_64-3.5/psutil
  x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector-strong -Wformat -Werror=format-security -I/usr/include/python3.5m -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_VERSION=548 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/root/build_glances/parts/glances/install/usr/include/python3.5m -c psutil/_psutil_common.c -o build/temp.linux-x86_64-3.5/psutil/_psutil_common.o
  unable to execute 'x86_64-linux-gnu-gcc': No such file or directory
  error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
  
  ----------------------------------------
  Failed building wheel for psutil
  Running setup.py clean for psutil
Successfully built Glances
Failed to build psutil
ERROR: Failed to build one or more wheels
Failed to run '/root/build_glances/parts/glances/install/usr/bin/python3 -m pip wheel --no-index --find-links /root/build_glances/parts/glances/python-packages --wheel-dir /tmp/tmpa95votgu .': Exited with code 1.
```

#### Resume

* Bug fix: yes