### PR TITLE
Consider quotes when splitting command arguments

### DIFF
--- a/glances/secure.py
+++ b/glances/secure.py
@@ -11,6 +11,7 @@
 
 from glances.compat import nativestr
 from subprocess import Popen, PIPE
+import re
 
 
 def secure_popen(cmd):
@@ -48,8 +49,8 @@ def __secure_popen(cmd):
     p_last = None
     # Split by pipe '|'
     for sub_cmd in cmd.split('|'):
-        # Split by space ' '
-        sub_cmd_split = [i for i in sub_cmd.split(' ') if i]
+        # Split by space character, but do no split spaces within quotes
+        sub_cmd_split = [_ for _ in list(filter(None, re.split(r'(\s+)|(".*?"+?)|(\'.*?\'+?)', sub_cmd))) if _ != ' ']
         p = Popen(sub_cmd_split, shell=False, stdin=sub_cmd_stdin, stdout=PIPE, stderr=PIPE)
         if p_last is not None:
             # Allow p_last to receive a SIGPIPE if p exits.


### PR DESCRIPTION
#### Description

I want to execute shell commands in an action. Those commands are currently split by space character for security reasons (to me it's not clear why this required, but there are probably good reasons to do that ;)). As I would like to pass strings of multipel words to my commands, we have to consider quotes in command arguments.

One simple use case is the following action:
```
send_mail.sh "this is my subject" "and this is my alert text"
```

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: 
