### PR TITLE
chg: Dockerfile - structured & cleaner build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,16 @@
-.dockerignore
-.git
+# Ignore everything
+*
+
+# Include only code files
+!/glances/**/*.py
+
+# Include WebUI files (remove when webui moved to seperate package)
+!/glances/outputs/static
+
+# Include Requirements files
+!/requirements.txt
+!/webui-requirements.txt
+!/optional-requirements.txt
+
+# Include Config file
+!/docker-compose/glances.conf

--- a/docker-files/alpine.Dockerfile
+++ b/docker-files/alpine.Dockerfile
@@ -50,7 +50,7 @@ RUN apk add --no-cache \
   libffi-dev \
   openssl-dev
 
-RUN python${PYTHON_VERSION} -m venv venv
+RUN python${PYTHON_VERSION} -m venv --system-site-packages --without-pip venv
 
 COPY requirements.txt webui-requirements.txt optional-requirements.txt ./
 

--- a/docker-files/alpine.Dockerfile
+++ b/docker-files/alpine.Dockerfile
@@ -11,11 +11,27 @@
 ARG IMAGE_VERSION=3.18.0
 ARG PYTHON_VERSION=3.11
 
-FROM alpine:${IMAGE_VERSION} as build
-ARG PYTHON_VERSION
+##############################################################################
+# Base layer to be used for building dependencies and the release images
+FROM alpine:${IMAGE_VERSION} as base
 
 RUN apk add --no-cache \
   python3 \
+  curl \
+  lm-sensors \
+  wireless-tools \
+  smartmontools \
+  iputils \
+  tzdata
+
+##############################################################################
+# BUILD Stages
+##############################################################################
+# BUILD: Base image shared by all build images
+FROM base as build
+ARG PYTHON_VERSION
+
+RUN apk add --no-cache \
   python3-dev \
   py3-pip \
   py3-wheel \
@@ -24,124 +40,78 @@ RUN apk add --no-cache \
   build-base \
   libzmq \
   zeromq-dev \
-  curl \
-  lm-sensors \
-  wireless-tools \
-  smartmontools \
-  iputils \
-  tzdata \
   # Required for 'cryptography' dependency of optional requirement 'cassandra-driver' \
   # Refer: https://cryptography.io/en/latest/installation/#alpine \
   # `git` required to clone cargo crates (dependencies)
-  gcc libffi-dev openssl-dev cargo pkgconfig git
+  git \
+  gcc \
+  cargo \
+  pkgconfig \
+  libffi-dev \
+  openssl-dev
+
+RUN python${PYTHON_VERSION} -m venv venv
+
+COPY requirements.txt webui-requirements.txt optional-requirements.txt ./
 
 ##############################################################################
-# Install the dependencies beforehand to make them cacheable
+# BUILD: Install the minimal image deps
+FROM build as buildMinimal
 
-FROM build as buildRequirements
-ARG PYTHON_VERSION
-
-COPY requirements.txt .
-RUN pip3 install --no-cache-dir --user -r requirements.txt
-
-# Minimal means no webui, but it break what is done previously (see #2155)
-# So install the webui requirements...
-COPY webui-requirements.txt .
-RUN pip3 install --no-cache-dir --user -r webui-requirements.txt
-
-# As minimal image we want to monitor others docker containers
-RUN pip3 install --no-cache-dir --user docker
-
-# Force install otherwise it could be cached without rerun
-ARG CHANGING_ARG
-RUN pip3 install --no-cache-dir --user glances
+RUN /venv/bin/python3 -m pip install  \
+    docker  \
+    python-dateutil  \
+    #-r requirements.txt \
+    -r webui-requirements.txt
 
 ##############################################################################
-
-FROM build as buildOptionalRequirements
-ARG PYTHON_VERSION
+# BUILD: Install all the deps
+FROM build as buildFull
 
 # Required for optional dependency cassandra-driver
-ENV CASS_DRIVER_NO_CYTHON=1
+ARG CASS_DRIVER_NO_CYTHON=1
 # See issue 2368
-ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
+ARG CARGO_NET_GIT_FETCH_WITH_CLI=true
 
-COPY requirements.txt .
-COPY optional-requirements.txt .
-RUN pip3 install --no-cache-dir --user -r optional-requirements.txt
+RUN /venv/bin/python3 -m pip install  \
+    #-r requirements.txt \
+    -r optional-requirements.txt
 
 ##############################################################################
