### PR TITLE
Make filesystem list unique

### DIFF
--- a/glances/plugins/glances_fs.py
+++ b/glances/plugins/glances_fs.py
@@ -185,8 +185,9 @@ class Plugin(GlancesPlugin):
                     else:
                         stats.append(fs_current)
 
-        # Update the stats
-        self.stats = stats
+        # Create unique list filter by "mnt_point" and update the stats
+        seen = set()
+        self.stats = [seen.add(stat['mnt_point']) or stat for stat in stats if stat['mnt_point'] not in seen]
 
         return self.stats
 


### PR DESCRIPTION
#### Description

Remove duplicate entries in the `FILE SYS` list. For some reason ZFS datasets are shown more than once, this removes the duplicate entries and filters them by `mnt_point`.

Before:
```console
FILE SYS                 Used  Total
/                        351G  1.79T
/boot (nvme0n1p1)       20.5M   511M
/mnt/Data/Backup         375G  4.73T
/mnt/Data/Backup         375G  4.73T
/mnt/Data/Deluge        2.25M  4.36T
/mnt/Data/Deluge        2.25M  4.36T
/mnt/Data/Snapshots      256K  4.36T
/mnt/Data/Snapshots      256K  4.36T
_iners/storage/overlay   351G  1.79T
```

After:
```console
FILE SYS                 Used  Total
/                        351G  1.79T
/boot (nvme0n1p1)       20.5M   511M
/mnt/Data/Backup         375G  4.73T
/mnt/Data/Deluge        2.25M  4.36T
/mnt/Data/Snapshots      256K  4.36T
_iners/storage/overlay   351G  1.79T
```

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:
