### PR TITLE
snap: Add packaging-specific gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,12 @@ bower_components/
 
 # visual stdio code
 .vscode/
+
+# Snap packaging specific
+/snap/.snapcraft/
+/parts/
+/stage/
+/prime/
+
+/*.snap
+/*_source.tar.bz2


### PR DESCRIPTION
#### Description
Avoid showing snap build artifacts as untracked files, this should also make the -dirty tag in the snap version string disappear.

#### Resume
* Bug fix: kinda
* New feature: no
