### PR TITLE
Implement More CPU Percentage Color Indicators #2995 

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -424,7 +424,7 @@ nice_warning=-20,-19,-18,-17,-16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2
 #export=.*firefox.*,pid:1234
 #
 # A username to display with critical colours. Example the 'root' user
-username_warning=root
+#username_warning=root
 
 [ports]
 disable=False

--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -422,6 +422,9 @@ nice_warning=-20,-19,-18,-17,-16,-15,-14,-13,-12,-11,-10,-9,-8,-7,-6,-5,-4,-3,-2
 # Define the list of processes to export using:
 # a comma-separated list of Glances filter
 #export=.*firefox.*,pid:1234
+#
+# A username to display with critical colours. Example the 'root' user
+username_warning=root
 
 [ports]
 disable=False

--- a/glances/plugins/processlist/__init__.py
+++ b/glances/plugins/processlist/__init__.py
@@ -317,7 +317,9 @@ class PluginModel(GlancesPluginModel):
             # docker internal users are displayed as ints only, therefore str()
             # Correct issue #886 on Windows OS
             msg = self.layout_stat['user'].format(str(p['username'])[:9])
-            ret = self.curse_add_line(msg)
+            
+            # Test to see if the colour will change as per the decoration
+            ret = self.curse_add_line(msg, decoration='CRITICAL')
         else:
             msg = self.layout_header['user'].format('?')
             ret = self.curse_add_line(msg)

--- a/glances/plugins/processlist/__init__.py
+++ b/glances/plugins/processlist/__init__.py
@@ -190,6 +190,12 @@ class PluginModel(GlancesPluginModel):
                 if args.export:
                     logger.info("Export process filter is set to: {}".format(config.as_dict()['processlist']['export']))
 
+        # For #2995. Load the username of a process to decorate with waning colours as from the config file.
+        if config is not None:
+            self.username_warning = config.get_value(self.plugin_name, 'username_warning')
+        else:
+            self.username_warning = ""
+
         # The default sort key could also be overwrite by command line (see #1903)
         if args and args.sort_processes_key is not None:
             glances_processes.set_sort_key(args.sort_processes_key, False)
@@ -319,7 +325,7 @@ class PluginModel(GlancesPluginModel):
             msg = self.layout_stat['user'].format(str(p['username'])[:9])
 
             # feature for #2995 adding the test to see if a user is root level
-            if (p['username'] == "root"):
+            if (p['username'] == self.username_warning):
                 # Set the decoration colour to be critical if the user is root
                 ret = self.curse_add_line(msg, decoration='CRITICAL')
             else:

--- a/glances/plugins/processlist/__init__.py
+++ b/glances/plugins/processlist/__init__.py
@@ -319,7 +319,7 @@ class PluginModel(GlancesPluginModel):
             msg = self.layout_stat['user'].format(str(p['username'])[:9])
 
             # feature for #2995 adding the test to see if a user is root level
-            if (msg == "root"):
+            if (msg == "root       "):
                 # Set the decoration colour to be critical if the user is root
                 ret = self.curse_add_line(msg, decoration='CRITICAL')
             else:

--- a/glances/plugins/processlist/__init__.py
+++ b/glances/plugins/processlist/__init__.py
@@ -325,7 +325,7 @@ class PluginModel(GlancesPluginModel):
             msg = self.layout_stat['user'].format(str(p['username'])[:9])
 
             # feature for #2995 adding the test to see if a user is root level
-            if (p['username'] == self.username_warning):
+            if (not (self.username_warning == "") and p['username'] == self.username_warning):
                 # Set the decoration colour to be critical if the user is root
                 ret = self.curse_add_line(msg, decoration='CRITICAL')
             else:

--- a/glances/plugins/processlist/__init__.py
+++ b/glances/plugins/processlist/__init__.py
@@ -263,14 +263,14 @@ class PluginModel(GlancesPluginModel):
         except KeyError:
             pass
         return 'DEFAULT'
-    
+
     def get_cpu_decoration(self, value):
         """Return the level of decoration needed for the CPU percentage based on the config file"""
         if value >= self.cpu_critical:
             return 'CRITICAL'
         elif value >= self.cpu_warning:
             return 'WARNING'
-        elif value >= self.cpu_warning:
+        elif value >= self.cpu_careful:
             return 'CAREFUL'
         else:
             return 'DEFAULT'

--- a/glances/plugins/processlist/__init__.py
+++ b/glances/plugins/processlist/__init__.py
@@ -317,9 +317,14 @@ class PluginModel(GlancesPluginModel):
             # docker internal users are displayed as ints only, therefore str()
             # Correct issue #886 on Windows OS
             msg = self.layout_stat['user'].format(str(p['username'])[:9])
-            
-            # Test to see if the colour will change as per the decoration
-            ret = self.curse_add_line(msg, decoration='CRITICAL')
+
+            # feature for #2995 adding the test to see if a user is root level
+            if (msg == "root"):
+                # Set the decoration colour to be critical if the user is root
+                ret = self.curse_add_line(msg, decoration='CRITICAL')
+            else:
+                # Set the decoration colour to be the default for all other users
+                ret = self.curse_add_line(msg, decoration='DEFAULT')
         else:
             msg = self.layout_header['user'].format('?')
             ret = self.curse_add_line(msg)

--- a/glances/plugins/processlist/__init__.py
+++ b/glances/plugins/processlist/__init__.py
@@ -319,7 +319,7 @@ class PluginModel(GlancesPluginModel):
             msg = self.layout_stat['user'].format(str(p['username'])[:9])
 
             # feature for #2995 adding the test to see if a user is root level
-            if (msg == "root       "):
+            if (p['username'] == "root"):
                 # Set the decoration colour to be critical if the user is root
                 ret = self.curse_add_line(msg, decoration='CRITICAL')
             else:


### PR DESCRIPTION
#### Description

Please describe the goal of this pull request.

This PR is adding a new option to the config file 
```
[processlist]
username_warning=root
```
And then performs and equality check in `glances/plugins/processlist/__init__.py` to see if there is any process with the same username and displays it with a `CRITICAL` decoration.

This PR also digs into the CPU percentage colour indicators and found some issues with the `get_alert()` function. There seems to be an issue with all non critical limits. Any warning or careful limit is not being used correctly in `get_alert()`. As I result I created a new function to bypass `get_alert()` for now so that #2995 is fully fixed and implemented.

I also had some issues with the linter and generating docs so I am sorry those parts are a little neglected in this PR.

#### Resume

* Bug fix: yes
* New feature: yes
* Fixed tickets: #2995
