### PR TITLE
Add option to set the strftime format

### DIFF
--- a/glances/config.py
+++ b/glances/config.py
@@ -107,7 +107,7 @@ class Config(object):
         # Re patern for optimize research of `foo`
         self.re_pattern = re.compile(r'(\`.+?\`)')
 
-        self.parser = ConfigParser()
+        self.parser = ConfigParser(interpolation=None)
         self.read()
 
     def config_file_paths(self):
@@ -223,6 +223,11 @@ class Config(object):
             self.parser.add_section('processlist')
         self.set_default_cwc('processlist', 'cpu')
         self.set_default_cwc('processlist', 'mem')
+
+        # Now
+        if not self.parser.has_section('strftime'):
+            self.parser.add_section('strftime')
+        self.set_default('strftime', 'format', '')
 
     @property
     def loaded_config_file(self):

--- a/glances/config.py
+++ b/glances/config.py
@@ -153,6 +153,16 @@ class Config(object):
                 self._loaded_config_file = config_file
                 break
 
+        # Globals
+        if not self.parser.has_section('global'):
+            self.parser.add_section('global')
+        self.set_default('global', 'strftime_format', '')
+
+        # check_update
+        if not self.parser.has_section('global'):
+            self.parser.add_section('global')
+        self.set_default('global', 'check_update', 'false')
+
         # Quicklook
         if not self.parser.has_section('quicklook'):
             self.parser.add_section('quicklook')
@@ -223,11 +233,6 @@ class Config(object):
             self.parser.add_section('processlist')
         self.set_default_cwc('processlist', 'cpu')
         self.set_default_cwc('processlist', 'mem')
-
-        # Now
-        if not self.parser.has_section('strftime'):
-            self.parser.add_section('strftime')
-        self.set_default('strftime', 'format', '')
 
     @property
     def loaded_config_file(self):

--- a/glances/main.py
+++ b/glances/main.py
@@ -254,6 +254,9 @@ Examples of use:
         # Globals options
         parser.add_argument('--disable-check-update', action='store_true', default=False,
                             dest='disable_check_update', help='disable online Glances version ckeck')
+        parser.add_argument('--strftime', dest='strftime_format', default='',
+                            help='strftime format string for displaying current date in standalone mode')
+
         return parser
 
     def parse_args(self):

--- a/glances/plugins/glances_now.py
+++ b/glances/plugins/glances_now.py
@@ -41,9 +41,11 @@ class Plugin(GlancesPlugin):
         # Set the message position
         self.align = 'bottom'
 
-        if config is not None:
-            if 'strftime' in config.as_dict():
-                self.strftime = config.as_dict()['strftime']['format']
+        if args.strftime_format:
+            self.strftime = args.strftime_format
+        elif config is not None:
+            if 'global' in config.as_dict():
+                self.strftime = config.as_dict()['global']['strftime_format']
 
     def reset(self):
         """Reset/init the stats."""

--- a/glances/plugins/glances_now.py
+++ b/glances/plugins/glances_now.py
@@ -41,6 +41,10 @@ class Plugin(GlancesPlugin):
         # Set the message position
         self.align = 'bottom'
 
+        if config is not None:
+            if 'strftime' in config.as_dict():
+                self.strftime = config.as_dict()['strftime']['format']
+
     def reset(self):
         """Reset/init the stats."""
         self.stats = ''
@@ -49,10 +53,14 @@ class Plugin(GlancesPlugin):
         """Update current date/time."""
         # Had to convert it to string because datetime is not JSON serializable
         # Add the time zone (issue #1249 / #1337 / #1598)
-        if (len(tzname[1]) > 6):
-            self.stats = strftime('%Y-%m-%d %H:%M:%S %z')
+
+        if self.strftime:
+            self.stats = strftime(self.strftime)
         else:
-            self.stats = strftime('%Y-%m-%d %H:%M:%S %Z')
+            if (len(tzname[1]) > 6):
+                self.stats = strftime('%Y-%m-%d %H:%M:%S %z')
+            else:
+                self.stats = strftime('%Y-%m-%d %H:%M:%S %Z')
 
         return self.stats
 


### PR DESCRIPTION
Add an option in the .conf and commandline to change the strftime format.

Set `ConfigParser(interpolation=None)` because otherwise you have to write `%%Y%%M` and so on. I don't think interpolation is used anywhere?

Also set the `[global]` config option `check_updates` to false by default. Since `[global]` exists, because `strftime_format` is set under it, **outdated.py** complains about `check_update` not being set otherwise.

Thoughts?