### PR TITLE
add date to index, unbreak object push

### DIFF
--- a/glances/exports/glances_elasticsearch.py
+++ b/glances/exports/glances_elasticsearch.py
@@ -119,7 +119,7 @@ class Export(GlancesExport):
             dtnow = datetime.utcnow()
             action = {
                 "_index": self.index,
-                "_id": c,
+                "_id": '{}.{}'.format(name,c),
                 "_type": "glances",
                 "_source": {
                     "plugin": name,

--- a/glances/exports/glances_elasticsearch.py
+++ b/glances/exports/glances_elasticsearch.py
@@ -125,8 +125,7 @@ class Export(GlancesExport):
                     "plugin": name,
                     "metric": c,
                     "value": str(p),
-                    "_timestamp": dtnow.timestamp(),
-                    "timestamp": dtnow.isoformat()
+                    "utc_datetime": dtnow.isoformat('T')
                 }
             }
             logger.debug("Exporting the following object to elasticsearch: {}".format(action))

--- a/glances/exports/glances_elasticsearch.py
+++ b/glances/exports/glances_elasticsearch.py
@@ -57,6 +57,7 @@ class Export(GlancesExport):
         if not self.export_enable:
             return None
 
+        self.index='{}-{}'.format(self.index, datetime.today().strftime("%Y.%m.%d"))
         try:
             es = Elasticsearch(hosts=['{}:{}'.format(self.host, self.port)])
         except Exception as e:
@@ -86,13 +87,16 @@ class Export(GlancesExport):
         for c, p in zip(columns, points):
             action = {
                 "_index": self.index,
-                "_type": name,
                 "_id": c,
+                "_type": "glances",
                 "_source": {
+                    "name": name,
                     "value": str(p),
+                    "type": "keyword",
                     "timestamp": datetime.now()
                 }
             }
+            logger.debug("Exporting the following object to elasticsearch: {}".format(action))
             actions.append(action)
 
         # Write input to the ES index

--- a/glances/exports/glances_elasticsearch.py
+++ b/glances/exports/glances_elasticsearch.py
@@ -57,7 +57,38 @@ class Export(GlancesExport):
         if not self.export_enable:
             return None
 
-        self.index='{}-{}'.format(self.index, datetime.today().strftime("%Y.%m.%d"))
+        self.index='{}-{}'.format(self.index, datetime.utcnow().strftime("%Y.%m.%d"))
+        template_body =  {
+          "mappings": {
+            "glances": {
+              "dynamic_templates": [
+                {
+                  "integers": {
+                    "match_mapping_type": "long",
+                    "mapping": {
+                      "type": "integer"
+                    }
+                  }
+                },
+                {
+                  "strings": {
+                    "match_mapping_type": "string",
+                    "mapping": {
+                      "type": "text",
+                      "fields": {
+                        "raw": {
+                          "type":  "keyword",
+                          "ignore_above": 256
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+
         try:
             es = Elasticsearch(hosts=['{}:{}'.format(self.host, self.port)])
         except Exception as e:
@@ -71,7 +102,7 @@ class Export(GlancesExport):
         except Exception as e:
             # Index did not exist, it will be created at the first write
             # Create it...
-            es.indices.create(self.index)
+            es.indices.create(index=self.index,body=template_body)
         else:
             logger.info("There is already %s entries in the ElasticSearch %s index" % (index_count, self.index))
 
@@ -85,15 +116,17 @@ class Export(GlancesExport):
         # https://elasticsearch-py.readthedocs.io/en/master/helpers.html
         actions = []
         for c, p in zip(columns, points):
+            dtnow = datetime.utcnow()
             action = {
                 "_index": self.index,
                 "_id": c,
                 "_type": "glances",
                 "_source": {
-                    "name": name,
+                    "plugin": name,
+                    "metric": c,
                     "value": str(p),
-                    "type": "keyword",
-                    "timestamp": datetime.now()
+                    "_timestamp": dtnow.timestamp(),
+                    "timestamp": dtnow.isoformat()
                 }
             }
             logger.debug("Exporting the following object to elasticsearch: {}".format(action))


### PR DESCRIPTION
#### Description

makes indices date-based (e.g. `glances-2019.03.13`) and also makes all fields of type `keyword`.  That is a hack and I will probably try to fix it later.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any #1272 
