### PR TITLE
Handle tabs in process arguments

### DIFF
--- a/glances/plugins/glances_processlist.py
+++ b/glances/plugins/glances_processlist.py
@@ -411,6 +411,7 @@ class Plugin(GlancesPlugin):
                 # Manage end of line in arguments (see #1692)
                 arguments = arguments.replace('\r\n', ' ')
                 arguments = arguments.replace('\n', ' ')
+                arguments = arguments.replace('\t', ' ')
                 if os.path.isdir(path) and not args.process_short_name:
                     msg = self.layout_stat['command'].format(path) + os.sep
                     ret.append(self.curse_add_line(msg, splittable=True))

--- a/glances/plugins/glances_processlist.py
+++ b/glances/plugins/glances_processlist.py
@@ -48,7 +48,7 @@ def split_cmdline(bare_process_name, cmdline):
         path, cmd = "", cmdline[0]
     else:
         path, cmd = os.path.split(cmdline[0])
-    arguments = ' '.join(cmdline[1:]).replace('\n', ' ')
+    arguments = ' '.join(cmdline[1:])
     return path, cmd, arguments
 
 
@@ -409,8 +409,8 @@ class Plugin(GlancesPlugin):
             if cmdline:
                 path, cmd, arguments = split_cmdline(bare_process_name, cmdline)
                 # Manage end of line in arguments (see #1692)
-                arguments.replace('\r\n', ' ')
-                arguments.replace('\n', ' ')
+                arguments = arguments.replace('\r\n', ' ')
+                arguments = arguments.replace('\n', ' ')
                 if os.path.isdir(path) and not args.process_short_name:
                     msg = self.layout_stat['command'].format(path) + os.sep
                     ret.append(self.curse_add_line(msg, splittable=True))


### PR DESCRIPTION
#### Description

Handling line endings and tab characters to not break UI

#### Resume

* Bug fix: yes
Fixes: #2337 

@nicolargo 
How about escaping `\n` to `\\n` (similarly for `\r\n` and `\t`) instead of replacing them with a space so that they will get displayed on the UI? 

One issue with this is that we could get processes with just line endings like:
`executable\narg1\narg2\narg3`

But we could maybe add a space along with the escapes to make it look like:
`executable \narg1 \narg2 \narg3`

What are your thoughts on this?
