### PR TITLE
(ci): Add linux/arm/v6 docker platform

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         id: prepare
         env:
           DOCKER_IMAGE: ${{ secrets.DOCKER_IMAGE }}
-          DOCKER_PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/386
+          DOCKER_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
         run: |
           VERSION=latest
           

--- a/README.rst
+++ b/README.rst
@@ -187,9 +187,9 @@ Get the Glances container (latest develop branch):
 
 Note, you can choose another branch with :
 
-- nicolargo/glances:latest for the last master branch (included multiple architectures 386, amd64, arm/v7 and arm64)
-- nicolargo/glances:dev for the last develop branch (included multiple architectures 386, amd64, arm/v7 and arm64)
-- nicolargo/glances:<version> for the specific <version> (included multiple architectures 386, amd64, arm/v7 and arm64)
+- nicolargo/glances:latest for the last master branch (included multiple architectures 386, amd64, arm/v6, arm/v7 and arm64)
+- nicolargo/glances:dev for the last develop branch (included multiple architectures 386, amd64, arm/v6, arm/v7 and arm64)
+- nicolargo/glances:<version> for the specific <version> (included multiple architectures 386, amd64, arm/v6, arm/v7 and arm64)
 
 Run the container in *console mode*:
 


### PR DESCRIPTION
#### Description

Add linux/arm/v6 docker platform for RPI0 support.

I tested this on a rpi0w. Only using the api is completely fine. Using the web ui leads to 30-50% CPU load.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: no
