### PR TITLE
Potential fix for code scanning alert no. 47: Clear-text logging of sensitive information

### DIFF
--- a/glances/client.py
+++ b/glances/client.py
@@ -68,7 +68,8 @@ class GlancesClient:
         try:
             self.client = xmlrpc.xmlrpc_client.ServerProxy(self.uri, transport=transport)
         except Exception as e:
-            self.log_and_exit(f"Client couldn't create socket {self.uri}: {e}")
+            # Do not log self.uri here because it may contain credentials
+            self.log_and_exit(f"Client couldn't create socket to http://{args.client}:{args.port}: {e}")
 
     @property
     def quiet(self):


### PR DESCRIPTION
Potential fix for [https://github.com/nicolargo/glances/security/code-scanning/47](https://github.com/nicolargo/glances/security/code-scanning/47)

In general, to fix clear-text logging of sensitive data, avoid including secrets (passwords, tokens, full auth-bearing URIs) in log messages. Instead, either omit those fields entirely or log only non-sensitive parts (e.g., host and port). If you must retain some identifier, mask or redact the secret before logging.

For this specific code, the best fix without changing existing functionality is:
- Keep using `self.uri` internally for connecting (so connection behavior is unchanged).
- Ensure that any error message passed to `log_and_exit` does not contain `self.uri` with embedded credentials.
- Instead, construct a “safe” connection description that only contains non-sensitive data (host, port, maybe username if considered non-secret) and use that in error messages.

Concretely:
- In `glances/client.py`, in `__init__`, replace the `except` block so that it calls `log_and_exit` with a message that does not reference `self.uri`. For example, use `args.client` and `args.port` only: `"Client couldn't create socket to http://{args.client}:{args.port}: {e}"`. This keeps useful context while removing the password.
- In `log_and_exit`, keep logging `msg` as is; once `msg` no longer includes credentials, the critical log is safe.
- No changes are needed in `glances/client_browser.py` beyond existing behavior, as the sensitive flow is already addressed by removing credential-bearing URIs from log messages.
- No change is strictly required in `tests/test_xmlrpc.py` for security (username/password are empty), and we are not logging those values there. The main tainted flow is eliminated by the change in `glances/client.py`.

No new imports or helper methods are necessary; we only adjust the error message string construction in the shown snippet of `glances/client.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
