### PR TITLE
Add missing dependencies for influxdb2 and web

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ujson<3; python_version < "3.0"
 ujson<4; python_version >= "3.5" and python_version < "3.6"
 ujson<5; python_version >= "3.6" and python_version < "3.7"
 ujson>=5.4.0; python_version >= "3.7"
+influxdb==1.39

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,10 @@ def get_install_requires():
         'ujson<4; python_version >= "3.5" and python_version < "3.6"',
         'ujson<5; python_version >= "3.6" and python_version < "3.7"',
         'ujson>=5.4.0; python_version >= "3.7"',
+        'bottle',
+        'influxdb-client==1.39',
     ]
     if sys.platform.startswith('win'):
-        requires.append('bottle')
         requires.append('requests')
 
     return requires


### PR DESCRIPTION
#### Description

Running as a web server or exporting to influxdb 2.x depends on the bottles and influxdb-client modules to work correctly. This fixes the missing package errors in the snap package.

A similar approach can probably be used to address #1738.

**Note:** this targets `support/glancesv3` as the current develop head fails to initialize the terminal on my system and could not be tested. However, the changes are trivial and can be easily be used as a reference to redo it against the `develop` branch.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:
