### PR TITLE
Fix reference link to configuration file in AMP

### DIFF
--- a/docs/aoa/amps.rst
+++ b/docs/aoa/amps.rst
@@ -4,7 +4,7 @@ Applications Monitoring Process
 ===============================
 
 Thanks to Glances and its AMP module, you can add specific monitoring to
-running processes. AMPs are defined in the Glances [configuration file](http://glances.readthedocs.io/en/stable/config.html).
+running processes. AMPs are defined in the Glances :ref:`configuration file<config>`.
 
 You can disable AMP using the ``--disable-plugin amps`` option or pressing the
 ``A`` key.


### PR DESCRIPTION
Hi dear devs of this fine monitoring tool,

first of all thank you for this extensive documentation. I'm particularly interested in the monitoring of processes like nginx or guacamole. While reading the [AMP](https://glances.readthedocs.io/en/latest/aoa/amps.html) doc page I've noticed that there is something wrong with your link to the configuration page. This tiny PR fixes the link (by swapping stable with latest).

See reference [cross-sections](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html#use-custom-link-text) for details.

* Bug fix: yes
* New feature: no