### PR TITLE
Bumped minimal Python version to 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
 

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Any and all contributions are greatly appreciated.
 Requirements
 ============
 
-- ``python>=3.8`` (use Glances 3.4.x for lower Python version)
+- ``python>=3.9`` (use Glances 3.4.x for lower Python version)
 - ``psutil`` (better with latest version)
 - ``defusedxml`` (in order to monkey patch xmlrpc)
 - ``packaging`` (for the version comparison)
@@ -90,7 +90,7 @@ Requirements
 
 *Note for Python 2 users*
 
-Glances version 4 or higher do not support Python 2 (and Python 3 < 3.8).
+Glances version 4 or higher do not support Python 2 (and Python 3 < 3.9).
 Please uses Glances version 3.4.x if you need Python 2 support.
 
 Optional dependencies:

--- a/glances/outputs/glances_restful_api.py
+++ b/glances/outputs/glances_restful_api.py
@@ -13,17 +13,8 @@ import socket
 import sys
 import tempfile
 import webbrowser
-from typing import Any, Union
+from typing import Annotated, Any, Union
 from urllib.parse import urljoin
-
-from glances.stats import GlancesStats
-
-try:
-    from typing import Annotated
-except ImportError:
-    # Only for Python 3.8
-    # To be removed when Python 3.8 support will be dropped
-    from typing_extensions import Annotated
 
 from glances import __apiversion__, __version__
 from glances.globals import json_dumps
@@ -31,6 +22,7 @@ from glances.logger import logger
 from glances.password import GlancesPassword
 from glances.servers_list import GlancesServersList
 from glances.servers_list_dynamic import GlancesAutoDiscoverClient
+from glances.stats import GlancesStats
 from glances.timer import Timer
 
 # FastAPI import

--- a/glances/plugins/gpu/cards/nvidia.py
+++ b/glances/plugins/gpu/cards/nvidia.py
@@ -20,7 +20,7 @@ try:
     # Avoid importing pynvml if NVML_LIB is not installed
     from ctypes import CDLL
 
-    if (sys.platform[:3] == "win"):
+    if sys.platform[:3] == "win":
         try:
             CDLL(os.path.join(os.getenv("WINDIR", "C:/Windows"), "System32/nvml.dll"))
         except OSError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ classifiers = [
   "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -34,7 +33,7 @@ keywords = ["cli", "curses", "monitoring", "system"]
 license = {text = "LGPLv3"}
 name = "Glances"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 urls.Homepage = "https://github.com/nicolargo/glances"
 
 [project.optional-dependencies]

--- a/tox.ini
+++ b/tox.ini
@@ -6,11 +6,11 @@
 
 [tox]
 envlist =
-    py38
     py39
     py310
     py311
     py312
+    py313
 
 [testenv]
 deps =


### PR DESCRIPTION
#### Description

Bumped minimal Python version to 3.9

#### Resume

* Python 3.8 is now [end of life](https://devguide.python.org/versions/)
* so doing, removed unused branch in `glances/outputs/glances_restful_api.py`
* branch introduced by f6545580dbd7e35174e7bda634a6be2b49030e56
* ruff also needs a bump; i.e, `s/py38/py39/`
* not done yet, since it needs to clear out warnings.