### PR TITLE
Fix missing docker image name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: ${{ env.PUSH_BRANCH == 'true' }}
-          tags: "${{ matrix.os != 'debian' && format('{0}-', matrix.os) || '' }}${{ matrix.tag.tag }}"
+          tags: "${{ env.DEFAULT_DOCKER_IMAGE }}:${{ matrix.os != 'debian' && format('{0}-', matrix.os) || '' }}${{ matrix.tag.tag }}"
           build-args: |
             CHANGING_ARG=${{ github.sha }}
           context: .


### PR DESCRIPTION
#### Description

Fixes the failing docker build.

I forgot the `nicolargo/glances` prefix in my previous MR, so docker tried to push to `dev`.
Which is obviously not allowed.

#### Resume

Now the images have the image name `nicolargo/glances`.

* Bug fix: yes
* New feature: no
