### PR TITLE
Fix matching problem when fs config has "show" value

### DIFF
--- a/glances/plugins/fs/__init__.py
+++ b/glances/plugins/fs/__init__.py
@@ -163,8 +163,8 @@ class PluginModel(GlancesPluginModel):
         # Loop over fs
         for fs in fs_stat:
             # Hide the stats if the mount point is in the exclude list
-            # It avoids unnecessary call to PsUtil disk_usage
-            if (not self.is_display(fs.mountpoint)) and (not self.is_display(fs.device)):
+            # # It avoids unnecessary call to PsUtil disk_usage
+            if not self.is_display_any(fs.mountpoint, fs.device):
                 continue
 
             # Grab the disk usage
@@ -236,7 +236,7 @@ class PluginModel(GlancesPluginModel):
             # Default behavior
             for fs, fs_value in fs_stat.item():
                 # Do not take hidden file system into account
-                if (not self.is_display(fs)) or (not self.is_display(fs_value['device_name'])):
+                if not self.is_display_any(fs, fs_value['device_name']):
                     continue
 
                 fs_current = {

--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -840,9 +840,8 @@ class GlancesPluginModel:
         show=sda.*
         """
         # TODO: possible optimisation: create a re.compile list
-        return any(
-            j for j in [re.fullmatch(i.lower(), value.lower()) for i in self.get_conf_value('show', header=header)]
-        )
+        # nguuuquaaa: no need a compile list, the re module caches the compiling itself
+        return any(re.fullmatch(i, value, re.I) for i in self.get_conf_value('show', header=header))
 
     def is_hide(self, value, header=""):
         """Return True if the value is in the hide configuration list.
@@ -853,9 +852,8 @@ class GlancesPluginModel:
         hide=sda2,sda5,loop.*
         """
         # TODO: possible optimisation: create a re.compile list
-        return any(
-            j for j in [re.fullmatch(i.lower(), value.lower()) for i in self.get_conf_value('hide', header=header)]
-        )
+        # nguuuquaaa: no need a compile list, the re module caches the compiling itself
+        return any(re.fullmatch(i, value, re.I) for i in self.get_conf_value('hide', header=header))
 
     def is_display(self, value, header=""):
         """Return True if the value should be displayed in the UI"""

--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -861,6 +861,12 @@ class GlancesPluginModel:
             return self.is_show(value, header=header)
         return not self.is_hide(value, header=header)
 
+    def is_display_any(self, *values, header=""):
+        """Return True if any of the values should be displayed in the UI"""
+        if self.get_conf_value('show', header=header) != []:
+            return any(self.is_show(value, header=header) for value in values)
+        return not any(self.is_hide(value, header=header) for value in values)
+
     def read_alias(self):
         if self.plugin_name + '_' + 'alias' in self._limits:
             return {i.split(':')[0].lower(): i.split(':')[1] for i in self._limits[self.plugin_name + '_' + 'alias']}


### PR DESCRIPTION
#### Description

Both GlancesPluginModel.is_hide and GlancesPluginModel.is_show has very bad case-insentitive regex matching implementation, and fs module has a double check on both mount point and device name that most of the time results in 0 match.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:
