### PR TITLE
Add hide option to sensors plugin

### DIFF
--- a/glances/plugins/glances_sensors.py
+++ b/glances/plugins/glances_sensors.py
@@ -127,14 +127,20 @@ class Plugin(GlancesPlugin):
 
             pass
 
-        # Set the alias for each stat
+        # Update the stats
+        self.stats = []
+
         for stat in stats:
+            # Do not take hide stat into account
+            if self.is_hide(stat["label"]):
+                continue
+
+            # Set the alias for each stat
             alias = self.has_alias(stat["label"].lower())
             if alias:
                 stat["label"] = alias
 
-        # Update the stats
-        self.stats = stats
+            self.stats.append(stat)
 
         return self.stats
 


### PR DESCRIPTION
#### Description

This pull request proposes to add the support of hide option to the sensors plugin. It may be useful when you want to hide core temperatures and only show main CPU temp of 10+ core CPUs.

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: N/A