-# full image
+# RELEASE Stages
 ##############################################################################
+# Base image shared by all releases
+FROM base as release
 
-FROM build as full
-ARG PYTHON_VERSION
-
-COPY --from=buildRequirements /root/.local/bin /usr/local/bin/
-COPY --from=buildRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /usr/lib/python${PYTHON_VERSION}/site-packages/
-COPY --from=buildOptionalRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /usr/lib/python${PYTHON_VERSION}/site-packages/
+# Copy source code and config file
 COPY ./docker-compose/glances.conf /etc/glances.conf
+COPY /glances /app/glances
 
 # EXPOSE PORT (XMLRPC / WebUI)
 EXPOSE 61209 61208
 
 # Define default command.
-WORKDIR /glances
-CMD python3 -m glances -C /etc/glances.conf $GLANCES_OPT
+WORKDIR /app
+CMD /venv/bin/python3 -m glances -C /etc/glances.conf $GLANCES_OPT
 
-##############################################################################
-# minimal image
-##############################################################################
+################################################################################
+# RELEASE: minimal
+FROM release as minimal
 
-# Create running images without any building dependency
-FROM alpine:${IMAGE_VERSION} as minimal
-ARG PYTHON_VERSION
+COPY --from=buildMinimal /venv /venv
 
-RUN apk add --no-cache \
-  python3 \
-  py3-packaging \
-  py3-dateutil \
-  py3-requests \
-  curl \
-  lm-sensors \
-  wireless-tools \
-  smartmontools \
-  iputils \
-  tzdata
+################################################################################
+# RELEASE: full
+FROM release as full
 
-COPY --from=buildRequirements /root/.local/bin /usr/local/bin/
-COPY --from=buildRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /usr/lib/python${PYTHON_VERSION}/site-packages/
-COPY ./docker-compose/glances.conf /etc/glances.conf
+RUN apk add --no-cache libzmq
 
-# EXPOSE PORT (XMLRPC / WebUI)
-EXPOSE 61209 61208
+COPY --from=buildFull /venv /venv
 
-# Define default command.
-WORKDIR /glances
-CMD python3 -m glances -C /etc/glances.conf $GLANCES_OPT
-
-##############################################################################
-# dev image
-##############################################################################
-
+################################################################################
+# RELEASE: dev - to be compatible with CI
 FROM full as dev
-ARG PYTHON_VERSION
-
-COPY --from=buildRequirements /root/.local/bin /usr/local/bin/
-COPY --from=buildRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /usr/lib/python${PYTHON_VERSION}/site-packages/
-COPY --from=buildOptionalRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /usr/lib/python${PYTHON_VERSION}/site-packages/
-COPY ./docker-compose/glances.conf /etc/glances.conf
-
-# Copy the current Glances source code
-COPY . /glances
-
-# EXPOSE PORT (XMLRPC / WebUI)
-EXPOSE 61209 61208
 
 # Forward access and error logs to Docker's log collector
 RUN ln -sf /dev/stdout /tmp/glances-root.log \
-    && ln -sf /dev/stderr /var/log/error.log
-
-# Define default command.
-WORKDIR /glances
-CMD python3 -m glances -C /etc/glances.conf $GLANCES_OPT
+    && ln -sf /dev/stderr /var/log/error.log \

--- a/docker-files/ubuntu.Dockerfile
+++ b/docker-files/ubuntu.Dockerfile
@@ -8,143 +8,107 @@
 # Ex: Python 3.10 for Ubuntu 22.04
 # Note: ENV is for future running containers. ARG for building your Docker image.
 
-# Image from CUDA https://hub.docker.com/r/nvidia/cuda/tags
-ARG IMAGE_VERSION=12.1.1-base-ubuntu22.04
-ARG PYTHON_VERSION=3.10
-ARG PIP_MIRROR=https://mirrors.aliyun.com/pypi/simple/
-FROM nvidia/cuda:${IMAGE_VERSION} as build
+ARG IMAGE_VERSION=23.04
+ARG PYTHON_VERSION=3.11
 
+##############################################################################
+# Base layer to be used for building dependencies and the release images
+FROM ubuntu:${IMAGE_VERSION} as base
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     python3 \
+    curl \
+    lm-sensors \
+    wireless-tools \
+    smartmontools \
+    net-tools \
+    tzdata \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+##############################################################################
+# BUILD Stages
+##############################################################################
+# BUILD: Base image shared by all build images
+FROM base as build
+ARG PYTHON_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install build-time dependencies
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
     python3-dev \
