### PR TITLE
Fix missing future in devel-arm Dockerfile

### DIFF
--- a/docker-files/devel-arm/Dockerfile
+++ b/docker-files/devel-arm/Dockerfile
@@ -12,9 +12,10 @@ RUN apk add --no-cache --virtual .build_deps \
 	gcc \
 	musl-dev \
 	linux-headers \
-	&& pip install 'psutil>=5.4.7,<5.5.0' bottle==0.12.13 \
+	git \
+	&& git clone -b develop https://github.com/nicolargo/glances.git \
+	&& pip install --no-cache-dir -r glances/requirements.txt bottle \
 	&& apk del .build_deps
-RUN apk add --no-cache git && git clone -b develop https://github.com/nicolargo/glances.git
 
 # Define working directory.
 WORKDIR /glances


### PR DESCRIPTION
#### Description

`future` has been added to requirements.txt, but is missing from arm Dockerfile.

Instead of adding future directly, I install all requirements so this should not be a problem in the future. Another improvement could be to install optional-requirements.txt so all modules are made available in the base image.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: n/a
