### PR TITLE
Fixes a typo in command-line options docs

### DIFF
--- a/docs/cmds.rst
+++ b/docs/cmds.rst
@@ -22,7 +22,7 @@ Command-Line Options
 
     path to the configuration file
 
-.. option:: -modules-list
+.. option:: --modules-list
 
     display modules (plugins & exports) list and exit
 


### PR DESCRIPTION
fixes a small typo in documentation
