### PR TITLE
Use is_set instead of isSet for Python 3.10 compatibility.

### DIFF
--- a/glances/plugins/glances_cloud.py
+++ b/glances/plugins/glances_cloud.py
@@ -189,4 +189,4 @@ class ThreadOpenStack(threading.Thread):
 
     def stopped(self):
         """Return True is the thread is stopped."""
-        return self._stopper.isSet()
+        return self._stopper.is_set()

--- a/glances/plugins/glances_docker.py
+++ b/glances/plugins/glances_docker.py
@@ -723,7 +723,7 @@ class ThreadDockerGrabber(threading.Thread):
 
     def stopped(self):
         """Return True is the thread is stopped."""
-        return self._stopper.isSet()
+        return self._stopper.is_set()
 
 
 def sort_stats(stats):

--- a/glances/plugins/glances_ports.py
+++ b/glances/plugins/glances_ports.py
@@ -256,7 +256,7 @@ class ThreadScanner(threading.Thread):
 
     def stopped(self):
         """Return True is the thread is stopped."""
-        return self._stopper.isSet()
+        return self._stopper.is_set()
 
     def _web_scan(self, web):
         """Scan the  Web/URL (dict) and update the status key."""


### PR DESCRIPTION
#### Description

Use is_set instead of isSet for Python 3.10 compatibility.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #2017 
