### PR TITLE
fix tablename cassandra export and variabilize the cassandra table-name

### DIFF
--- a/glances/exports/glances_cassandra.py
+++ b/glances/exports/glances_cassandra.py
@@ -115,11 +115,11 @@ class Export(GlancesExport):
 
         # Write input to the Cassandra table
         try:
+
+            stmt = "INSERT INTO {} (plugin, time, stat) VALUES (?, ?, ?)".format(self.table)
+            query = self.session.prepare(stmt)
             self.session.execute(
-                """
-                INSERT INTO localhost (plugin, time, stat)
-                VALUES (%s, %s, %s)
-                """,
+                query,
                 (name, uuid_from_time(datetime.now()), data)
             )
         except Exception as e:


### PR DESCRIPTION
#### Description

In the Cassandra export, the conf file allows choosing a table name for the destination table in the Cassandra database, but the name can be the only localhost because it's hardcoded

https://github.com/nicolargo/glances/blob/62debf21b4e22425caa4b71c0b423638dd6daf36/glances/exports/glances_cassandra.py#L103

glances/exports/glances_cassandra.py#L103
```python
            session.execute("CREATE TABLE %s (plugin text, time timeuuid, stat map<text,float>, PRIMARY KEY (plugin, time)) WITH CLUSTERING ORDER BY (time DESC)" % self.table)
```

#### Resume
The goal of this PR is to use truly  the table name variable

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
