### PR TITLE
Update config.rst

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -20,7 +20,7 @@ You can put your own ``glances.conf`` file in the following locations:
 ``Linux``, ``SunOS`` ~/.config/glances/, /etc/glances/, /usr/share/docs/glances/
 ``*BSD``             ~/.config/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
 ``macOS``            ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
-``Windows``          %APPDATA%\\glances\glances.conf
+``Windows``          %APPDATA%\\glances\\glances.conf
 ==================== =============================================================
 
 - On Windows XP, ``%APPDATA%`` is: ``C:\Documents and Settings\<USERNAME>\Application Data``.


### PR DESCRIPTION
(Forgive any mistakes in process. I read the guidelines, but I've never submitted a pull request before.)

An escape backslash was missing from the Windows location for the glances conf, making it appear as glancesglances.conf.

#### Description

To fix a typo in the Windows glances conf location.

For any questions concerning installation or use, please open a discussion (https://github.com/nicolargo/glances/discussions), not an issue.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
