### PR TITLE
snap: Fix broken --webserver due to missing network-bind plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,6 +23,7 @@ apps:
       - physical-memory-observe
       - upower-observe
       - home
+      - network-bind
     environment:
       LANG: C.UTF-8
       LC_ALL: C.UTF-8


### PR DESCRIPTION
#### Description

This patch fixes the following error: 

```
$ glances --web-server
Glances Web User Interface started on http://0.0.0.0:61208/
Traceback (most recent call last):
  File "/snap/glances/x1/bin/glances", line 11, in <module>
nces')()
  File "/snap/glances/x1/lib/python3.5/site-packages/glances/__init__.py", line 140, in main
    start(config=config, args=args)
  File "/snap/glances/x1/lib/python3.5/site-packages/glances/__init__.py", line 109, in start
    mode.serve_forever()
  File "/snap/glances/x1/lib/python3.5/site-packages/glances/webserver.py", line 48, in serve_forever
    self.web.start(self.stats)
  File "/snap/glances/x1/lib/python3.5/site-packages/glances/outputs/glances_bottle.py", line 218, in start
    quiet=not self.args.debug)
  File "/snap/glances/x1/bin/bottle.py", line 755, in run
    run(self, **kwargs)
  File "/snap/glances/x1/bin/bottle.py", line 3129, in run
    server.run(app)
  File "/snap/glances/x1/bin/bottle.py", line 2781, in run
    srv = make_server(self.host, self.port, app, server_cls, handler_cls)
  File "/snap/glances/x1/usr/lib/python3.5/wsgiref/simple_server.py", line 160, in make_server
    server = server_class((host, port), handler_class)
  File "/snap/glances/x1/usr/lib/python3.5/socketserver.py", line 441, in __init__
    self.server_activate()
  File "/snap/glances/x1/usr/lib/python3.5/socketserver.py", line 463, in server_activate
    self.socket.listen(self.request_queue_size)
PermissionError: [Errno 1] Operation not permitted
```

#### Resume

* Bug fix: yes
* New feature: no
