### PR TITLE
Fix python lib path in alpine images

### DIFF
--- a/docker-files/debian.Dockerfile
+++ b/docker-files/debian.Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=remoteInstall /root/.local/bin /usr/local/bin/
-COPY --from=remoteInstall /root/.local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages/
+COPY --from=remoteInstall /root/.local/lib/python3.9/site-packages /usr/lib/python3.9/site-packages/
 
 # EXPOSE PORT (XMLRPC / WebUI)
 EXPOSE 61209 61208
@@ -72,4 +72,4 @@ CMD python3 -m glances -C /glances/conf/glances.conf $GLANCES_OPT
 
 FROM minimal as full
 
-COPY --from=additional-packages /root/.local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages/
+COPY --from=additional-packages /root/.local/lib/python3.9/site-packages /usr/lib/python3.9/site-packages/


### PR DESCRIPTION
#### Description

When using the latest alpine-full image the pre-packed python dependencies are in the wrong folder. This MR moves them to the correct one.

As a hotfix until the next version the images can be started with:

```bash
 docker run -it nicolargo/glances:alpine-3.2.1-full bash -c 'cp -r /usr/local/python3.8/site-packages/* /usr/lib/python3.8/site-packages/ && glances -C /glances/conf/glances.conf <your glances options>'
```

or when used in a docker-compose:
```yaml
command: bash -c 'cp -r /usr/local/python3.8/site-packages/* /usr/lib/python3.8/site-packages/ && glances -C /glances/conf/glances.conf <your glances options>'
```

#### Resume

* Bug fix: yes
* New feature: no
