### PR TITLE
Fix grammar in sensors documentation

### DIFF
--- a/docs/aoa/sensors.rst
+++ b/docs/aoa/sensors.rst
@@ -7,7 +7,7 @@ Sensors
 
 .. image:: ../_static/sensors.png
 
-Glances can displays the sensors information using ``psutil`` and/or
+Glances can display the sensors information using ``psutil`` and/or
 ``hddtemp``.
 
 There is no alert on this information.


### PR DESCRIPTION
#### Description

Fix grammar:
Glances can display**s** the sensors information using ``psutil`` and/or
Glances can display the sensors information using ``psutil`` and/or

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
