### PR TITLE
Support multiple docker socket

### DIFF
--- a/docker-compose/glances.conf
+++ b/docker-compose/glances.conf
@@ -425,7 +425,7 @@ all=False
 # Define Podman sock
 #podman_sock=unix:///run/user/1000/podman/podman.sock
 # Define Docker sock
-#docker_sock=unix://var/run/docker.sock
+docker_sock=unix:///var/run/docker.sock
 
 [amps]
 # AMPs configuration are defined in the bottom of this file

--- a/docker-compose/glances.conf
+++ b/docker-compose/glances.conf
@@ -424,6 +424,8 @@ max_name_size=20
 all=False
 # Define Podman sock
 #podman_sock=unix:///run/user/1000/podman/podman.sock
+# Define Docker sock
+#docker_sock=unix://var/run/docker.sock
 
 [amps]
 # AMPs configuration are defined in the bottom of this file

--- a/glances/plugins/containers/engines/docker.py
+++ b/glances/plugins/containers/engines/docker.py
@@ -215,25 +215,26 @@ class DockerContainersExtension:
 
     CONTAINER_ACTIVE_STATUS = ['running', 'paused']
 
-    def __init__(self, server_url:str = 'unix://var/run/docker.sock'):
+    def __init__(self, server_urls:str|list = 'unix://var/run/docker.sock'):
         if import_docker_error_tag:
             raise Exception("Missing libs required to run Docker Extension (Containers) ")
 
-        self.client = None
+        self.clients = None
         self.ext_name = "containers (Docker)"
         self.stats_fetchers = {}
 
-        self.connect(server_url)
+        self.connect(server_urls)
 
-    def connect(self, base_url:str = 'unix://var/run/docker.sock'):
+    def connect(self, base_urls:str|list = 'unix://var/run/docker.sock'):
         """Connect to the Docker server."""
         # Init the Docker API Client
+        base_urls = [base_urls] if isinstance(base_urls, str) else base_urls
         try:
             # Do not use the timeout option (see issue #1878)
-            self.client = docker.DockerClient(base_url)
+            self.clients = [docker.DockerClient(url) for url in base_urls]
         except Exception as e:
             logger.error("{} plugin - Can't connect to Docker ({})".format(self.ext_name, e))
-            self.client = None
+            self.clients = None
 
     def update_version(self):
         # Long and not useful anymore because the information is no more displayed in UIs
@@ -248,7 +249,7 @@ class DockerContainersExtension:
     def update(self, all_tag):
         """Update Docker stats using the input method."""
 
-        if not self.client:
+        if not self.clients:
             return {}, []
 
         version_stats = self.update_version()
@@ -257,7 +258,8 @@ class DockerContainersExtension:
         try:
             # Issue #1152: Docker module doesn't export details about stopped containers
             # The Containers/all key of the configuration file should be set to True
-            containers = self.client.containers.list(all=all_tag)
+            containers = []
+            [[containers.append(container_per_client) for container_per_client in client.containers.list(all=all_tag)] for client in self.clients]
         except Exception as e:
             logger.error("{} plugin - Can't get containers list ({})".format(self.ext_name, e))
             return version_stats, []

--- a/glances/plugins/containers/engines/docker.py
+++ b/glances/plugins/containers/engines/docker.py
@@ -215,7 +215,7 @@ class DockerContainersExtension:
 
     CONTAINER_ACTIVE_STATUS = ['running', 'paused']
 
-    def __init__(self):
+    def __init__(self, server_url:str = 'unix://var/run/docker.sock'):
         if import_docker_error_tag:
             raise Exception("Missing libs required to run Docker Extension (Containers) ")
 
@@ -223,14 +223,14 @@ class DockerContainersExtension:
         self.ext_name = "containers (Docker)"
         self.stats_fetchers = {}
 
-        self.connect()
+        self.connect(server_url)
 
-    def connect(self):
+    def connect(self, base_url:str = 'unix://var/run/docker.sock'):
         """Connect to the Docker server."""
         # Init the Docker API Client
         try:
             # Do not use the timeout option (see issue #1878)
-            self.client = docker.from_env()
+            self.client = docker.DockerClient(base_url)
         except Exception as e:
             logger.error("{} plugin - Can't connect to Docker ({})".format(self.ext_name, e))
             self.client = None

--- a/glances/plugins/containers/engines/docker.py
+++ b/glances/plugins/containers/engines/docker.py
@@ -301,6 +301,7 @@ class DockerContainersExtension:
             # Container Status (from attrs)
             'Status': container.attrs['State']['Status'],
             'Created': container.attrs['Created'],
+            'Socket_URL': container.client.api.base_url,
             'Command': [],
         }
 

--- a/glances/plugins/containers/engines/docker.py
+++ b/glances/plugins/containers/engines/docker.py
@@ -215,7 +215,7 @@ class DockerContainersExtension:
 
     CONTAINER_ACTIVE_STATUS = ['running', 'paused']
 
-    def __init__(self, server_urls:str|list = 'unix://var/run/docker.sock'):
+    def __init__(self, server_urls:str|list = 'unix:///var/run/docker.sock'):
         if import_docker_error_tag:
             raise Exception("Missing libs required to run Docker Extension (Containers) ")
 
@@ -225,7 +225,7 @@ class DockerContainersExtension:
 
         self.connect(server_urls)
 
-    def connect(self, base_urls:str|list = 'unix://var/run/docker.sock'):
+    def connect(self, base_urls:str|list = 'unix:///var/run/docker.sock'):
         """Connect to the Docker server."""
         # Init the Docker API Client
         base_urls = [base_urls] if isinstance(base_urls, str) else base_urls

