### PR TITLE
Add MQTT hostname configuration

### DIFF
--- a/docker-compose/glances.conf
+++ b/docker-compose/glances.conf
@@ -595,7 +595,6 @@ queue=glances_queue
 # Configuration for the --export mqtt option
 host=localhost
 port=8883
-hostname=NONE
 tls=false
 user=guest
 password=guest

--- a/docker-compose/glances.conf
+++ b/docker-compose/glances.conf
@@ -595,6 +595,7 @@ queue=glances_queue
 # Configuration for the --export mqtt option
 host=localhost
 port=8883
+hostname=NONE
 tls=false
 user=guest
 password=guest

--- a/glances/exports/mqtt/__init__.py
+++ b/glances/exports/mqtt/__init__.py
@@ -38,13 +38,17 @@ class Export(GlancesExport):
 
         # Load the MQTT configuration file
         self.export_enable = self.load_conf(
-            'mqtt', mandatories=['host', 'password'], options=['port', 'user', 'topic', 'tls', 'topic_structure']
+            'mqtt', mandatories=['host', 'password'], options=['port', 'user', 'hostname', 'topic', 'tls', 'topic_structure']
         )
         if not self.export_enable:
             exit('Missing MQTT config')
 
         # Get the current hostname
-        self.hostname = socket.gethostname()
+        self.hostname = (self.hostname or socket.gethostname())
+        if self.hostname in ['NONE']:
+            self.hostname = socket.gethostname()
+        else:
+            self.hostname = self.hostname
         self.port = int(self.port) or 8883
         self.topic = self.topic or 'glances'
         self.user = self.user or 'glances'

--- a/glances/exports/mqtt/__init__.py
+++ b/glances/exports/mqtt/__init__.py
@@ -38,17 +38,13 @@ class Export(GlancesExport):
 
         # Load the MQTT configuration file
         self.export_enable = self.load_conf(
-            'mqtt', mandatories=['host', 'password'], options=['port', 'user', 'hostname', 'topic', 'tls', 'topic_structure']
+            'mqtt', mandatories=['host', 'password'], options=['port', 'user', 'devicename', 'topic', 'tls', 'topic_structure']
         )
         if not self.export_enable:
             exit('Missing MQTT config')
 
         # Get the current hostname
-        self.hostname = (self.hostname or socket.gethostname())
-        if self.hostname in ['NONE']:
-            self.hostname = socket.gethostname()
-        else:
-            self.hostname = self.hostname
+        self.devicename = self.devicename or socket.gethostname()
         self.port = int(self.port) or 8883
         self.topic = self.topic or 'glances'
         self.user = self.user or 'glances'
@@ -69,7 +65,7 @@ class Export(GlancesExport):
         if not self.export_enable:
             return None
         try:
-            client = paho.Client(client_id='glances_' + self.hostname, clean_session=False)
+            client = paho.Client(client_id='glances_' + self.devicename, clean_session=False)
             client.username_pw_set(username=self.user, password=self.password)
             if self.tls:
                 client.tls_set(certifi.where())
@@ -93,7 +89,7 @@ class Export(GlancesExport):
             for sensor, value in zip(columns, points):
                 try:
                     sensor = [whitelisted(name) for name in sensor.split('.')]
-                    to_export = [self.topic, self.hostname, name]
+                    to_export = [self.topic, self.devicename, name]
                     to_export.extend(sensor)
                     topic = '/'.join(to_export)
 
@@ -102,7 +98,7 @@ class Export(GlancesExport):
                     logger.error("Can not export stats to MQTT server (%s)" % e)
         elif self.topic_structure == 'per-plugin':
             try:
-                topic = '/'.join([self.topic, self.hostname, name])
+                topic = '/'.join([self.topic, self.devicename, name])
                 sensor_values = dict(zip(columns, points))
 
                 # Build the value to output


### PR DESCRIPTION
#### Description

I added the possibility of configuring the hostname of the machine in the MQTT topic.
Are you going to ask me why?
Well I have a dualboot machine. Two different operating systems but the same hardware.
But the 'socket.gethostname()' command returns a different value depending on the operating system ("DESKTOP-B1JV0TR" on Windows and "My-ubuntu" on Linux)
This has the consequence that the access path to the topic is different in my broker even though it is the same machine.
However, I need to read the information on a topic without having to modify it depending on the OS on which I started my machine.
I thought this might be useful to other people.

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: not for the moment
