### PR TITLE
add comparable NVML_LIB check for Windows

### DIFF
--- a/glances/plugins/gpu/cards/nvidia.py
+++ b/glances/plugins/gpu/cards/nvidia.py
@@ -8,6 +8,9 @@
 
 """NVidia Extension unit for Glances' GPU plugin."""
 
+import os
+import sys
+
 from glances.globals import nativestr
 from glances.logger import logger
 
@@ -17,7 +20,13 @@ try:
     # Avoid importing pynvml if NVML_LIB is not installed
     from ctypes import CDLL
 
-    CDLL(NVML_LIB)
+    if (sys.platform[:3] == "win"):
+        try:
+            CDLL(os.path.join(os.getenv("WINDIR", "C:/Windows"), "System32/nvml.dll"))
+        except OSError as ose:
+            CDLL(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/nvml.dll"))
+    else:
+        CDLL(NVML_LIB)
     import pynvml
 except OSError:
     nvidia_gpu_enable = False

--- a/glances/plugins/gpu/cards/nvidia.py
+++ b/glances/plugins/gpu/cards/nvidia.py
@@ -23,7 +23,7 @@ try:
     if (sys.platform[:3] == "win"):
         try:
             CDLL(os.path.join(os.getenv("WINDIR", "C:/Windows"), "System32/nvml.dll"))
-        except OSError as ose:
+        except OSError:
             CDLL(os.path.join(os.getenv("ProgramFiles", "C:/Program Files"), "NVIDIA Corporation/NVSMI/nvml.dll"))
     else:
         CDLL(NVML_LIB)


### PR DESCRIPTION
#### Description
Fix regression in gpu module on Windows introduced in https://github.com/nicolargo/glances/commit/49d15b20dacf6a0fdf5931573f736782234f2a85 by adding additional handling for Windows. Same approach taken as in https://github.com/gpuopenanalytics/pynvml/blob/master/pynvml/nvml.py#L1787.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: n/a
