### PR TITLE
default_config_dir: Fix config path to include glances/ directory

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -17,9 +17,9 @@ Location
 You can place your ``glances.conf`` file in the following locations:
 
 ==================== =============================================================
-``Linux``, ``SunOS`` ~/.config/glances/, /etc/glances/, /usr/share/docs/glances/
-``*BSD``             ~/.config/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
-``macOS``            ~/.config/glances/, ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
+``Linux``, ``SunOS`` ~/.config/glances/, /etc/glances/, /usr/share/doc/glances/
+``*BSD``             ~/.config/glances/, /usr/local/etc/glances/, /usr/share/doc/glances/
+``macOS``            ~/.config/glances/, ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/doc/glances/
 ``Windows``          %APPDATA%\\glances\\glances.conf
 ``All``              + <venv_root_folder>/share/doc/glances/
 ==================== =============================================================

--- a/docs/man/glances.1
+++ b/docs/man/glances.1
@@ -565,19 +565,19 @@ l|l.
 T{
 \fBLinux\fP, \fBSunOS\fP
 T}	T{
-~/.config/glances/, /etc/glances/, /usr/share/docs/glances/
+~/.config/glances/, /etc/glances/, /usr/share/doc/glances/
 T}
 _
 T{
 \fB*BSD\fP
 T}	T{
-~/.config/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
+~/.config/glances/, /usr/local/etc/glances/, /usr/share/doc/glances/
 T}
 _
 T{
 \fBmacOS\fP
 T}	T{
-~/.config/glances/, ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/docs/glances/
+~/.config/glances/, ~/Library/Application Support/glances/, /usr/local/etc/glances/, /usr/share/doc/glances/
 T}
 _
 T{

--- a/glances/config.py
+++ b/glances/config.py
@@ -81,18 +81,20 @@ def default_config_dir():
     - Linux, SunOS, *BSD, macOS: /usr/share/doc (as defined in the setup.py files)
     - Windows: %APPDATA%\glances
     """
-    path = []
-    # Add venv path (solve issue #2803)
-    if in_virtualenv():
-        path.append(os.path.join(sys.prefix, 'share', 'doc', 'glances'))
+    paths = []
 
-    # Add others system path
+    # Add system path
     if LINUX or SUNOS or BSD or MACOS:
-        path.append('/usr/share/doc')
+        paths.append(os.path.join(sys.prefix, 'share', 'doc'))
     else:
-        path.append(os.environ.get('APPDATA'))
+        paths.append(os.environ.get('APPDATA'))
 
-    return path
+    # If we are in venv (issue #2803), sys.prefix != sys.base_prefix and we
+    # already added venv path with sys.prefix. Add base_prefix path too
+    if in_virtualenv():
+        paths.append(os.path.join(sys.base_prefix, 'share', 'doc'))
+
+    return [os.path.join(path, 'glances') if path is not None else '' for path in paths]
 
 
 def in_virtualenv():


### PR DESCRIPTION
#### Description
Non-venv default config path was `/usr/share/doc/glances.conf` instead of `/usr/share/doc/glances/glances.conf` since a55970a.
Fix it and place the venv path to the end of the paths list, so it will have priority over the system default.

By the way, I'm not sure if we need to keep system default config path in venv, then we can delete `get_base_prefix_compat()` and `in_virtualenv()` functions, since they only check for sys.base_prefix != sys.prefix, and sys.prefix will point to venv when inside it and to `/usr` when outside

Also fixed some typos in docs on the way

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: no
