### PR TITLE
Double quote array expansions to avoid re-splitting elements in docker-bin.sh

### DIFF
--- a/docker-bin.sh
+++ b/docker-bin.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/venv/bin/python3 -m glances $@
+/venv/bin/python3 -m glances "$@"


### PR DESCRIPTION
#### Description

This PR aims to add double quotes around `$@` in the [docker-bin.sh](https://github.com/nicolargo/glances/blob/develop/docker-bin.sh) script (which I introduced in https://github.com/nicolargo/glances/pull/2419) to prevent globbing and word splitting.
For more information, see: https://www.shellcheck.net/wiki/SC2068

*To be fair, I can't think of a particular case where globbing and word splitting could have been an issue with `glances` but it doesn't hurt having a properly syntaxed/written script :smile:*

#### Resume

* Bug fix: yes *(kinda)*
* New feature: no

