### PR TITLE
Add key for DeviceName in SMART data

### DIFF
--- a/glances/plugins/smart/__init__.py
+++ b/glances/plugins/smart/__init__.py
@@ -229,7 +229,8 @@ class SmartPlugin(GlancesPluginModel):
 
         if self.input_method == 'local':
             # Update stats and hide some sensors(#2996)
-            stats = [s for s in get_smart_data(self.hide_attributes) if self.is_display(s[self.get_key()])]
+            stats = [dict(s, key=self.get_key()) for s in get_smart_data(
+                self.hide_attributes) if self.is_display(s[self.get_key()])]
         elif self.input_method == 'snmp':
             pass
 


### PR DESCRIPTION
#### Description

When SMART stats are updated, the top level dict (per-device stats), is missing the `key` property. This prevents the SMART stats from multiple devices to be filtered by device name when exported.

For reference, in the plugins/diskio update function: https://github.com/nicolargo/glances/blob/c24d3de65199d8ebad7c09e0a6a7ae0b3d629bf5/glances/plugins/diskio/__init__.py#L166

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: N/A
