### PR TITLE
fix(security): resolve B701 (Jinja2) and B113 (timeout) vulnerabilities

### DIFF
--- a/glances/amps/nginx/__init__.py
+++ b/glances/amps/nginx/__init__.py
@@ -66,7 +66,7 @@ class Amp(GlancesAmp):
         """Update the AMP"""
         # Get the Nginx status
         logger.debug('{}: Update stats using status URL {}'.format(self.NAME, self.get('status_url')))
-        res = requests.get(self.get('status_url'))
+        res = requests.get(self.get('status_url'), timeout=15)
         if res.ok:
             # u'Active connections: 1 \nserver accepts handled requests\n 1 1 1 \nReading: 0 Writing: 1 Waiting: 0 \n'
             self.set_result(res.text.rstrip())

--- a/glances/exports/glances_restful/__init__.py
+++ b/glances/exports/glances_restful/__init__.py
@@ -54,7 +54,7 @@ class Export(GlancesExport):
             # One complete loop have been done
             logger.debug(f"Export stats ({listkeys(self.buffer)}) to RESTful endpoint ({self.client})")
             # Export stats
-            post(self.client, json=self.buffer, allow_redirects=True)
+            post(self.client, json=self.buffer, allow_redirects=True, timeout=15)
             # Reset buffer
             self.buffer = {}
 

--- a/glances/outputs/glances_stdout_fetch.py
+++ b/glances/outputs/glances_stdout_fetch.py
@@ -78,7 +78,7 @@ class GlancesStdoutFetch:
                 fetch_template = f.read()
 
         # Create a Jinja2 environment
-        jinja_env = jinja2.Environment(loader=jinja2.BaseLoader())
+        jinja_env = jinja2.Environment(loader=jinja2.BaseLoader(), autoescape=True)
         template = jinja_env.from_string(fetch_template)
         output = template.render(gl=self.gl)
         print(output)


### PR DESCRIPTION
Fixes #3353

## Description
Addressed security vulnerabilities identified by Bandit scan:
1.  **High Severity (B701)**: Enable `autoescape=True` for Jinja2 environment in `glances/outputs/glances_stdout_fetch.py` to mitigate XSS risks.
2.  **Medium Severity (B113)**: Added explicit `timeout=15` to `requests` calls in:
    - `glances/amps/nginx/__init__.py`
    - `glances/exports/glances_restful/__init__.py`

## Verification
- Ran `bandit -r glances` to verify issues are resolved.
- Ran `python -m pytest tests/test_core.py` (All passed).
- Ran `python -m pytest tests/test_restful.py` (Tests involving unmodified components passed; local container-related failures unrelated to changes).