### PR TITLE
fix: Use `ncurses` dedicated functions for the separator line

### DIFF
--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -448,22 +448,14 @@ class _GlancesCurses:
         if self.line >= 0:
             position = [self.line, self.column]
             line_color = self.colors_list[color]
+            line_type = curses.ACS_HLINE if not self.args.disable_unicode else unicode_message('MEDIUM_LINE', self.args)
 
-            if not self.args.disable_unicode:
-                # Use curses.ACS_HLINE for the separator line
-                self.term_window.hline(
-                    *position,
-                    curses.ACS_HLINE,
-                    line_width,
-                    line_color,
-                )
-            else:
-                self.term_window.addnstr(
-                    *position,
-                    unicode_message('MEDIUM_LINE', self.args) * line_width,
-                    line_width,
-                    line_color,
-                )
+            self.term_window.hline(
+                *position,
+                line_type,
+                line_width,
+                line_color,
+            )
 
     def __get_stat_display(self, stats, layer):
         """Return a dict of dict with all the stats display.

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -446,13 +446,24 @@ class _GlancesCurses:
         self.line -= 1
         line_width = self.term_window.getmaxyx()[1] - self.column
         if self.line >= 0:
-            self.term_window.addnstr(
-                self.line,
-                self.column,
-                unicode_message('MEDIUM_LINE', self.args) * line_width,
-                line_width,
-                self.colors_list[color],
-            )
+            position = [self.line, self.column]
+            line_color = self.colors_list[color]
+
+            if not self.args.disable_unicode:
+                # Use curses.ACS_HLINE for the separator line
+                self.term_window.hline(
+                    *position,
+                    curses.ACS_HLINE,
+                    line_width,
+                    line_color,
+                )
+            else:
+                self.term_window.addnstr(
+                    *position,
+                    unicode_message('MEDIUM_LINE', self.args) * line_width,
+                    line_width,
+                    line_color,
+                )
 
     def __get_stat_display(self, stats, layer):
         """Return a dict of dict with all the stats display.


### PR DESCRIPTION
Finally solves #2817, #2866 and fixes #2876 for [Kitty](https://sw.kovidgoyal.net/kitty/) and other terminals. Related: #2867.

The bug was also present in [Alacritty](https://alacritty.org/), [Contour](https://contour-terminal.org/) and [Rio](https://raphamorim.io/rio).

#### Description

Ensures `ncurses` proper line drawing, by using `self.term_window.hline()` and `curses.ACS_HLINE`. These functions are more correct and prevent drawing bugs, as suggested by Kitty's terminal maintainer, see: https://github.com/kovidgoyal/kitty/issues/7622.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #2817, #2866 and #2876

#### Passing Terminals (macOS)
- ✅ alacritty `v0.13.2`
- ✅ archipelago `v6.0.7`
- ✅ contour `v0.4.3.6442`
- ✅ cool-retro-term `v1.2.0`
- ✅ edex-ui `v2.2.8`
- ✅ electerm `v1.39.76`
- ✅ fig `v2.19.0`
- ✅ hyper `v3.4.1`
- ✅ iterm2 `v3.5.3 `
- ✅ kitty `v0.35.2`
- ✅ rio `v0.1.1`
- ✅ tabby `v1.0.209`
- ✅ Terminal.app `v2.14`
- ✅ warp `0.2024.07.09.08.01.stable_00`
- ✅ wezterm `20240203-110809,5046fc22`
- ✅ windterm `2.6.1`
- ✅ zoc `8.08.6`