### PR TITLE
Update public ip at intervals

### DIFF
--- a/docs/aoa/header.rst
+++ b/docs/aoa/header.rst
@@ -11,6 +11,17 @@ Additionally, on GNU/Linux, it also shows the kernel version.
 
 In client mode, the server connection status is also displayed.
 
+It is possible to define time interval to be used for refreshing the
+public IP address (default is 300 seconds) from the configuration
+file under the ``[ip]`` section:
+
+.. code-block:: ini
+    [ip]
+    public_refresh_interval=240
+
+**NOTE:** Setting low values will result in frequent HTTP request to
+the IP detection servers. Recommended range: 120-600 seconds
+
 **Connected**:
 
 .. image:: ../_static/connected.png


### PR DESCRIPTION
#### Description

Let the Public IP address get updated every `t` seconds

The time interval can be configured by the config option under `ip` section with `public_refresh_interval`.
Default value is 300 seconds.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: Closes #2028
