### PR TITLE
Label error in docs

### DIFF
--- a/docs/aoa/network.rst
+++ b/docs/aoa/network.rst
@@ -72,7 +72,7 @@ can also be used to set a threshold higher than zero.
 
 .. code-block:: ini
 
-    [diskio]
+    [network]
     hide_zero=True
     hide_threshold_bytes=0
 


### PR DESCRIPTION
Fix labeling error

#### Description

diskio label instead of network label in documentation.

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: n/a