### PR TITLE
Filter duplicate public IP addresses in IP plugin

### DIFF
--- a/glances/plugins/glances_ip.py
+++ b/glances/plugins/glances_ip.py
@@ -173,7 +173,7 @@ class PublicIpAddress(object):
             if q.qsize() > 0:
                 ip = q.get()
 
-        return ip
+        return ', '.join(set([x.strip() for x in ip.split(',')]))
 
     def _get_ip_public(self, queue_target, url, json=False, key=None):
         """Request the url service and put the result in the queue_target."""


### PR DESCRIPTION
#### Description

I just noticed that httpbin.org is returning duplicate IP addresses in the format "1.2.3.4, 1.2.3.4". Here is a cosmetic fix that deduplicates the data. 

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: None
