### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -239,7 +239,7 @@ To install the binary package:
 
 .. code-block:: console
 
-    # pkg install py27-glances
+    # pkg install py37-glances
 
 To install Glances from ports:
 


### PR DESCRIPTION
Documentation: Change package install command for FreeBSD

Python-2.7 is EOL and no longer supported in FreeBSD - the new default version is Python-3.7 and the package name has to be adjusted to refer to that Python version.