### PR TITLE
Replace `py3nvml` with `nvidia-ml-py`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Optional dependencies:
 - ``kafka-python`` (for the Kafka export module)
 - ``netifaces`` (for the IP plugin)
 - ``orjson`` (fast JSON library, used under the hood by FastAPI)
-- ``py3nvml`` (for the GPU plugin)
+- ``nvidia-ml-py`` (for the GPU plugin)
 - ``pycouchdb`` (for the CouchDB export module)
 - ``pika`` (for the RabbitMQ/ActiveMQ export module)
 - ``podman`` (for the Containers Podman monitoring support)

--- a/docs/aoa/gpu.rst
+++ b/docs/aoa/gpu.rst
@@ -4,7 +4,8 @@ GPU
 ===
 
 .. note::
-    You need to install the `py3nvml`_ library on your system.
+    You need to install the `nvidia-ml-py`_ library on your system.
+    Or `py3nvml`_ for Glances 3.4.0.2 or lower.
     Or `nvidia-ml-py3`_ for Glances 3.1.3 or lower.
 
 The GPU stats are shown as a percentage of value and for the configured
@@ -49,5 +50,6 @@ GPU (PROC/MEM) Status
 ``>90%``       ``CRITICAL``
 ============== ============
 
+.. _nvidia-ml-py: https://pypi.org/project/nvidia-ml-py/
 .. _py3nvml: https://pypi.org/project/py3nvml/
 .. _nvidia-ml-py3: https://pypi.org/project/nvidia-ml-py3/

--- a/glances/plugins/gpu/__init__.py
+++ b/glances/plugins/gpu/__init__.py
@@ -13,9 +13,8 @@ from glances.globals import nativestr, to_fahrenheit
 from glances.logger import logger
 from glances.plugins.plugin.model import GlancesPluginModel
 
-# In Glances 3.1.4 or higher, we use the py3nvml lib (see issue #1523)
 try:
-    import py3nvml.py3nvml as pynvml
+    import pynvml
 except Exception as e:
     import_error_tag = True
     # Display debug message if import KeyError

--- a/optional-requirements.txt
+++ b/optional-requirements.txt
@@ -26,7 +26,7 @@ pycouchdb
 pygal
 pymdstat
 pymongo; python_version >= "3.7"
-py3nvml; python_version >= "3.5"
+nvidia-ml-py; python_version >= "3.5"
 pysnmp
 pySMART.smartx
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def get_install_extras_require():
                    'ibmcloudant', 'influxdb>=1.0.0', 'influxdb-client', 'pymongo',
                    'kafka-python', 'pika', 'paho-mqtt', 'potsdb', 'prometheus_client',
                    'pyzmq', 'statsd'],
-        'gpu': ['py3nvml'],
+        'gpu': ['nvidia-ml-py'],
         'graph': ['pygal'],
         'ip': ['netifaces'],
         'raid': ['pymdstat'],


### PR DESCRIPTION
#### Description

`py3nvml` hasn't been updated for 3 years, meanwhile https://pypi.org/project/nvidia-ml-py/ appears to be directly published by nvidia and actively maintained.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: 
