### PR TITLE
macOS: default to `~/.config/glances`

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -19,7 +19,7 @@ You can place your ``glances.conf`` file in the following locations:
 ==================== =============================================================
 ``Linux``, ``SunOS`` ~/.config/glances/, /etc/glances/, /usr/share/docs/glances/
 ``*BSD``             ~/.config/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
-``macOS``            ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
+``macOS``            ~/.config/glances/, ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
 ``Windows``          %APPDATA%\\glances\\glances.conf
 ==================== =============================================================
 

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -576,7 +576,7 @@ _
 T{
 \fBmacOS\fP
 T}	T{
-~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
+~/.config/glances/, ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
 T}
 _
 T{

--- a/glances/config.py
+++ b/glances/config.py
@@ -127,7 +127,7 @@ class Config(object):
         * custom path: /path/to/glances
         * Linux, SunOS: ~/.config/glances, /etc/glances
         * *BSD: ~/.config/glances, /usr/local/etc/glances
-        * macOS: ~/Library/Application Support/glances, /usr/local/etc/glances
+        * macOS: ~/.config/glances, ~/Library/Application Support/glances, /usr/local/etc/glances
         * Windows: %APPDATA%\glances
 
         The config file will be searched in the following order of priority:


### PR DESCRIPTION
Fixes nicolargo/glances#2636

#### Description

To allow following the `~/.config` convention.

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: #2636
