### PR TITLE
Bug fix for UTF-8 check

### DIFF
--- a/glances/outputs/glances_sparklines.py
+++ b/glances/outputs/glances_sparklines.py
@@ -36,7 +36,7 @@ except ImportError as e:
 
 try:
     '┌┬┐╔╦╗╒╤╕╓╥╖│║─═├┼┤╠╬╣╞╪╡╟╫╢└┴┘╚╩╝╘╧╛╙╨╜'.encode(sys.stdout.encoding)
-except (UnicodeEncodeError, TypeError):
+except (UnicodeEncodeError, TypeError) as e:
     logger.warning("UTF-8 is mandatory for sparklines ({})".format(e))
     sparklines_module = False
 


### PR DESCRIPTION
#### Description

Pretty straight-forward, e was not defined causing glances to crash when encoding is not UTF-8

With this fix, a warning is appended to the log. Reproduced below:
```
2019-11-14 05:27:38,350 -- WARNING -- UTF-8 is mandatory for sparklines ('ascii' codec can't encode characters in position 0-39: ordinal not in range(128))
```

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: (none)
