### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "/run/user/1000/podman/podman.sock:/run/user/1000/podman/podman.sock:ro"
       - "./glances.conf:/glances/conf/glances.conf"
+#     # Uncomment for proper distro information in upper panel. 
+#     # Works only for distros that do have this file (most of distros do).
+#      - "/etc/os-release:/etc/os-release:ro"
     environment:
       - TZ=${TZ}
       - GLANCES_OPT=-C /glances/conf/glances.conf -w


### PR DESCRIPTION
#### Description
added commented out by default mount point for /etc/os-release. without it Glances container shows distibution information from container itself and not host system.

* Bug fix: no
* New feature: no
* Fixed tickets: none
