### PR TITLE
Add CallbackAPIversion for MQTT export

### DIFF
--- a/docker-compose/glances.conf
+++ b/docker-compose/glances.conf
@@ -595,6 +595,7 @@ queue=glances_queue
 # Configuration for the --export mqtt option
 host=localhost
 port=8883
+hostname=NONE
 tls=false
 user=guest
 password=guest

--- a/glances/exports/mqtt/__init__.py
+++ b/glances/exports/mqtt/__init__.py
@@ -65,7 +65,7 @@ class Export(GlancesExport):
         if not self.export_enable:
             return None
         try:
-            client = paho.Client(client_id='glances_' + self.hostname, clean_session=False)
+            client = paho.Client(callback_api_version=2, client_id='glances_' + self.hostname, clean_session=False)
             client.username_pw_set(username=self.user, password=self.password)
             if self.tls:
                 client.tls_set(certifi.where())

--- a/glances/exports/mqtt/__init__.py
+++ b/glances/exports/mqtt/__init__.py
@@ -38,13 +38,17 @@ class Export(GlancesExport):
 
         # Load the MQTT configuration file
         self.export_enable = self.load_conf(
-            'mqtt', mandatories=['host', 'password'], options=['port', 'user', 'topic', 'tls', 'topic_structure']
+            'mqtt', mandatories=['host', 'password'], options=['port', 'user', 'hostname', 'topic', 'tls', 'topic_structure']
         )
         if not self.export_enable:
             exit('Missing MQTT config')
 
         # Get the current hostname
-        self.hostname = socket.gethostname()
+        self.hostname = (self.hostname or socket.gethostname())
+        if self.hostname in ['NONE']:
+            self.hostname = socket.gethostname()
+        else:
+            self.hostname = self.hostname
         self.port = int(self.port) or 8883
         self.topic = self.topic or 'glances'
         self.user = self.user or 'glances'


### PR DESCRIPTION
#### Description


Due to the recent update of paho-mqtt to version V2.0.0 which requires API versioning, I added callback_api_version VERSION2 in paho.Client to warn of future removal of VERSION1

When installing paho-mqtt with the command 'pip install paho-mqtt' this automatically installs the latest version (currently 2.0.0)
This caused an error when launching Glances with the `--export mqtt` option.
`Connection to MQTT server xxx.xxx.xxx.xxx:XXXX failed with error: Client.__init__() missing 1 required positional argument: 'callback_api_version'`
The workaround was to install paho-mqtt V1.X with this command 'pip install "paho-mqtt<2"

With this fix, Glances works with the new version of paho-mqtt

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: not for the moment
