### PR TITLE
Add raid information to API documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -726,6 +726,41 @@ Get a specific field::
     # curl http://localhost:61208/api/3/quicklook/cpu
     {"cpu": 47.6}
 
+GET raid
+-----------
+
+Get plugin stats::
+
+    # curl http://localhost:61208/api/3/raid
+    {"md3": {"status": "active",
+             "type": "raid1",
+             "components": {"sdh1": "2",
+                            "sdi1": "0"},
+             "available": "2",
+             "used": "2",
+             "config": "UU"},
+     "md1": {"status": "active",
+             "type": "raid1",
+             "components": {"sdg": "0",
+                            "sde": "1"},
+             "available": "2",
+             "used": "2",
+             "config": "UU"},
+     "md4": {"status": "active",
+             "type": "raid1",
+             "components": {"sdf1": "1",
+                            "sdb1": "0"},
+             "available": "2",
+             "used": "2",
+             "config": "UU"},
+     "md0": {"status": "active",
+             "type": "raid1",
+             "components": {"sdc": "2",
+                            "sdd": "3"},
+             "available": "2",
+             "used": "2",
+             "config": "UU"}}
+
 GET sensors
 -----------
 


### PR DESCRIPTION
#### Description

Add data received by API call for raid plugin to documentation.
I did not have more information than the given data.
Interesting additions would be different states, raid types and raid configs.

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
