### PR TITLE
Allow use of configuration files when installed as snap.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,12 @@ apps:
       - network-observe
       - physical-memory-observe
       - upower-observe
+      - system-files
+      - home
+
+plugs:
+  system-files:
+    read: [ /etc/glances/glances.conf ]
 
 parts:
   glances:


### PR DESCRIPTION
Closes #1403

#### Description

Allow use of configuration files when installed as snap.
Valid configuration files are:
 * `/etc/glances/glances.conf`
 * `~/*`

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: 1403
