### PR TITLE
fix(sec): upgrade psutil to 5.6.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psutil>=5.3.0
+psutil>=5.6.7
 defusedxml
 packaging
 future; python_version < "3.0"


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in psutil 5.3.0
- [CVE-2019-18874](https://www.oscs1024.com/hd/CVE-2019-18874)


### What did I do？
Upgrade psutil from 5.3.0 to 5.6.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS