### PR TITLE
docs: fix simple typo, optionnal -> optional

### DIFF
--- a/glances/static_list.py
+++ b/glances/static_list.py
@@ -54,7 +54,7 @@ class GlancesStaticServer(object):
                 for s in ['name', 'port', 'alias']:
                     new_server[s] = config.get_value(self._section, '%s%s' % (postfix, s))
                 if new_server['name'] is not None:
-                    # Manage optionnal information
+                    # Manage optional information
                     if new_server['port'] is None:
                         new_server['port'] = '61209'
                     new_server['username'] = 'glances'


### PR DESCRIPTION
There is a small typo in glances/static_list.py.

Should read `optional` rather than `optionnal`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md