### PR TITLE
Add background color to UI plugin blocks for visual distinction

### DIFF
--- a/glances/outputs/static/css/style.scss
+++ b/glances/outputs/static/css/style.scss
@@ -165,7 +165,14 @@ body {
 // Plugins
 
 .plugin {
-    margin-bottom: 1em;
+    background-color: #282c34;
+    border-radius: 4px;
+    padding: 4px;
+    margin: 4px 2px 4px 2px;
+}
+
+.header .plugin {
+    background-color: transparent;
 }
 
 .button {


### PR DESCRIPTION
## Summary

- Apply background-color: #282c34 to all .plugin sections for visual distinction
- Add border-radius: 4px, padding: 4px, margin: 4px 2px 4px 2px to create card-style layout
- Override .header .plugin to keep header transparent
- Creates card-style layout with consistent dark theme

## Changes

**File Modified:** glances/outputs/static/css/style.scss

## Testing

- Changes verified in Firefox DevTools
- Background color successfully compiled into glances.js

## Motivation

The new background color provides better visual separation between monitoring blocks, making the UI more readable and organized while maintaining the overall dark theme consistency.