### PR TITLE
Fixed formatting on FS example

### DIFF
--- a/docs/aoa/fs.rst
+++ b/docs/aoa/fs.rst
@@ -40,8 +40,9 @@ Also, you can hide mount points as well (in the following ``/boot``):
 
 .. code-block:: ini
 
-[fs]
-hide=/boot.*
+    [fs]
+    hide=/boot.*
+
 Filtering can also be done on device name (Glances 3.1.4 or higher):
 
 .. code-block:: ini


### PR DESCRIPTION
#### Description
This should fix some formatting issues on the FileSystem documentation page:
<img width="729" alt="image" src="https://user-images.githubusercontent.com/13683094/83972800-86734d00-a8e2-11ea-8a6a-4086527de33d.png">
#### Resume

* Bug fix: yes
* New feature:no
* Fixed tickets: /