+    python3-venv \
     python3-pip \
     python3-wheel \
+    libzmq5 \
     musl-dev \
     build-essential \
-    libzmq5 \
-    curl \
-    lm-sensors \
-    wireless-tools \
-    smartmontools \
-    net-tools \
-    tzdata \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-##############################################################################
-# Install the dependencies beforehand to make them cacheable
+RUN python${PYTHON_VERSION} -m venv venv
 
-FROM build as buildRequirements
-ARG PYTHON_VERSION
-ARG PIP_MIRROR
-
-ARG PIP_MIRROR=https://mirrors.aliyun.com/pypi/simple/
-
-COPY requirements.txt .
-RUN python${PYTHON_VERSION} -m pip install --no-cache-dir --user -r requirements.txt -i ${PIP_MIRROR}
-
-# Minimal means no webui, but it break what is done previously (see #2155)
-# So install the webui requirements...
-COPY webui-requirements.txt .
-RUN python${PYTHON_VERSION} -m pip install --no-cache-dir --user -r webui-requirements.txt -i ${PIP_MIRROR}
-
-# As minimal image we want to monitor others docker containers
-RUN python${PYTHON_VERSION} -m pip install --no-cache-dir --user docker -i ${PIP_MIRROR}
-
-# Force install otherwise it could be cached without rerun
-ARG CHANGING_ARG
-RUN python${PYTHON_VERSION} -m pip install --no-cache-dir --user glances -i ${PIP_MIRROR}
+COPY requirements.txt webui-requirements.txt optional-requirements.txt ./
 
 ##############################################################################
+# BUILD: Install the minimal image deps
+FROM build as buildMinimal
 
-FROM build as buildOptionalRequirements
-ARG PYTHON_VERSION
-ARG PIP_MIRROR
-
-COPY requirements.txt .
-COPY optional-requirements.txt .
-RUN CASS_DRIVER_NO_CYTHON=1 pip3 install --no-cache-dir --user -r optional-requirements.txt -i ${PIP_MIRROR}
+RUN /venv/bin/python3 -m pip install  \
+    docker  \
+    python-dateutil  \
+    #-r requirements.txt \
+    -r webui-requirements.txt
 
 ##############################################################################
-# full image
+# BUILD: Install all the deps
+FROM build as buildFull
+
+RUN /venv/bin/python3 -m pip install  \
+    #-r requirements.txt \
+    -r optional-requirements.txt
+
 ##############################################################################
+# RELEASE Stages
+##############################################################################
+# Base image shared by all releases
+FROM base as release
 
-FROM build as full
-ARG PYTHON_VERSION
-
-COPY --from=buildRequirements /root/.local/bin /root/.local/bin/
-COPY --from=buildRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /root/.local/lib/python${PYTHON_VERSION}/site-packages/
-COPY --from=buildOptionalRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /root/.local/lib/python${PYTHON_VERSION}/site-packages/
+# Copy Glances source code and config file
 COPY ./docker-compose/glances.conf /etc/glances.conf
+COPY /glances /app/glances
 
 # EXPOSE PORT (XMLRPC / WebUI)
 EXPOSE 61209 61208
 
 # Define default command.
-WORKDIR /glances
-CMD python3 -m glances -C /etc/glances.conf $GLANCES_OPT
+WORKDIR /app
+CMD /venv/bin/python3 -m glances -C /etc/glances.conf $GLANCES_OPT
 
-##############################################################################
-# minimal image
-##############################################################################
+################################################################################
+# RELEASE: minimal
+FROM release as minimal
 
-# Create running images without any building dependency
-FROM nvidia/cuda:${IMAGE_VERSION} as minimal
-ARG PYTHON_VERSION
+COPY --from=buildMinimal /venv /venv
 
-ARG DEBIAN_FRONTEND=noninteractive
+################################################################################
+# RELEASE: full
+FROM release as full
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends \
-    python3 \
-    python3-packaging \
-    python3-dateutil \
-    python3-requests \
-    curl \
-    lm-sensors \
-    wireless-tools \
-    smartmontools \
-    net-tools \
-    tzdata \
+  && apt-get install -y --no-install-recommends libzmq5 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=buildRequirements /root/.local/bin /root/.local/bin/
-COPY --from=buildRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /root/.local/lib/python${PYTHON_VERSION}/site-packages/
-COPY ./docker-compose/glances.conf /etc/glances.conf
+COPY --from=buildFull /venv /venv
 
