### PR TITLE
Fix: Docker plugin - Invalid IO stats with Arch Linux

### DIFF
--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -488,12 +488,15 @@ class Plugin(GlancesPlugin):
             # XML/RPC API, which would otherwise be overly difficult work
             # for users of the API
             try:
+                new_io_service_bytes_recursive = iocounters['io_service_bytes_recursive']
+                old_io_service_bytes_recursive = self.iocounters_old[container_id]['io_service_bytes_recursive']
+
                 # Read IOR and IOW value in the structure list of dict
-                ior = [i for i in iocounters['io_service_bytes_recursive'] if i['op'] == 'Read'][0]['value']
-                iow = [i for i in iocounters['io_service_bytes_recursive'] if i['op'] == 'Write'][0]['value']
-                ior_old = [i for i in self.iocounters_old[container_id]['io_service_bytes_recursive'] if i['op'] == 'Read'][0]['value']
-                iow_old = [i for i in self.iocounters_old[container_id]['io_service_bytes_recursive'] if i['op'] == 'Write'][0]['value']
-            except (TypeError, IndexError, KeyError) as e:
+                ior = [i for i in new_io_service_bytes_recursive if i['op'].lower() == 'read'][0]['value']
+                iow = [i for i in new_io_service_bytes_recursive if i['op'].lower() == 'write'][0]['value']
+                ior_old = [i for i in old_io_service_bytes_recursive if i['op'].lower() == 'read'][0]['value']
+                iow_old = [i for i in old_io_service_bytes_recursive if i['op'].lower() == 'write'][0]['value']
+            except (TypeError, IndexError, KeyError, AttributeError) as e:
                 # all_stats do not have io information
                 logger.debug("docker plugin - Cannot grab block IO usage for container {} ({})".format(container_id, e))
             else:


### PR DESCRIPTION
#### Description
The IO stats for the containers on Arch Linux fail to be displayed. Reason being a small difference in responses. This PR aims to handle that.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #1918 (maybe, not sure)

#### Details
Assuming Ubuntu to be the standard as the stats are displays properly on it. The difference lies in the values for `blkio_stats.io_service_bytes_recursive` of the response for the Docker's container [stats API](https://docs.docker.com/engine/api/v1.41/#operation/ContainerStats). The API's example doesn't seem to document any response with the concerned field, so I ended up checking the responses. I logged the responses with a small script:
```python
import docker
client = docker.from_env()
containers = client.containers.list()
cont = containers[0]
for stats in cont.stats(decode=True):
    print(stats["blkio_stats"]['io_service_bytes_recursive'])
```

**Ubuntu:**
Version: `Docker version 20.10.7, build 20.10.7-0ubuntu5~20.04.1`
```
[{'major': 252, 'minor': 0, 'op': 'Read', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Write', 'value': 253952}, {'major': 252, 'minor': 0, 'op': 'Sync', 'value': 249856}, {'major': 252, 'minor': 0, 'op': 'Async', 'value': 4096}, {'major': 252, 'minor': 0, 'op': 'Discard', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Total', 'value': 253952}]
[{'major': 252, 'minor': 0, 'op': 'Read', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Write', 'value': 253952}, {'major': 252, 'minor': 0, 'op': 'Sync', 'value': 249856}, {'major': 252, 'minor': 0, 'op': 'Async', 'value': 4096}, {'major': 252, 'minor': 0, 'op': 'Discard', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Total', 'value': 253952}]
[{'major': 252, 'minor': 0, 'op': 'Read', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Write', 'value': 253952}, {'major': 252, 'minor': 0, 'op': 'Sync', 'value': 249856}, {'major': 252, 'minor': 0, 'op': 'Async', 'value': 4096}, {'major': 252, 'minor': 0, 'op': 'Discard', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Total', 'value': 253952}]
[{'major': 252, 'minor': 0, 'op': 'Read', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Write', 'value': 253952}, {'major': 252, 'minor': 0, 'op': 'Sync', 'value': 249856}, {'major': 252, 'minor': 0, 'op': 'Async', 'value': 4096}, {'major': 252, 'minor': 0, 'op': 'Discard', 'value': 0}, {'major': 252, 'minor': 0, 'op': 'Total', 'value': 253952}]
```

**Arch Linux:**
Version: `Docker version 20.10.10, build b485636f4b`
```
[{'major': 259, 'minor': 0, 'op': 'read', 'value': 107044864}, {'major': 259, 'minor': 0, 'op': 'write', 'value': 2048000}]
[{'major': 259, 'minor': 0, 'op': 'read', 'value': 107044864}, {'major': 259, 'minor': 0, 'op': 'write', 'value': 2048000}]
[{'major': 259, 'minor': 0, 'op': 'read', 'value': 107044864}, {'major': 259, 'minor': 0, 'op': 'write', 'value': 2048000}]
[{'major': 259, 'minor': 0, 'op': 'read', 'value': 107044864}, {'major': 259, 'minor': 0, 'op': 'write', 'value': 2048000}]
```
Now look at the values for `op`. The response from Arch Linux's daemon is `read`/`write` while Ubuntu gives `Read`/`Write`
That difference causes the failure. I am not sure if other OSes follow this behavior.

The PR just converts the `op` field to lowercase text before the comparison. That should fix the issue without breaking anything.