### PR TITLE
:ambulance: Fix typo for protocol, fixes #1514

### DIFF
--- a/glances/exports/glances_influxdb.py
+++ b/glances/exports/glances_influxdb.py
@@ -41,7 +41,7 @@ class Export(GlancesExport):
         self.db = None
 
         # Optionals configuration keys
-        self.protocole = 'http'
+        self.protocol = 'http'
         self.prefix = None
         self.tags = None
 


### PR DESCRIPTION
#### Description

Fix typo on protocol configuration, as protocol is empty `ssl=(self.protocol.lower() == 'https'),` fails, therefore an error is thrown on startup when InfluxDB is configured.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #1514 