--- a/glances/plugins/containers/model.py
+++ b/glances/plugins/containers/model.py
@@ -70,13 +70,13 @@ class PluginModel(GlancesPluginModel):
         self.args = args
 
         # Default config keys
-        self.config = config # TODO: need to debug this point
+        self.config = config
 
         # We want to display the stat in the curse interface
         self.display_curse = True
 
         # Init the Docker API
-        self.docker_extension = DockerContainersExtension() if not import_docker_error_tag else None
+        self.docker_extension = DockerContainersExtension(server_urls=self._docker_sock()) if not import_docker_error_tag else None
 
         # Init the Podman API
         if import_podman_error_tag:
@@ -91,6 +91,16 @@ class PluginModel(GlancesPluginModel):
         self.update()
         self.refresh_timer.set(0)
 
+    def _docker_sock(self):
+        """Return the docker socks.
+        Default value: unix://var/run/docker.sock
+        """
+        conf_docker_sock = self.get_conf_value('docker_sock')
+        if len(conf_docker_sock) == 0:
+            return "unix://var/run/docker.sock"
+        else:
+            return conf_docker_sock
+        
     def _podman_sock(self):
         """Return the podman sock.
         Could be desfined in the [docker] section thanks to the podman_sock option.
@@ -157,7 +167,7 @@ class PluginModel(GlancesPluginModel):
 
         if self.input_method == 'local':
             # Update stats
-            stats_docker = self.update_docker() if self.docker_extension else {} # TODO: need to concat all docker client
+            stats_docker = self.update_docker() if self.docker_extension else {}
             stats_podman = self.update_podman() if self.podman_client else {}
             stats = {
                 'version': stats_docker.get('version', {}),

--- a/glances/plugins/containers/model.py
+++ b/glances/plugins/containers/model.py
@@ -307,6 +307,8 @@ class PluginModel(GlancesPluginModel):
         ret.append(self.curse_add_line(msg))
         msg = ' {:<7}'.format('Tx/s')
         ret.append(self.curse_add_line(msg))
+        msg = '{:<30}'.format('Socket URL')
+        ret.append(self.curse_add_line(msg))
         msg = ' {:8}'.format('Command')
         ret.append(self.curse_add_line(msg))
 
@@ -391,6 +393,12 @@ class PluginModel(GlancesPluginModel):
             except KeyError:
                 msg = ' {:<7}'.format('_')
             ret.append(self.curse_add_line(msg))
+            # Socket URL
+            if container['Socket_URL'] is not None:
+                msg = '{:<30}'.format(container['Socket_URL'])
+            else:
+                msg = '{:<30}'.format('_')
+            ret.append(self.curse_add_line(msg, splittable=True))
             # Command
             if container['Command'] is not None:
                 msg = ' {}'.format(' '.join(container['Command']))

--- a/glances/plugins/containers/model.py
+++ b/glances/plugins/containers/model.py
@@ -70,7 +70,7 @@ class PluginModel(GlancesPluginModel):
         self.args = args
 
         # Default config keys
-        self.config = config
+        self.config = config # TODO: need to debug this point
 
         # We want to display the stat in the curse interface
         self.display_curse = True
@@ -82,7 +82,7 @@ class PluginModel(GlancesPluginModel):
         if import_podman_error_tag:
             self.podman_client = None
         else:
-            self.podman_client = PodmanContainersExtension(podman_sock=self._podman_sock())
+            self.podman_client = PodmanContainersExtension(podman_sock=self._podman_sock()) # TODO: podman also
 
         # Sort key
         self.sort_key = None
@@ -157,7 +157,7 @@ class PluginModel(GlancesPluginModel):
 
         if self.input_method == 'local':
             # Update stats
-            stats_docker = self.update_docker() if self.docker_extension else {}
+            stats_docker = self.update_docker() if self.docker_extension else {} # TODO: need to concat all docker client
             stats_podman = self.update_podman() if self.podman_client else {}
             stats = {
                 'version': stats_docker.get('version', {}),

--- a/glances/plugins/containers/model.py
+++ b/glances/plugins/containers/model.py
@@ -93,11 +93,11 @@ class PluginModel(GlancesPluginModel):
 
     def _docker_sock(self):
         """Return the docker socks.
-        Default value: unix://var/run/docker.sock
+        Default value: unix:///var/run/docker.sock
         """
         conf_docker_sock = self.get_conf_value('docker_sock')
         if len(conf_docker_sock) == 0:
-            return "unix://var/run/docker.sock"
+            return "unix:///var/run/docker.sock"
         else:
             return conf_docker_sock
         


### PR DESCRIPTION
#### Description

Docker can separate docker **context** by user. That is, we can have multiple **docker.sock** files per user. The `/var/run/docker.sock` file is default socket file for default context, but `run/user/<USER-ID>/docker.sock` file also can exists for each user account, and the user can switch context and use docker in that context. eg, docker rootless mode, but i think glances binds only one `docker.sock` file through the volume option [when create a new container of glances](https://github.com/nicolargo/glances#docker-the-fun-way).

I wish glances could take multiple docker.sock files and monitor containers per context when glances.conf is set as below.
```
[containers]
# Define Podman sock
#podman_sock=unix:///run/user/1000/podman/podman.sock
# Define Docker sock
#docker_sock=unix:///var/run/docker.sock
docker_sock=unix:///run/user/1000/docker.sock,unix:///run/user/1001/docker.sock
```

I just push a draft version for CLI mode.
The web interface and Podman parts also need to be implemented.
I hope it's worth it. Thanks.

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any