### PR TITLE
Readd support for arm/v6 to docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,7 @@ env:
   DEFAULT_DOCKER_IMAGE: nicolargo/glances
   NODE_ENV: ${{ (contains('refs/heads/master', github.ref) || startsWith(github.ref, 'refs/tags/v')) && 'prod' || 'dev' }}
   PUSH_BRANCH: ${{ 'refs/heads/develop' == github.ref || 'refs/heads/master' == github.ref || startsWith(github.ref, 'refs/tags/v') }}
-  # linux/arm/v7 (drop support for v6) support following issue - See issue #2120
-  DOCKER_PLATFORMS: linux/amd64,linux/arm/v7,linux/arm64,linux/386
+  DOCKER_PLATFORMS: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/386
   # Ubuntu image only support linux/amd64 and linux/arm64 - See issue #2185
   DOCKER_PLATFORMS_UBUNTU: linux/amd64,linux/arm64
 


### PR DESCRIPTION
The support for arm/v6 was dropped since the build was based on python, which did not have support for arm/v6, but now they are based on alpine.

#### Description

I tried running glances using docker on my raaspberry pi zero but it wouldn't start. Digged through some old issues and found that support for arm/v6 was dropped some time ago. But I think it should be fine to add it back now.O

#### Resume

* Bug fix: no
* New feature: yes