-# EXPOSE PORT (XMLRPC / WebUI)
-EXPOSE 61209 61208
-
-# Define default command.
-WORKDIR /glances
-CMD python3 -m glances -C /etc/glances.conf $GLANCES_OPT
-
-##############################################################################
-# dev image
-##############################################################################
-
+################################################################################
+# RELEASE: dev - to be compatible with CI
 FROM full as dev
-ARG PYTHON_VERSION
-
-COPY --from=buildRequirements /root/.local/bin /root/.local/bin/
-COPY --from=buildRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /root/.local/lib/python${PYTHON_VERSION}/site-packages/
-COPY --from=buildOptionalRequirements /root/.local/lib/python${PYTHON_VERSION}/site-packages /root/.local/lib/python${PYTHON_VERSION}/site-packages/
-COPY ./docker-compose/glances.conf /etc/glances.conf
-
-# Copy the current Glances source code
-COPY . /glances
-
-# EXPOSE PORT (XMLRPC / WebUI)
-EXPOSE 61209 61208
 
 # Forward access and error logs to Docker's log collector
 RUN ln -sf /dev/stdout /tmp/glances-root.log \
     && ln -sf /dev/stderr /var/log/error.log
-
-# Define default command.
-WORKDIR /glances
-CMD python3 -m glances -C /etc/glances.conf $GLANCES_OPT

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -166,5 +166,53 @@ You can add a ``[passwords]`` block to the Glances configuration file as mention
     localhost=mylocalhostpassword
     default=mydefaultpassword
 
+Using GPU Plugin with Docker (Only Nvidia GPUs)
+------------------------------------------------------------------
+
+Complete the steps mentioned in the `docker docs <https://docs.docker.com/config/containers/resource_constraints/#gpu>`_
+to make the GPU accessible by the docker engine.
+
+With `docker run`
+^^^^^^^^^^^^^^^^^
+Include the `--gpus` flag with the `docker run` command.
+
+**Note:** Make sure the `--gpus` is present before the image name in the command, otherwise it won't work.
+
+.. code-block:: ini
+
+    docker run --rm -v /var/run/docker.sock:/var/run/docker.sock:ro --gpus --pid host --network host -it docker.io/nicolargo/glances:latest-full
+
+..
+
+
+With `docker-compose`
+^^^^^^^^^^^^^^^^^^^^^
+Include the `deploy` section in compose file as specified below in the example service definition.
+
+.. code-block:: ini
+
+    version: '3'
+
+    services:
+      monitoring:
+        image: nicolargo/glances:latest-full
+        pid: host
+        network_mode: host
+        volumes:
+          - /var/run/docker.sock:/var/run/docker.sock
+        environment:
+          - "GLANCES_OPT=-w"
+        # For nvidia GPUs
+        deploy:
+          resources:
+            reservations:
+              devices:
+                - driver: nvidia
+                  count: 1
+                  capabilities: [gpu]
+
+..
+
+Reference: https://docs.docker.com/compose/gpu-support/
 
 .. _DockerHub: https://hub.docker.com/r/nicolargo/glances/tags


### PR DESCRIPTION
@nicolargo 

I've tried to make the docker builds more cleaner. 
PTAL. Changes still need to be reviewed.

Couple of Questions
1. Why is are the non-dev tags being built off the glances being pulled from pypi?
2. Why is the nvidia/cuda image used for the ubuntu images?
3. Why was a custom pip mirror used for the ubuntu builds? (mirrors.aliyun.com)

Notable difference from the original process:
- Build dependencies are no longer present in final images
- Glances is installed directly from the source code rather than from pypi
- glances built and run on a venv installed on the container


I've pushed the built images for dev on dockerhub for ref: https://hub.docker.com/r/razcrimson/glances/tags

The images seem to be running fine for now. Not all plugins were tested, but there shouldn't be any big issues.
Results seems very good. Here is a small comparison:

| Tag        | Old Size | New Size |
|------------|----------|----------|
| dev        | 1.3 GB   | 163 MB   |
| ubuntu-dev | 760 MB   | 336 MB   |
| latest     | 74 MB    | 69 MB    | 

Sizes were measured using dive: https://github.com/wagoodman/dive