### PR TITLE
fix(setup): add missing pydantic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,14 +39,11 @@ def get_data_files():
 
     return data_files
 
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
 
 def get_install_requires():
-    requires = [
-        'psutil>=5.6.7',
-        'defusedxml',
-        'packaging',
-        'ujson>=5.4.0',
-    ]
+    requires = required
     if sys.platform.startswith('win'):
         requires.append('fastapi')
         requires.append('uvicorn')


### PR DESCRIPTION
#### Description

While [upgrading glances formula to 4.0.0](https://github.com/Homebrew/homebrew-core/pull/171483), we found the pydantic dependency missing (caused runtime failure). This PR is adding it into the setup.py for pypi artifact.

#### Resume

* Bug fix: yes
* New feature: no

---

- https://github.com/Homebrew/homebrew-core/pull/171483
