### PR TITLE
Add 'Availability' topic to MQTT connection

### DIFF
--- a/glances/exports/glances_mqtt/__init__.py
+++ b/glances/exports/glances_mqtt/__init__.py
@@ -79,6 +79,19 @@ class Export(GlancesExport):
                 client_id='glances_' + self.devicename,
                 clean_session=False,
             )
+
+            def on_connect(client, userdata, flags, reason_code, properties):
+                """Action to perform when connecting."""
+                self.client.publish(topic='/'.join([self.topic, self.devicename, "availability"]), payload="Online")
+
+            def on_disconnect(client, userdata, flags, reason_code, properties):
+                """Action to perform when the connection is over."""
+                self.client.publish(topic='/'.join([self.topic, self.devicename, "availability"]), payload="Offline")
+
+            client.on_connect = on_connect
+            client.on_disconnect = on_disconnect
+            client.will_set(topic='/'.join([self.topic, self.devicename, "availability"]), payload="Offline")
+
             client.username_pw_set(username=self.user, password=self.password)
             if self.tls:
                 client.tls_set(certifi.where())


### PR DESCRIPTION
#### Description

Addition of the 'availability' topic: Online or Offline when using the --export MQTT option in the case where other devices on the same broker are looking for our Glances instance

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: no
