### PR TITLE
Fix prometheus export format

### DIFF
--- a/glances/exports/export.py
+++ b/glances/exports/export.py
@@ -225,7 +225,7 @@ class GlancesExport:
 
     def is_excluded(self, field):
         """Return true if the field is excluded."""
-        return hasattr(self, 'exclude_fields') and any(re.fullmatch(i, field, re.I) for i in self.exclude_fields)
+        return any(re.fullmatch(i, field, re.I) for i in (getattr(self, 'exclude_fields') or ()))
 
     def plugins_to_export(self, stats):
         """Return the list of plugins to export.

--- a/glances/exports/export.py
+++ b/glances/exports/export.py
@@ -152,7 +152,7 @@ class GlancesExport:
         d_tags = {}
         if tags:
             try:
-                d_tags = dict([x.split(":") for x in tags.split(",")])
+                d_tags = dict(x.split(":", 1) for x in tags.split(","))
             except ValueError:
                 # one of the 'key:value' pairs was missing
                 logger.info("Invalid tags passed: %s", tags)

--- a/glances/exports/glances_prometheus/__init__.py
+++ b/glances/exports/glances_prometheus/__init__.py
@@ -48,6 +48,7 @@ class Export(GlancesExport):
 
         self.plugin_to_object_label = {
             "amps": "app",
+            "containers": "container",
             "diskio": "device",
             "fs": "mount_point",
             "gpu": "name",

--- a/glances/exports/glances_prometheus/__init__.py
+++ b/glances/exports/glances_prometheus/__init__.py
@@ -73,17 +73,17 @@ class Export(GlancesExport):
         logger.debug(f"Export {name} stats to Prometheus exporter")
 
         # Remove non number stats and convert all to float (for Boolean)
-        data = {k: float(v) for k, v in zip(columns, points) if isinstance(v, Number)}
+        data = {str(k): float(v) for k, v in zip(columns, points) if isinstance(v, Number)}
 
         # Write metrics to the Prometheus exporter
         for metric, value in data.items():
-            metric = str(metric)
+            metric_name = self.prefix + self.METRIC_SEPARATOR + name + self.METRIC_SEPARATOR
             try:
                 obj, stat = metric.split('.')
-                metric_name = self.prefix + self.METRIC_SEPARATOR + str(name) + self.METRIC_SEPARATOR + stat
+                metric_name += stat
             except ValueError:
                 obj = ''
-                metric_name = self.prefix + self.METRIC_SEPARATOR + str(metric)
+                metric_name += metric
 
             # Prometheus is very sensible to the metric name
             # See: https://prometheus.io/docs/practices/naming/

--- a/glances/exports/glances_prometheus/__init__.py
+++ b/glances/exports/glances_prometheus/__init__.py
@@ -53,6 +53,8 @@ class Export(GlancesExport):
             "gpu": "name",
             "network": "interface",
             "percpu": "core",
+            "sensors": "object",
+            "wifi": "interface",
         }
 
     def init(self):


### PR DESCRIPTION
#### Description

### **This is a breaking change for anyone already relying on the affected metrics**


Using proper labels for prometheus metrics of specific plugins (amps, containers, diskio, fs, gpu, network, percpu, sensors, wifi) instead of exporting each individual object as it's own metric which is both hard to use and against prometheus best-practices.

For example, before this PR we exported the following FS metrics:

`glances_fs__etc_hostname_free{hostname="HOSTNAME"}` 

This PR changes this metrics to

`glances_fs_free{hostname="HOSTNAME",mnt_point="/etc/hostname"}`

The used labels are the return value of each plugin's `get_key()`. 
At the moment these are:

- amps: name
- containers: name
- diskio: disk_name
- fs: mnt_point
- gpu: gpu_id
- network: interface_name
- percpu: cpu_number
- sensors: label
- wifi: ssid

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #3166 
