### PR TITLE
support for Python from 3.9 to 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
       - name: Install pypa/build
         run: >-
           python3 -m

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     py311
     py312
     py313
+    py314
 
 [testenv]
 deps =


### PR DESCRIPTION
Good morning,

I would like to discover the git workflow in open-source projects.

Thanks for your understanding,

#### Description

Python 3.9 is end of life, and Python 3.14 is released.

Link: https://devguide.python.org/versions/

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: