### PR TITLE
Remove surrounding quotes for quoted command arguments

### DIFF
--- a/glances/secure.py
+++ b/glances/secure.py
@@ -49,8 +49,9 @@ def __secure_popen(cmd):
     p_last = None
     # Split by pipe '|'
     for sub_cmd in cmd.split('|'):
-        # Split by space character, but do no split spaces within quotes
-        sub_cmd_split = [_ for _ in list(filter(None, re.split(r'(\s+)|(".*?"+?)|(\'.*?\'+?)', sub_cmd))) if _ != ' ']
+        # Split by space character, but do no split spaces within quotes (remove surrounding quotes, though)
+        tmp_split = [_ for _ in list(filter(None, re.split(r'(\s+)|(".*?"+?)|(\'.*?\'+?)', sub_cmd))) if _ != ' ']
+        sub_cmd_split = [_[1:-1] if (_[0]==_[-1]=='"') or (_[0]==_[-1]=='\'') else _ for _ in tmp_split]
         p = Popen(sub_cmd_split, shell=False, stdin=sub_cmd_stdin, stdout=PIPE, stderr=PIPE)
         if p_last is not None:
             # Allow p_last to receive a SIGPIPE if p exits.


### PR DESCRIPTION
#### Description

Extension of https://github.com/nicolargo/glances/pull/2239: For quoted command arguments we have to strip surrounding quotes when creating the subprocess.

I tested the previous PR only outside glances and therefore didn't notice that behavior. Sorry for that!

#### Resume

* Bug fix: yes
* New feature: no
