### PR TITLE
Ignore loop back file systems under Ubuntu

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -149,7 +149,7 @@ critical=-85
 [diskio]
 # Define the list of hidden disks (comma-separated regexp)
 #hide=sda2,sda5,loop.*
-hide=loop.*
+hide=loop.*,/dev/loop*
 # Alias for sda1
 #sda1_alias=IntDisk
 


### PR DESCRIPTION
#### Description

This hides about a dozen loop back file systems on my Ubuntu 18.04 machine, cleaning up the side bar tremendously.

#### Resume

* Bug fix: Some loop back file systems do not get ignored, cluttering the side bar.