### PR TITLE
Fix custom refresh time in the web UI

### DIFF
--- a/glances/main.py
+++ b/glances/main.py
@@ -301,9 +301,8 @@ Examples of use:
         if WINDOWS:
             args.webserver = True
 
-        # In web server mode, default refresh time: 5 sec
+        # In web server mode
         if args.webserver:
-            args.time = 5
             args.process_short_name = True
 
         # Server or client login/password

--- a/glances/outputs/glances_bottle.py
+++ b/glances/outputs/glances_bottle.py
@@ -225,7 +225,7 @@ class GlancesBottle(object):
         """Bottle callback for index.html (/) file."""
 
         if refresh_time is None or refresh_time < 1:
-            refresh_time = self.args.time
+            refresh_time = int(self.args.time)
 
         # Update the stat
         self.__update__()


### PR DESCRIPTION
#### Description

The cmd `glances -t 30 -w` was not working because in web UI mode, the time arg was force to 5 seconds.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #1521
