### PR TITLE
Fix history_add, so it allows history_max_size to be zero

### DIFF
--- a/glances/attribute.py
+++ b/glances/attribute.py
@@ -21,7 +21,6 @@
 
 from datetime import datetime
 
-
 class GlancesAttribute(object):
 
     def __init__(self, name, description='', history_max_size=None):
@@ -105,10 +104,10 @@ class GlancesAttribute(object):
     def history_add(self, value):
         """Add a value in the history
         """
-        if not (self._history_max_size is None or self.history_len() < self._history_max_size):
-            #self._history = self._history[1:] + [value]
-            self._history.pop(0)
-        self._history.append(value)
+        if self._history_max_size:
+            if self.history_len() >= self._history_max_size:
+                self._history.pop(0)
+            self._history.append(value)
 
     def history_size(self):
         """Return the history size (maximum nuber of value in the history)


### PR DESCRIPTION
#### Description
Prevents pop from an empty list when history_max_size is zero.
The error was introduced in bd6e682a .

#### Resume
* Bug fix

#### Error fixed
Setting
```
history_size=0
```
in `glances.conf` caused
```
  File "/Users/Shared/src/scm/os/glances/glances/attribute.py", line 85, in value
    self.history_add(self._value)
  File "/Users/Shared/src/scm/os/glances/glances/attribute.py", line 110, in history_add
    self._history.pop(0)
IndexError: pop from empty list
```