### PR TITLE
Allow using maximum current frequency instead of average current frequency

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -44,6 +44,9 @@ swap_careful=50
 swap_warning=70
 swap_critical=90
 
+# Use the current maximum core frequency as the current frequency instead of an average of all current core frequencies 
+# cpu_max=False
+
 [system]
 # This plugin display the first line in the Glances UI with:
 # Hostname / Operating system name / Architecture information

--- a/glances/cpu_percent.py
+++ b/glances/cpu_percent.py
@@ -61,7 +61,7 @@ class CpuPercent(object):
             return self.__get_cpu()
 
     def get_info(self):
-        """Get additional informations about the CPU"""
+        """Get additional informations about the CPU, using the average frequency of all cores as the current frequency"""
         # Never update more than 1 time per cached_timer_cpu_info
         if self.timer_cpu_info.finished() and hasattr(psutil, 'cpu_freq'):
             # Get the CPU freq current/max
@@ -72,6 +72,28 @@ class CpuPercent(object):
                 self.cpu_info['cpu_hz_current'] = None
             if hasattr(cpu_freq, 'max'):
                 self.cpu_info['cpu_hz'] = cpu_freq.max
+            else:
+                self.cpu_info['cpu_hz'] = None
+            # Reset timer for cache
+            self.timer_cpu_info.reset(duration=self.cached_timer_cpu_info)
+        return self.cpu_info
+
+    def get_info_max(self):
+        """Get additional informations about the CPU, using the current highest core frequency as the current frequency"""
+        # Never update more than 1 time per cached_timer_cpu_info
+        if self.timer_cpu_info.finished() and hasattr(psutil, 'cpu_freq'):
+            # Get the CPU freq current/max
+            cpu_freq = psutil.cpu_freq(percpu=True)
+            if hasattr(cpu_freq[0], 'current'):
+                cpu_freq_cur = 0
+                for c in cpu_freq:
+                    if cpu_freq_cur < c.current:
+                        cpu_freq_cur = c.current
+                self.cpu_info['cpu_hz_current'] = cpu_freq_cur
+            else:
+                self.cpu_info['cpu_hz_current'] = None
+            if hasattr(cpu_freq[0], 'max'):
+                self.cpu_info['cpu_hz'] = cpu_freq[0].max
             else:
                 self.cpu_info['cpu_hz'] = None
             # Reset timer for cache

--- a/glances/plugins/glances_quicklook.py
+++ b/glances/plugins/glances_quicklook.py
@@ -57,6 +57,7 @@ class Plugin(GlancesPlugin):
                                      items_history_list=items_history_list)
         # We want to display the stat in the curse interface
         self.display_curse = True
+        self.config = config
 
     @GlancesPlugin._check_decorator
     @GlancesPlugin._log_result_decorator
@@ -80,7 +81,11 @@ class Plugin(GlancesPlugin):
                 stats['swap'] = None
 
             # Get additional information
-            cpu_info = cpu_percent.get_info()
+            if self.config.get_bool_value(self.plugin_name, 'cpu_max', default=False) == True:
+                cpu_info = cpu_percent.get_info_max()
+            else:
+                cpu_info = cpu_percent.get_info()
+
             stats['cpu_name'] = cpu_info['cpu_name']
             stats['cpu_hz_current'] = self._mhz_to_hz(cpu_info['cpu_hz_current']) if cpu_info['cpu_hz_current'] is not None else None
             stats['cpu_hz'] = self._mhz_to_hz(cpu_info['cpu_hz']) if cpu_info['cpu_hz'] is not None else None


### PR DESCRIPTION
#### Description

Allow users to use the maximum current frequency of their CPU, as opposed to an average of all current CPU freqencies

Some users may find it more useful to see what frequencies their CPU is clocking up to. For example, some CPU's turbo much higher on a single core when running single core workloads.

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: None
