### PR TITLE
Documentation to password protect Dockerized Glances

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -115,13 +115,20 @@ You will then need to copy the password file to your host machine:
 and make it visible to your container by adding it to ``docker-compose.yml`` as a ``secret``:
 
 .. code-block:: yaml
+    version: '3'
+    
     services:
       glances:
         image: nicolargo/glances:latest
+        restart: always
+        environment:
+          - GLANCES_OPT="-w --password"
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock:ro
+        pid: host
         secrets:
           - source: glances_password
             target: /root/.config/glances/glances.pwd
-            mode: '0440'
     
     secrets:
       glances_password:

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -97,6 +97,7 @@ and generate the password file (the default login is ``glances``, add the ``--us
 which will prompt you to answer the following questions:
 
 .. code-block:: console
+
     Define the Glances server password (glances username): 
     Password (confirm): 
     Do you want to save the password? [Yes/No]: Yes
@@ -104,17 +105,20 @@ which will prompt you to answer the following questions:
 after which you will need to kill the process by entering ``CTRL+C`` (potentially twice), before leaving the container:
 
 .. code-block:: console
+
     ^C^C
     exit
 
 You will then need to copy the password file to your host machine:
 
 .. code-block:: console
+
     docker cp glances_docker:/root/.config/glances/glances.pwd ./secrets/glances_password
 
 and make it visible to your container by adding it to ``docker-compose.yml`` as a ``secret``:
 
 .. code-block:: yaml
+
     version: '3'
     
     services:


### PR DESCRIPTION
#### Description

Adds clear instructions about enabling password protection when Glances is running inside a Docker container to the ReadTheDocs documentation.

Previous PRs from `patch-1` (#1777 and #1778 ) should be disregarded, this has been rebased on `develop`, whereas they were targeting `master`.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: #1674
