### PR TITLE
unitary tests should run loopback interface

### DIFF
--- a/unitest-restful.py
+++ b/unitest-restful.py
@@ -64,7 +64,7 @@ class TestGlances(unittest.TestCase):
         global pid
 
         print('INFO: [TEST_000] Start the Glances Web Server')
-        cmdline = "python -m glances -w -p %s" % SERVER_PORT
+        cmdline = "python -m glances -B localhost -w -p %s" % SERVER_PORT
         print("Run the Glances Web Server on port %s" % SERVER_PORT)
         args = shlex.split(cmdline)
         pid = subprocess.Popen(args)

--- a/unitest-xmlrpc.py
+++ b/unitest-xmlrpc.py
@@ -53,7 +53,7 @@ class TestGlances(unittest.TestCase):
         global pid
 
         print('INFO: [TEST_000] Start the Glances Web Server')
-        cmdline = "python -m glances -s -p %s" % SERVER_PORT
+        cmdline = "python -m glances -B localhost -s -p %s" % SERVER_PORT
         print("Run the Glances Server on port %s" % SERVER_PORT)
         args = shlex.split(cmdline)
         pid = subprocess.Popen(args)


### PR DESCRIPTION
#### Description

RESTful and XML-RPC API unitary tests should run on localhost

When you run the Glances with default binding (0.0.0.0) during the restful/xmlrpc unitary tests, starting the web server might take sometime (appx 5~30sec) depends on the host and testing may fail. I realized this when I was building the rpm package for EPEL8+9 and if you run the Glances with only loopback interface web server starts within a second. Instead of waiting subprocess with time.sleep it's better to run the tests in localhost.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none
