### PR TITLE
Update docker.rst to remove latest-alpine tag

### DIFF
--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -80,7 +80,7 @@ You can also include Glances container in you own `docker-compose.yml`. Here's a
           - "traefik.frontend.rule=Host:whoami.docker.localhost"
 
       monitoring:
-        image: nicolargo/glances:latest-alpine
+        image: nicolargo/glances:latest
         restart: always
         pid: host
         volumes:


### PR DESCRIPTION
#### Description

`latest-alpine` tag is decrepated, so updating the compose example to use `latest` instead

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any
