### PR TITLE
Ignore unsupported line endings in password file

### DIFF
--- a/glances/password.py
+++ b/glances/password.py
@@ -118,4 +118,4 @@ class GlancesPassword:
         """Load the hashed password from the Glances folder."""
         # Read the password file, if it exists
         with builtins.open(self.password_file) as file_pwd:
-            return file_pwd.read()
+            return file_pwd.read().strip()


### PR DESCRIPTION
#### Description

This simply fixes a small issue with password files, which can contain unsupported line endings depending on how they were created/edited. 

#### Resume

* Bug fix: yes
* New feature: no

Related to Issue/#2268
https://github.com/nicolargo/glances/issues/2268

Converted to Discussion/#2274
Comment of the behavior by Kankaristo:
https://github.com/nicolargo/glances/discussions/2274#discussioncomment-12500492