### PR TITLE
Reflect "used percent" user disk space for [fs] alert

### DIFF
--- a/docs/aoa/actions.rst
+++ b/docs/aoa/actions.rst
@@ -25,10 +25,40 @@ reached:
     [fs]
     warning=70
     warning_action=echo {{mnt_point}} {{used}}/{{size}} > /tmp/fs.alert
+    
+A last example would be to create a log file
+containing the total user disk space usage for a device and notify by email each time a space trigger critical is
+reached:
+    
+.. code-block:: ini
+
+    [fs]
+    critical=90
+    critical_action_repeat=echo {{device_name}} {{percent}} > /tmp/fs.alert && python /etc/glances/actions.d/fs-critical.py
+    
+Within ``/etc/glances/actions.d/fs-critical.py``:
+
+.. code-block:: python
+
+    import subprocess
+    from requests import get
+
+    fs_alert = open('/tmp/fs.alert', 'r').readline().strip().split(' ')
+    device = fs_alert[0]
+    percent = fs_alert[1]
+    system = subprocess.check_output(['uname', '-rn']).decode('utf-8').strip()
+    ip = get('https://api.ipify.org').text
+
+    body = 'Used user disk space for ' + device + ' is at ' + percent + '%.\nPlease cleanup the filesystem to clear the alert.\nServer: ' + str(system)+ '.\nIP address: ' + ip
+    ps = subprocess.Popen(('echo', '-e', body), stdout=subprocess.PIPE)
+    subprocess.call(['mail', '-s', 'CRITICAL: disk usage above 90%', '-r', 'postmaster@example.com', 'glances@example.com'], stdin=ps.stdout)
+
+
+
 
 .. note::
     You can use all the stats for the current plugin. See
-    https://github.com/nicolargo/glances/wiki/The-Glances-2.x-API-How-to
+    https://github.com/nicolargo/glances/wiki/The-Glances-RESTFULL-JSON-API
     for the stats list.
 
 It is also possible to repeat action until the end of the alert.

--- a/docs/aoa/actions.rst
+++ b/docs/aoa/actions.rst
@@ -16,7 +16,9 @@ then add the ``_action`` line to the Glances configuration file:
     critical_action=python /path/to/foo.py
 
 All the stats are available in the command line through the use of the
-`{{mustache}}`_ syntax. Another example would be to create a log file
+`{{mustache}}`_ syntax. `Pystache`_ is required to render the mustache's template syntax.
+
+Another example would be to create a log file
 containing used vs total disk space if a space trigger warning is
 reached:
 
@@ -72,3 +74,4 @@ use with caution:
     critical_action_repeat=/home/myhome/bin/bipper.sh
 
 .. _{{mustache}}: https://mustache.github.io/
+.. _Pystache: https://github.com/defunkt/pystache

--- a/docs/aoa/fs.rst
+++ b/docs/aoa/fs.rst
@@ -8,18 +8,18 @@ File System
 Glances displays the used and total file system disk space. The unit is
 adapted dynamically.
 
-Alerts are set for used disk space.
+Alerts are set for `user disk space usage <https://psutil.readthedocs.io/en/latest/index.html?highlight=disk%20usage#psutil.disk_usage>`_.
 
 Legend:
 
-=========== ============
-Disk usage  Status
-=========== ============
-``<50%``    ``OK``
-``>50%``    ``CAREFUL``
-``>70%``    ``WARNING``
-``>90%``    ``CRITICAL``
-=========== ============
+===================== ============
+User disk space usage Status
+===================== ============
+``<50%``              ``OK``
+``>50%``              ``CAREFUL``
+``>70%``              ``WARNING``
+``>90%``              ``CRITICAL``
+===================== ============
 
 .. note::
     Limit values can be overwritten in the configuration file under

--- a/glances/plugins/glances_fs.py
+++ b/glances/plugins/glances_fs.py
@@ -199,7 +199,7 @@ class Plugin(GlancesPlugin):
         # Alert
         for i in self.stats:
             self.views[i[self.get_key()]]['used']['decoration'] = self.get_alert(
-                i['used'], maximum=i['size'], header=i['mnt_point'])
+                current=i['size'] - i['free'], maximum=i['size'], header=i['mnt_point'])
 
     def msg_curse(self, args=None, max_width=None):
         """Return the dict to display in the curse interface."""


### PR DESCRIPTION
`psutill` [says the following](https://github.com/giampaolo/psutil/blob/master/psutil/_psposix.py):

>  Note: UNIX usually reserves 5% disk space which is not accessible
    by user. In this function "total" and "used" values reflect the
    total and used disk space whereas "free" and "percent" represent
    the "free" and "used percent" user disk space.

This commit fixed the alert value that has been notified in this issue https://github.com/nicolargo/glances/issues/1658.
The issue https://github.com/nicolargo/glances/issues/644 has fixed it one way, this PR is completing the fix for the alert feature of the `fs` plugin.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: https://github.com/nicolargo/glances/issues/644, https://github.com/nicolargo/glances/issues/1658

- [x] Fix bug to reflect user disk space usage
- [x] Fix fs doc
- [x] Fix actions doc