### PR TITLE
Update Debian image to include `smartmontools`

### DIFF
--- a/docker-files/debian.Dockerfile
+++ b/docker-files/debian.Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
   build-essential \
   lm-sensors \
   wireless-tools \
+  smartmontools \
   iputils-ping && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 
@@ -57,6 +58,7 @@ RUN apt-get update && \
   curl              \
   lm-sensors        \
   wireless-tools    \
+  smartmontools     \
   iputils-ping && \
   apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
#### Description
This adds the `smartmontools` package to the Debian based Docker image.

This package provides the `smartctl` binary which the `pySMART.smartx` package
requires.

Without this change, in the Docker container, with `--device=/dev/sda:/dev/sda` passed to `docker run`
```
# python3
Python 3.9.6 (default, Aug 17 2021, 02:38:04) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pySMART import DeviceList
>>> DeviceList()
<DeviceList contents:
>
```

With this change:
```
# python3
Python 3.9.6 (default, Aug 17 2021, 02:38:04) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pySMART import DeviceList
KeyboardInterrupt
>>> from pySMART import DeviceList
>>> DeviceList()
<DeviceList contents:
<SCSI device on /dev/sda mod:None sn:AB202000000000001398>
>
```

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #1926
