### PR TITLE
Fix quicklook in case psutil.cpu_freq().max=0.0

### DIFF
--- a/glances/cpu_percent.py
+++ b/glances/cpu_percent.py
@@ -84,7 +84,7 @@ class CpuPercent:
                     self.cpu_info['cpu_hz_current'] = cpu_freq.current
                 else:
                     self.cpu_info['cpu_hz_current'] = None
-                if hasattr(cpu_freq, 'max'):
+                if hasattr(cpu_freq, 'max') and cpu_freq.max != 0.0:
                     self.cpu_info['cpu_hz'] = cpu_freq.max
                 else:
                     self.cpu_info['cpu_hz'] = None

--- a/glances/plugins/quicklook/__init__.py
+++ b/glances/plugins/quicklook/__init__.py
@@ -205,12 +205,18 @@ class QuicklookPlugin(GlancesPluginModel):
         if (
             'cpu_hz_current' in self.stats
             and self.stats['cpu_hz_current'] is not None
-            and 'cpu_hz' in self.stats
-            and self.stats['cpu_hz'] is not None
         ):
-            msg_freq = ' {:.2f}/{:.2f}GHz'.format(
-                self._hz_to_ghz(self.stats['cpu_hz_current']), self._hz_to_ghz(self.stats['cpu_hz'])
-            )
+            if (
+                'cpu_hz' in self.stats
+                and self.stats['cpu_hz'] is not None
+            ):
+                msg_freq = ' {:.2f}/{:.2f}GHz'.format(
+                    self._hz_to_ghz(self.stats['cpu_hz_current']), self._hz_to_ghz(self.stats['cpu_hz'])
+                )
+            else:
+                msg_freq = ' {:.2f}GHz'.format(
+                    self._hz_to_ghz(self.stats['cpu_hz_current'])
+                )
         else:
             msg_freq = ''
 


### PR DESCRIPTION
#### Description

Inside WSL2, quicklook reports CPU frequencies like `2.00/0.00GHz`.

[`psutil.cpu_freq()`](https://psutil.readthedocs.io/en/latest/#psutil.cpu_freq) may return 0.0 for `max` if not available, which is the case inside WSL2. The PR changes quicklook to show only the current freq in this case.

As a separate issue not addressed by the PR, current freq doesn't vary inside (my) WSL2 and is constantly cpu base frequency.

#### Resume

* Bug fix: yes
* New feature: no