### PR TITLE
Update master dockerfile for Ubuntu 20.04

### DIFF
--- a/docker-files/master/Dockerfile
+++ b/docker-files/master/Dockerfile
@@ -5,12 +5,30 @@
 #
 
 # Pull base image.
-FROM ubuntu
+FROM ubuntu:20.04
 
-# Install Glances (develop branch)
-RUN apt-get update && apt-get -y install curl iputils-ping && rm -rf /var/lib/apt/lists/*
-RUN curl -L https://raw.githubusercontent.com/nicolargo/glancesautoinstall/master/install.sh | /bin/bash && rm -rf /var/lib/apt/lists/*
 
+# Install package
+# Must used calibre package to be able to run external module
+ENV DEBIAN_FRONTEND noninteractive
+RUN \
+  apt-get update           && \
+  apt-get install -y          \
+            curl              \
+            gcc               \
+            lm-sensors        \
+            wireless-tools    \
+            iputils-ping      \
+            python3-pip       \
+            python3-dev    && \
+  rm -rf /var/lib/apt/lists/*
+
+## Instal glances
+RUN \
+  pip3 install --upgrade pip                                                                                 && \
+  pip3 install setuptools                                                                                       \
+               glances[action,batinfo,browser,cpuinfo,docker,export,folders,gpu,graph,ip,raid,snmp,web,wifi]    \
+               glances
 
 # Define working directory.
 WORKDIR /glances
@@ -22,4 +40,4 @@ EXPOSE 61209
 EXPOSE 61208
 
 # Define default command.
-CMD python -m glances -C /glances/conf/glances.conf $GLANCES_OPT
+CMD python3 -m glances -C /glances/conf/glances.conf $GLANCES_OPT


### PR DESCRIPTION
#### Description

As described in issue #1662 and [glancesautoinstall#39](https://github.com/nicolargo/glancesautoinstall/issues/39), I have tried to use glances in docker. Unfortunately the image was not up to date. I tried to build it in local but your Dockerfile was not working with last ubuntu 20.04 because package python-pip got removed from officiel repo.

I have decided to rewrite your dockerfile explicity was should be install to get it work on ubuntu:20.04. I fixed the FROM image to avoid the same kind of issue later.

I hope it helps.
Thank you

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #1662, [glancesautoinstall#39]
