### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
 

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ Glances - An eye on your system
     :target: https://pepy.tech/project/glances
     :alt: Pypi downloads
 
-.. image:: https://img.shields.io/travis/nicolargo/glances/master.svg?maxAge=3600&label=Linux%20/%20BSD%20/%20macOS
-    :target: https://travis-ci.org/nicolargo/glances
-    :alt: Linux tests (Travis)
+.. image:: https://github.com/nicolargo/glances/actions/workflows/test.yml/badge.svg
+    :target: https://github.com/nicolargo/glances/actions
+    :alt: Linux tests (GitHub Actions)
 
 .. image:: https://img.shields.io/appveyor/ci/nicolargo/glances/master.svg?maxAge=3600&label=Windows
     :target: https://ci.appveyor.com/project/nicolargo/glances

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: System :: Monitoring'
     ]
 )


### PR DESCRIPTION
#### Description

Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

In the README, let's also replace the Travis CI badge with one for GitHub Actions. 

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: none
