### PR TITLE
Draft: Add glances binary to '/usr/local/bin' + Update ENV PATH to include '/venv/bin' in Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,6 @@
 
 # Include Config file
 !/docker-compose/glances.conf
+
+# Include binary file
+!/docker-bin.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,5 +16,5 @@
 # Include Config file
 !/docker-compose/glances.conf
 
-# Include binary file
+# Include Binary file
 !/docker-bin.sh

--- a/docker-bin.sh
+++ b/docker-bin.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+/venv/bin/python3 -m glances $@

--- a/docker-files/alpine.Dockerfile
+++ b/docker-files/alpine.Dockerfile
@@ -86,6 +86,10 @@ FROM base as release
 COPY ./docker-compose/glances.conf /etc/glances.conf
 COPY /glances /app/glances
 
+# Copy binary and update PATH
+COPY docker-bin.sh /usr/local/bin/glances
+ENV PATH="$PATH:/venv/bin"
+
 # EXPOSE PORT (XMLRPC / WebUI)
 EXPOSE 61209 61208
 

--- a/docker-files/alpine.Dockerfile
+++ b/docker-files/alpine.Dockerfile
@@ -88,7 +88,7 @@ COPY /glances /app/glances
 
 # Copy binary and update PATH
 COPY docker-bin.sh /usr/local/bin/glances
-ENV PATH="$PATH:/venv/bin"
+ENV PATH="/venv/bin:$PATH"
 
 # EXPOSE PORT (XMLRPC / WebUI)
 EXPOSE 61209 61208

--- a/docker-files/ubuntu.Dockerfile
+++ b/docker-files/ubuntu.Dockerfile
@@ -80,6 +80,10 @@ FROM base as release
 COPY ./docker-compose/glances.conf /etc/glances.conf
 COPY /glances /app/glances
 
+# Copy binary and update PATH
+COPY docker-bin.sh /usr/local/bin/glances
+ENV PATH="$PATH:/venv/bin"
+
 # EXPOSE PORT (XMLRPC / WebUI)
 EXPOSE 61209 61208
 

--- a/docker-files/ubuntu.Dockerfile
+++ b/docker-files/ubuntu.Dockerfile
@@ -82,7 +82,7 @@ COPY /glances /app/glances
 
 # Copy binary and update PATH
 COPY docker-bin.sh /usr/local/bin/glances
-ENV PATH="$PATH:/venv/bin"
+ENV PATH="/venv/bin:$PATH"
 
 # EXPOSE PORT (XMLRPC / WebUI)
 EXPOSE 61209 61208


### PR DESCRIPTION
#### Description

This PR aims to add the `glances` binary back, as well as prepend `/venv/bin/` to the PATH.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #2406, #2418 