### PR TITLE
Add note about `host` for Prometheus exporter in a container

### DIFF
--- a/docs/gw/prometheus.rst
+++ b/docs/gw/prometheus.rst
@@ -15,7 +15,13 @@ listening on <host:port> (define in the Glances configuration file).
     prefix=glances
     labels=src:glances
 
-Note: you can use dynamc fields for the label (ex: labels=system:`uname -s`)
+.. note::
+
+    When running Glances in a container, set ``host=0.0.0.0`` in the Glances configuration file.
+
+.. note::
+
+    You can use dynamic fields for the label (ex: labels=system:`uname -s`)
 
 and run Glances with:
 


### PR DESCRIPTION
#### Description

Add a note to the Prometheus Exporter documentation about using `host=0.0.0.0` in the `glances.conf` file otherwise, it will not work.

#### Resume

* Bug fix: no
* New feature: no
* Resolves #2087 
