### PR TITLE
Replace `U+23AF` with `U+2500`

### DIFF
--- a/glances/outputs/glances_unicode.py
+++ b/glances/outputs/glances_unicode.py
@@ -15,7 +15,7 @@ _unicode_message = {
     'ARROW_DOWN': ['\u2193', 'v'],
     'CHECK': ['\u2713', ''],
     'PROCESS_SELECTOR': ['>', '>'],
-    'MEDIUM_LINE': ['\u23af', '-'],
+    'MEDIUM_LINE': ['\u2500', '─'],
     'LOW_LINE': ['\u2581', '_'],
 }
 


### PR DESCRIPTION
This PR ***partly*** fixes #2866 and #2817 for `iTerm`, but not `kitty`. Not sure what the best course of action is, help appreciated.

Currently, the char `U+23AF` _"Horizontal Line Extension"_ is used for rendering the horizontal divider lines `MEDIUM_LINE` [(glances_unicode.py#L18)](`MEDIUM_LINE`) in `separator_line()` [glances_curses.py#L441-L455](`separator_line()`)

This char belongs to the _Miscellaneous Technical_ block, as indicated in the following PDF from The Unicode Consortium:

<div align="center">
  <img src="https://github.com/Neved4/applist/assets/63655535/70e819b1-e4a8-4703-908f-f00a031a8de0" alt="U+23AF" style="width: 75%" />

  ###### U+23AF, in _The Unicode Standard_, _Miscellaneous Technical_, p. 5.[^mtech]
</div>

The PR favors `─` (U+2500) from the _Box Drawing_ `[2500-257F]` block, which better suited for this purpose and more widely supported across fonts and terminal emulators.

Alternatively, _em dash_ `—` (U+2014) and _horizontal bar_ `―` (U+2015), from _General Punctuation_ `[2000-206F]` would also be good candidates that are readily available, even if their purpose lies better in punctuation and other typographical conventions.

[`MEDIUM_LINE`]: https://github.com/nicolargo/glances/blob/363a66c2634e0baedad103a8f9d663092bd5a5bb/glances/outputs/glances_unicode.py#L18
[`separator_line()`]: https://github.com/nicolargo/glances/blob/363a66c2634e0baedad103a8f9d663092bd5a5bb/glances/outputs/glances_curses.py#L441-L455

[^mtech]: The Unicode Consortium, _Miscellaneous Technical_ `[2300–23FF]`. The Unicode Standard, Version 15.1. Online: https://www.unicode.org/charts/PDF/U2300.pdf
