### PR TITLE
Added missing options to help menu

### DIFF
--- a/glances/plugins/glances_help.py
+++ b/glances/plugins/glances_help.py
@@ -89,7 +89,7 @@ class Plugin(GlancesPlugin):
         self.view_data['show_hide_left_sidebar'] = msg_col.format('2', 'Show/hide left sidebar')
         self.view_data['reset_history'] = msg_col2.format('r', 'Reset history')
         self.view_data['enable_disable_process_stats'] = msg_col.format('z', 'Enable/disable processes stats')
-        self.view_data['quit'] = msg_col2.format('q', 'Quit (Esc and Ctrl-C also work)')
+        self.view_data['quit'] = msg_col.format('q', 'Quit (Esc and Ctrl-C also work)')
         self.view_data['enable_disable_top_extends_stats'] = msg_col.format('e', 'Enable/disable top extended stats')
         self.view_data['enable_disable_short_processname'] = msg_col.format('/', 'Enable/disable short processes name')
         self.view_data['enable_disable_irix'] = msg_col.format('0', 'Enable/disable Irix process CPU')
@@ -101,6 +101,16 @@ class Plugin(GlancesPlugin):
         self.view_data['enable_disable_gpu'] = msg_col.format('G', 'Enable/disable gpu plugin')
         self.view_data['enable_disable_mean_gpu'] = msg_col2.format('6', 'Enable/disable mean gpu')
         self.view_data['edit_pattern_filter'] = 'ENTER: Edit the process filter pattern'
+        self.view_data['enable_disable_application_monitor_process'] = msg_col2.format('A','Enable/disable application monitoring process' )
+        self.view_data['erase_current_process_filter'] = msg_col.format('E', 'Erase current process filter')
+        self.view_data['show_hide_tcp_connection'] = msg_col.format('K', 'Show/hide TCP connections')
+        self.view_data['kill_process'] = msg_col2.format('k', 'Kill process')
+        self.view_data['reset_process_summary_min_max'] = msg_col.format('M', 'Reset processes summary min/max')
+        self.view_data['show_hide_current_time'] = msg_col2.format('N', 'Show/hide current time')
+        self.view_data['show_hide_raid_plugin'] = msg_col.format('R', 'Show/hide RAID plugin')
+        self.view_data['show_hide_wifi_module'] = msg_col2.format('W', 'Show/hide Wifi module')
+        self.view_data['enable_disable_all_but_quick_look_and_load_module'] = msg_col2.format('4', 'Enable/disable all but quick look and load module')
+
 
     def get_view_data(self, args=None):
         """Return the view."""
@@ -178,9 +188,23 @@ class Plugin(GlancesPlugin):
         ret.append(self.curse_add_line(self.view_data['enable_disable_mean_gpu']))
         ret.append(self.curse_new_line())
         ret.append(self.curse_add_line(self.view_data['enable_disable_irix']))
-        ret.append(self.curse_add_line(self.view_data['quit']))
+        ret.append(self.curse_add_line(self.view_data['show_hide_wifi_module']))
         ret.append(self.curse_new_line())
-
+        ret.append(self.curse_add_line(self.view_data['erase_current_process_filter']))
+        ret.append(self.curse_add_line(self.view_data['enable_disable_application_monitor_process']))
+        ret.append(self.curse_new_line())
+        ret.append(self.curse_add_line(self.view_data['show_hide_tcp_connection']))
+        ret.append(self.curse_add_line(self.view_data['kill_process']))
+        ret.append(self.curse_new_line())
+        ret.append(self.curse_add_line(self.view_data['reset_process_summary_min_max']))
+        ret.append(self.curse_add_line(self.view_data['show_hide_current_time']))
+        ret.append(self.curse_new_line())
+        ret.append(self.curse_add_line(self.view_data['show_hide_raid_plugin']))
+        ret.append(self.curse_add_line(self.view_data['enable_disable_all_but_quick_look_and_load_module']))
+        ret.append(self.curse_new_line())
+        ret.append(self.curse_add_line(self.view_data['quit']))
+        
+        ret.append(self.curse_new_line())
         ret.append(self.curse_new_line())
 
         ret.append(self.curse_add_line(self.view_data['edit_pattern_filter']))


### PR DESCRIPTION
#### Description

The missing options in the help menu have been added.

A - Enable/disable Application Monitoring Process
E - Erase current process filter
K - Show/hide TCP connections
k - Kill process
M - Reset processes summary min/max
N - Show/hide current time
R - Show/hide RAID plugin
W - Show/hide Wifi module
4 - Enable/disable all but quick look and load module

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: fixes #1973
