### PR TITLE
Fix broken method call when config is None

### DIFF
--- a/glances/plugins/glances_processlist.py
+++ b/glances/plugins/glances_processlist.py
@@ -117,9 +117,10 @@ class Plugin(GlancesPlugin):
         self.pid_max = glances_processes.pid_max
 
         # Set the default sort key if it is defined in the configuration file
-        if 'processlist' in config.as_dict() and 'sort_key' in config.as_dict()['processlist']:
-            logger.debug('Configuration overwrites processes sort key by {}'.format(config.as_dict()['processlist']['sort_key']))
-            glances_processes.set_sort_key(config.as_dict()['processlist']['sort_key'], False)
+        if config is not None:
+            if 'processlist' in config.as_dict() and 'sort_key' in config.as_dict()['processlist']:
+                logger.debug('Configuration overwrites processes sort key by {}'.format(config.as_dict()['processlist']['sort_key']))
+                glances_processes.set_sort_key(config.as_dict()['processlist']['sort_key'], False)
 
         # Note: 'glances_processes' is already init in the processes.py script
 


### PR DESCRIPTION
#### Description

Fix method calls on `config` triggering an `AttributeError` when no config files were found

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #1569 
