### PR TITLE
Add RSS metric for containers

### DIFF
--- a/glances/outputs/static/js/components/plugin-docker/controller.js
+++ b/glances/outputs/static/js/components/plugin-docker/controller.js
@@ -19,6 +19,7 @@ export default function GlancesPluginDockerController($scope, GlancesStats) {
                 'status': containerData.Status,
                 'cpu': containerData.cpu.total,
                 'memory': containerData.memory.usage != undefined ? containerData.memory.usage : '?',
+                'rss': containerData.memory.rss != undefined ? containerData.memory.usage: '?',
                 'ior': containerData.io.ior != undefined ? containerData.io.ior : '?',
                 'iow': containerData.io.iow != undefined ? containerData.io.iow : '?',
                 'io_time_since_update': containerData.io.time_since_update,

--- a/glances/outputs/static/js/components/plugin-docker/view.html
+++ b/glances/outputs/static/js/components/plugin-docker/view.html
@@ -7,6 +7,7 @@
             <div class="table-cell">Status</div>
             <div class="table-cell">CPU%</div>
             <div class="table-cell">MEM</div>
+            <div class="table-cell">RSS</div>
             <div class="table-cell">IOR/s</div>
             <div class="table-cell">IOW/s</div>
             <div class="table-cell">RX/s</div>
@@ -19,6 +20,7 @@
             </div>
             <div class="table-cell">{{ container.cpu | number:1 }}</div>
             <div class="table-cell">{{ container.memory | bytes }}</div>
+            <div class="table-cell">{{ container.rss | bytes }}</div>
             <div class="table-cell">{{ container.ior / container.io_time_since_update | bits }}</div>
             <div class="table-cell">{{ container.iow / container.io_time_since_update | bits }}</div>
             <div class="table-cell">{{ container.rx / container.net_time_since_update | bits }}</div>

--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -319,9 +319,8 @@ class Plugin(GlancesPlugin):
         ret = {}
         # Read the stats
         try:
-            # Do not exist anymore with Docker 1.11 (issue #848)
-            # ret['rss'] = all_stats['memory_stats']['stats']['rss']
-            # ret['cache'] = all_stats['memory_stats']['stats']['cache']
+            ret['rss'] = all_stats['memory_stats']['stats']['rss']
+            ret['cache'] = all_stats['memory_stats']['stats']['cache']
             ret['usage'] = all_stats['memory_stats']['usage']
             ret['limit'] = all_stats['memory_stats']['limit']
             ret['max_usage'] = all_stats['memory_stats']['max_usage']


### PR DESCRIPTION
#### Description

Add `rss` and `cache` memory stats for containers.

Docker plugin now returns `rss` and `cache` stats for containers. These were commented out due to them not being present in Docker 1.11 (maybe due to a bug in Docker?) See https://github.com/nicolargo/glances/issues/848. Since these stats are available in newer versions of Docker I thought it'd be nice to bring them back.

I've also added an additional column for `rss` in the web UI for containers.

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: Enhacement https://github.com/nicolargo/glances/issues/1694
