### PR TITLE
Add bottle and influxdb python packages to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,11 +45,16 @@ parts:
     - selective-checkout
     plugin: python
     source: .
+    python-packages:
+      - bottle
+      - influxdb-client==1.39
     # FIXME: Theoretically this also replaces `summary` and `description`
     #        keys, however due to the following bug we still need to keep
     #        them until it is fixed.
     #        https://bugs.launchpad.net/snapcraft/+bug/1813364
     parse-info: [setup.py]
+    stage-packages:
+      - file
     override-pull: |
       snapcraftctl pull
       "$SNAPCRAFT_STAGE"/scriptlets/selective-checkout


### PR DESCRIPTION
#### Description

Add optional packages to allow glances run as a server or export to
influxdb2 when executed from the snap package.

This affects only snap packaging and won't add optional packages to
the default installation.

This patch can be directly applied to `support/glancesv3` to fix the
current published snap. It was not tested with the `develop` branch
due to failure to initialize the terminal.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: