### PR TITLE
Update README.rst for FreeBSD install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,7 +273,7 @@ To install the binary package:
 
 .. code-block:: console
 
-    # pkg install py38-glances
+    # pkg install py39-glances
 
 To install Glances from ports:
 


### PR DESCRIPTION
FreeBSD has moved glances to python 3.9 so the package name has changed

#### Description

```
➜  ~ pkg install py38-glances
Updating FreeBSD repository catalogue...
Fetching packagesite.pkg: 100%    7 MiB   7.5MB/s    00:01
Processing entries: 100%
FreeBSD repository update completed. 34067 packages processed.
All repositories are up to date.
pkg: No packages available to install matching 'py38-glances' have been found in the repositories
➜  ~ pkg search glances
py39-glances-3.3.1_1           CLI curses based monitoring tool for GNU/Linux and BSD OS
➜  ~ pkg install py39-glances
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
pkg: gio-fam-backend has a missing dependency: perl
The following 6 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
        py39-defusedxml: 0.7.1
        py39-future: 0.18.3
        py39-glances: 3.3.1_1
        py39-packaging: 23.2
        py39-psutil: 5.9.8
        py39-ujson: 5.9.0

Number of packages to be installed: 6

The process will require 10 MiB more space.
2 MiB to be downloaded.

Proceed with this action? [y/N]:
```