### PR TITLE
Unittests: Use sys.executable instead of hardcoding the python interpreter

### DIFF
--- a/unitest-restful.py
+++ b/unitest-restful.py
@@ -22,6 +22,7 @@
 
 import shlex
 import subprocess
+import sys
 import time
 import numbers
 import unittest
@@ -64,7 +65,7 @@ class TestGlances(unittest.TestCase):
         global pid
 
         print('INFO: [TEST_000] Start the Glances Web Server')
-        cmdline = "python -m glances -w -p %s" % SERVER_PORT
+        cmdline = "%s -m glances -w -p %s" % (sys.executable, SERVER_PORT)
         print("Run the Glances Web Server on port %s" % SERVER_PORT)
         args = shlex.split(cmdline)
         pid = subprocess.Popen(args)

--- a/unitest-xmlrpc.py
+++ b/unitest-xmlrpc.py
@@ -23,6 +23,7 @@
 import json
 import shlex
 import subprocess
+import sys
 import time
 import unittest
 
@@ -53,7 +54,7 @@ class TestGlances(unittest.TestCase):
         global pid
 
         print('INFO: [TEST_000] Start the Glances Web Server')
-        cmdline = "python -m glances -s -p %s" % SERVER_PORT
+        cmdline = "%s -m glances -s -p %s" % (sys.executable, SERVER_PORT)
         print("Run the Glances Server on port %s" % SERVER_PORT)
         args = shlex.split(cmdline)
         pid = subprocess.Popen(args)


### PR DESCRIPTION
#### Description

Use sys.executable instead of hardcoding the python interpreter in the unittests.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: -