### PR TITLE
Enhance plugins to compute min/max/mean stats since Glances startup

### DIFF
--- a/docs/aoa/memory.rst
+++ b/docs/aoa/memory.rst
@@ -40,9 +40,11 @@ Additional stats available in through the API:
   never moved to disk.
 - **shared**: (BSD): memory that may be simultaneously accessed by multiple
   processes.
-- **min_percent**: the minimum memory usage percentage observed since
+- **percent_min**: the minimum memory usage percentage observed since
   Glances startup.
-- **max_percent**: the maximum memory usage percentage observed since
+- **percent_max**: the maximum memory usage percentage observed since
+  Glances startup.
+- **percent_mean**: the mean memory usage percentage observed since
   Glances startup.
 
 It is possible to display the available memory instead of the used memory

--- a/glances/plugins/mem/__init__.py
+++ b/glances/plugins/mem/__init__.py
@@ -28,14 +28,7 @@ and it is supposed to be used to monitor actual memory usage in a cross platform
     'percent': {
         'description': 'The percentage usage calculated as (total - available) / total * 100.',
         'unit': 'percent',
-    },
-    'min_percent': {
-        'description': 'Minimum memory usage percentage observed since Glances startup.',
-        'unit': 'percent',
-    },
-    'max_percent': {
-        'description': 'Maximum memory usage percentage observed since Glances startup.',
-        'unit': 'percent',
+        'mmm': True
     },
     'used': {
         'description': 'Memory used, calculated differently depending on the platform and \
@@ -139,10 +132,6 @@ class MemPlugin(GlancesPluginModel):
 
         # ZFS
         self.zfs_enabled = zfs_enable()
-
-        # Runtime min/max memory usage percentage tracking (since Glances startup)
-        self._min_percent = None
-        self._max_percent = None
 
         # We want to display the stat in the curse interface
         self.display_curse = True
@@ -261,34 +250,10 @@ class MemPlugin(GlancesPluginModel):
 
         return stats
 
-    def _track_min_max_percent(self, stats):
-        """Track runtime min/max memory usage percentage since Glances startup.
-
-        The min/max values are stored as private attributes so they survive
-        the stats dict rebuild on every update. They are then exposed in the
-        stats dict (and thus via the /api/4/mem endpoint) as 'min_percent'
-        and 'max_percent'.
-        """
-        current_percent = stats.get('percent')
-        if current_percent is None:
-            # Cannot track without a percent value; keep previous values if any
-            if self._min_percent is not None:
-                stats['min_percent'] = self._min_percent
-            if self._max_percent is not None:
-                stats['max_percent'] = self._max_percent
-            return
-
-        # Initialize on first run, otherwise update the running min/max
-        if self._min_percent is None or current_percent < self._min_percent:
-            self._min_percent = current_percent
-        if self._max_percent is None or current_percent > self._max_percent:
-            self._max_percent = current_percent
-
-        stats['min_percent'] = self._min_percent
-        stats['max_percent'] = self._max_percent
 
     @GlancesPluginModel._check_decorator
     @GlancesPluginModel._log_result_decorator
+    @GlancesPluginModel._manage_mmm
     def update(self):
         """Update RAM memory stats using the input method."""
         init = self.get_init_value()
@@ -302,9 +267,6 @@ class MemPlugin(GlancesPluginModel):
 
         if stats in ['reset']:
             return self.stats
-
-        # Track runtime min/max memory usage percentage since Glances startup
-        self._track_min_max_percent(stats)
 
         # Update the stats
         self.stats = stats

--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -132,6 +132,9 @@ class GlancesPluginModel:
         # Init stats description
         self.fields_description = fields_description
 
+        # Init MMM (Min/Max/Mean) tracking for fields with mmm=True
+        self._mmm_fields = self._init_mmm_fields()
+
         # Init the stats
         self.stats_init_value = stats_init_value
         self.time_since_last_update = None
@@ -179,6 +182,120 @@ class GlancesPluginModel:
     def get_init_value(self):
         """Return a copy of the init value."""
         return copy.copy(self.stats_init_value)
+
+    def _init_mmm_fields(self):
+        """Initialize MMM (Min/Max/Mean) field tracking.
+        
+        Scan fields_description for fields with mmm=True and create tracking structures.
+        Also automatically add field descriptions for the generated fields.
+        
+        Returns a dictionary with mmm field tracking info.
+        """
+        mmm_fields = {}
+        
+        if self.fields_description is None:
+            return mmm_fields
+        
+        # Find all fields with mmm=True (iterate over keys to avoid dict size change during iteration)
+        mmm_field_names = [
+            field_name for field_name, field_info in self.fields_description.items()
+            if field_info.get('mmm', False)
+        ]
+        
+        # Now process the mmm fields
+        for field_name in mmm_field_names:
+            field_info = self.fields_description[field_name]
+            
+            # Initialize tracking for this field
+            mmm_fields[field_name] = {
+                'values': [],  # Keep history for mean calculation
+                'min': None,
+                'max': None,
+                'unit': field_info.get('unit', ''),
+            }
+            
+            # Automatically add field descriptions for the generated fields if not already present
+            suffix_map = {
+                '_min': f"Minimum {field_name} observed since Glances startup.",
+                '_max': f"Maximum {field_name} observed since Glances startup.",
+                '_mean': f"Mean (average) {field_name} computed from the history.",
+            }
+            
+            for suffix, description in suffix_map.items():
+                generated_field = field_name + suffix
+                if generated_field not in self.fields_description:
+                    self.fields_description[generated_field] = {
+                        'description': description,
+                        'unit': field_info.get('unit', ''),
+                    }
+        
+        return mmm_fields
+
+    def _update_mmm_fields(self, stats):
+        """Update MMM (Min/Max/Mean) fields for all fields with mmm=True.
+        
+        This method should be called after the plugin's update method.
+        It will compute and add _min, _max, and _mean fields to stats.
+        
+        Args:
+            stats: The stats dictionary to update (should be a dict or dict from list item)
+        
+        Returns:
+            The stats dictionary with mmm fields added
+        """
+        if not isinstance(stats, dict) or not self._mmm_fields:
+            return stats
+        
+        # Update mmm fields for each tracked field
+        for field_name, mmm_info in self._mmm_fields.items():
+            if field_name not in stats:
+                continue
+            
+            current_value = stats[field_name]
+            
+            # Only process numeric values
+            if current_value is None or (not isinstance(current_value, (int, float))):
+                continue
+            
+            # Keep history for mean calculation (limit to reasonable size to avoid memory growth)
+            max_history_size = 28800  # ~1 day at 1 sample/sec
+            mmm_info['values'].append(current_value)
+            if len(mmm_info['values']) > max_history_size:
+                mmm_info['values'].pop(0)
+            
+            # Update min and max
+            if mmm_info['min'] is None or current_value < mmm_info['min']:
+                mmm_info['min'] = current_value
+            if mmm_info['max'] is None or current_value > mmm_info['max']:
+                mmm_info['max'] = current_value
+            
+            # Add generated fields to stats
+            stats[field_name + '_min'] = mmm_info['min']
+            stats[field_name + '_max'] = mmm_info['max']
+            
+            # Compute mean from history
+            if mmm_info['values']:
+                stats[field_name + '_mean'] = round(mean(mmm_info['values']), 2)
+        
+        return stats
+
+    def _update_mmm_fields_on_list(self, stats_list):
+        """Update MMM fields for a list of stats dictionaries.
+        
+        Args:
+            stats_list: A list of stats dictionaries
+        
+        Returns:
+            The list with mmm fields updated for each item
+        """
+        if not isinstance(stats_list, list):
+            return stats_list
+        
+        for stat in stats_list:
+            if isinstance(stat, dict):
+                self._update_mmm_fields(stat)
+        
+        return stats_list
 
     def reset(self):
         """Reset the stats.
@@ -1252,7 +1369,30 @@ class GlancesPluginModel:
 
         return wrapper
 
+    def _manage_mmm(fct):
+        """Manage MMM (Min/Max/Mean) decorator for update method.
+        
+        Automatically computes and adds min/max/mean fields for any field with mmm=True.
+        """
+
+        def wrapper(self, *args, **kw):
+            # Call the father method
+            stats = fct(self, *args, **kw)
+
+            # Update MMM fields
+            if isinstance(stats, dict):
+                # Stats is a dict
+                self._update_mmm_fields(stats)
+            elif isinstance(stats, list):
+                # Stats is a list
+                self._update_mmm_fields_on_list(stats)
+
+            return stats
+
+        return wrapper
+
     # Mandatory to call the decorator in child classes
     _check_decorator = staticmethod(_check_decorator)
     _log_result_decorator = staticmethod(_log_result_decorator)
     _manage_rate = staticmethod(_manage_rate)
+    _manage_mmm = staticmethod(_manage_mmm)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -955,6 +955,311 @@ class TestGlances(unittest.TestCase):
         plugin_instance.update_views()
         self.assertFalse(plugin_instance.get_views()[key][field]['hidden'])
 
+    def test_700_mmm_feature_parent_class(self):
+        """Test MMM (Min/Max/Mean) feature in parent class."""
+        print('INFO: [TEST_700] MMM Feature (Min/Max/Mean) in parent class')
+        
+        # Create a test plugin with MMM enabled
+        test_fields = {
+            'value': {
+                'description': 'A test value',
+                'unit': 'percent',
+                'mmm': True
+            },
+            'other': {
+                'description': 'A value without MMM',
+                'unit': 'bytes'
+            }
+        }
+        
+        class TestMMMPlugin(GlancesPluginModel):
+            def __init__(self):
+                super().__init__(
+                    args=None,
+                    config=None,
+                    fields_description=test_fields
+                )
+        
+        plugin = TestMMMPlugin()
+        
+        # Test 1: MMM fields initialized
+        self.assertIn('value', plugin._mmm_fields, "value field should be in _mmm_fields")
+        self.assertNotIn('other', plugin._mmm_fields, "other field should NOT be in _mmm_fields")
+        
+        # Test 2: Auto-generated descriptions exist
+        self.assertIn('value_min', plugin.fields_description, "value_min description should be auto-generated")
+        self.assertIn('value_max', plugin.fields_description, "value_max description should be auto-generated")
+        self.assertIn('value_mean', plugin.fields_description, "value_mean description should be auto-generated")
+        
+        # Test 3: Units are inherited
+        self.assertEqual(plugin.fields_description['value_min']['unit'], 'percent')
+        self.assertEqual(plugin.fields_description['value_max']['unit'], 'percent')
+        self.assertEqual(plugin.fields_description['value_mean']['unit'], 'percent')
+        
+        # Test 4: MMM field structure is correct
+        mmm_info = plugin._mmm_fields['value']
+        self.assertIn('values', mmm_info, "values list should exist")
+        self.assertIn('min', mmm_info, "min should exist")
+        self.assertIn('max', mmm_info, "max should exist")
+        self.assertIn('unit', mmm_info, "unit should exist")
+        self.assertIsNone(mmm_info['min'], "min should start as None")
+        self.assertIsNone(mmm_info['max'], "max should start as None")
+
+    def test_701_mmm_update_functionality(self):
+        """Test MMM update functionality."""
+        print('INFO: [TEST_701] MMM update functionality')
+        
+        test_fields = {
+            'temperature': {
+                'description': 'Temperature in Celsius',
+                'unit': 'celsius',
+                'mmm': True
+            }
+        }
+        
+        class TestMMMPlugin(GlancesPluginModel):
+            def __init__(self):
+                super().__init__(
+                    args=None,
+                    config=None,
+                    fields_description=test_fields
+                )
+        
+        plugin = TestMMMPlugin()
+        
+        # Test 1: First update
+        stats = {'temperature': 50.0}
+        updated_stats = plugin._update_mmm_fields(stats)
+        
+        self.assertIn('temperature_min', updated_stats)
+        self.assertIn('temperature_max', updated_stats)
+        self.assertIn('temperature_mean', updated_stats)
+        self.assertEqual(updated_stats['temperature_min'], 50.0)
+        self.assertEqual(updated_stats['temperature_max'], 50.0)
+        self.assertEqual(updated_stats['temperature_mean'], 50.0)
+        
+        # Test 2: Second update with higher value
+        stats = {'temperature': 60.0}
+        updated_stats = plugin._update_mmm_fields(stats)
+        
+        self.assertEqual(updated_stats['temperature_min'], 50.0, "min should not increase")
+        self.assertEqual(updated_stats['temperature_max'], 60.0, "max should increase")
+        self.assertLess(50.0, updated_stats['temperature_mean'])
+        self.assertLess(updated_stats['temperature_mean'], 60.0)
+        
+        # Test 3: Third update with lower value
+        stats = {'temperature': 40.0}
+        updated_stats = plugin._update_mmm_fields(stats)
+        
+        self.assertEqual(updated_stats['temperature_min'], 40.0, "min should decrease")
+        self.assertEqual(updated_stats['temperature_max'], 60.0, "max should not decrease")
+
+    def test_702_mmm_mean_calculation(self):
+        """Test MMM mean calculation is correct."""
+        print('INFO: [TEST_702] MMM mean calculation')
+        
+        test_fields = {
+            'value': {
+                'description': 'A test value',
+                'unit': 'percent',
+                'mmm': True
+            }
+        }
+        
+        class TestMMMPlugin(GlancesPluginModel):
+            def __init__(self):
+                super().__init__(
+                    args=None,
+                    config=None,
+                    fields_description=test_fields
+                )
+        
+        plugin = TestMMMPlugin()
+        
+        # Add known values
+        test_values = [10.0, 20.0, 30.0, 40.0, 50.0]
+        for val in test_values:
+            stats = {'value': val}
+            updated_stats = plugin._update_mmm_fields(stats)
+        
+        # Expected mean of all values
+        expected_mean = sum(test_values) / len(test_values)
+        
+        self.assertAlmostEqual(updated_stats['value_mean'], expected_mean, places=1)
+        # Also verify min and max
+        self.assertEqual(updated_stats['value_min'], min(test_values))
+        self.assertEqual(updated_stats['value_max'], max(test_values))
+
+    def test_703_mmm_history_limit(self):
+        """Test MMM history respects size limit."""
+        print('INFO: [TEST_703] MMM history respects size limit')
+        
+        test_fields = {
+            'value': {
+                'description': 'A test value',
+                'unit': 'percent',
+                'mmm': True
+            }
+        }
+        
+        class TestMMMPlugin(GlancesPluginModel):
+            def __init__(self):
+                super().__init__(
+                    args=None,
+                    config=None,
+                    fields_description=test_fields
+                )
+        
+        plugin = TestMMMPlugin()
+        
+        # Check default limit
+        max_history_size = 28800
+        
+        # Add values but only a reasonable number (not the full limit to keep test fast)
+        test_iterations = 100
+        for i in range(test_iterations):
+            stats = {'value': float(i % 100)}
+            plugin._update_mmm_fields(stats)
+        
+        # History should not exceed limit
+        mmm_info = plugin._mmm_fields['value']
+        self.assertLessEqual(len(mmm_info['values']), max_history_size)
+        # Should have roughly the number we added (100)
+        self.assertEqual(len(mmm_info['values']), test_iterations)
+
+    def test_704_mmm_handles_list_of_dicts(self):
+        """Test MMM update can handle list of stats dictionaries."""
+        print('INFO: [TEST_704] MMM handles list of dicts')
+        
+        test_fields = {
+            'utilization': {
+                'description': 'Utilization percent',
+                'unit': 'percent',
+                'mmm': True
+            }
+        }
+        
+        class TestMMMPlugin(GlancesPluginModel):
+            def __init__(self):
+                super().__init__(
+                    args=None,
+                    config=None,
+                    fields_description=test_fields
+                )
+        
+        plugin = TestMMMPlugin()
+        
+        # Create a list of stats
+        stats_list = [
+            {'name': 'item1', 'utilization': 50.0},
+            {'name': 'item2', 'utilization': 60.0},
+            {'name': 'item3', 'utilization': 40.0},
+        ]
+        
+        # Update with list
+        updated_list = plugin._update_mmm_fields_on_list(stats_list)
+        
+        # Check that each item has MMM fields
+        for item in updated_list:
+            self.assertIn('utilization_min', item)
+            self.assertIn('utilization_max', item)
+            self.assertIn('utilization_mean', item)
+
+    def test_705_mmm_ignores_non_numeric_values(self):
+        """Test MMM ignores non-numeric values."""
+        print('INFO: [TEST_705] MMM ignores non-numeric values')
+        
+        test_fields = {
+            'status': {
+                'description': 'Status string',
+                'unit': 'string',
+                'mmm': True
+            }
+        }
+        
+        class TestMMMPlugin(GlancesPluginModel):
+            def __init__(self):
+                super().__init__(
+                    args=None,
+                    config=None,
+                    fields_description=test_fields
+                )
+        
+        plugin = TestMMMPlugin()
+        
+        # Try to update with non-numeric value
+        stats = {'status': 'active'}
+        updated_stats = plugin._update_mmm_fields(stats)
+        
+        # Non-numeric values should not create MMM fields (or they should be None)
+        if 'status_min' in updated_stats:
+            self.assertIsNone(updated_stats.get('status_min'))
+
+    def test_706_mmm_decorator_integration(self):
+        """Test MMM decorator integration with update method."""
+        print('INFO: [TEST_706] MMM decorator integration')
+        
+        test_fields = {
+            'cpu': {
+                'description': 'CPU usage',
+                'unit': 'percent',
+                'mmm': True
+            }
+        }
+        
+        class TestMMMPlugin(GlancesPluginModel):
+            def __init__(self):
+                super().__init__(
+                    args=None,
+                    config=None,
+                    fields_description=test_fields
+                )
+            
+            @GlancesPluginModel._manage_mmm
+            def test_update(self):
+                """Test method with MMM decorator."""
+                return {'cpu': 50.5}
+        
+        plugin = TestMMMPlugin()
+        
+        # Call the decorated method
+        result = plugin.test_update()
+        
+        # Should have MMM fields
+        self.assertIn('cpu_min', result)
+        self.assertIn('cpu_max', result)
+        self.assertIn('cpu_mean', result)
+
+    def test_707_mmm_with_mem_plugin(self):
+        """Test MMM integration with actual MemPlugin."""
+        print('INFO: [TEST_707] MMM integration with MemPlugin')
+        
+        # Get the mem plugin from stats
+        mem_plugin = stats.get_plugin('mem')
+        
+        # Verify percent field has MMM enabled
+        self.assertTrue(mem_plugin.fields_description['percent'].get('mmm', False))
+        
+        # Verify MMM fields are in fields_description
+        self.assertIn('percent_min', mem_plugin.fields_description)
+        self.assertIn('percent_max', mem_plugin.fields_description)
+        self.assertIn('percent_mean', mem_plugin.fields_description)
+        
+        # Update and verify stats contain MMM fields
+        mem_plugin.update()
+        raw_stats = mem_plugin.get_raw()
+        
+        self.assertIn('percent', raw_stats)
+        self.assertIn('percent_min', raw_stats)
+        self.assertIn('percent_max', raw_stats)
+        self.assertIn('percent_mean', raw_stats)
+        
+        # Verify relationships
+        self.assertLessEqual(raw_stats['percent_min'], raw_stats['percent'])
+        self.assertGreaterEqual(raw_stats['percent_max'], raw_stats['percent'])
+        self.assertLessEqual(raw_stats['percent_min'], raw_stats['percent_mean'])
+        self.assertGreaterEqual(raw_stats['percent_max'], raw_stats['percent_mean'])
+
     # def test_700_secure(self):
     #     """Test secure functions"""
     #     print('INFO: [TEST_700] Secure functions')

--- a/tests/test_plugin_mem.py
+++ b/tests/test_plugin_mem.py
@@ -305,8 +305,12 @@ class TestMemPluginExport:
             assert 'total' in export
 
 
-class TestMemPluginMinMaxPercent:
-    """Test Memory plugin runtime min/max percent tracking."""
+class TestMemPluginMMM:
+    """Test Memory plugin MMM (Min/Max/Mean) feature.
+    
+    The MMM feature automatically tracks minimum, maximum, and mean values
+    for fields marked with 'mmm': True in fields_description.
+    """
 
     @staticmethod
     def _force_update(plugin):
@@ -315,157 +319,199 @@ class TestMemPluginMinMaxPercent:
         The session-scoped glances_stats fixture means the plugin instance is
         shared across tests and, because update() is throttled by a refresh
         timer (default 2s), back-to-back calls can be no-ops. Expiring the
-        timer ensures update() really runs so the min/max trackers are fed.
+        timer ensures update() really runs so the min/max/mean trackers are fed.
         """
         from glances.timer import Timer
 
         plugin.refresh_timer = Timer(0)
         plugin.update()
 
-    def test_min_max_percent_attributes_exist(self, mem_plugin):
-        """Test that min/max percent tracking attributes are initialized."""
-        assert hasattr(mem_plugin, '_min_percent')
-        assert hasattr(mem_plugin, '_max_percent')
+    def test_percent_field_has_mmm_flag(self, mem_plugin):
+        """Test that percent field is marked with mmm=True."""
+        assert 'percent' in mem_plugin.fields_description
+        assert mem_plugin.fields_description['percent'].get('mmm', False) is True
 
-    def test_min_max_percent_in_fields_description(self, mem_plugin):
-        """Test that min_percent and max_percent are described."""
-        assert 'min_percent' in mem_plugin.fields_description
-        assert 'max_percent' in mem_plugin.fields_description
-        assert mem_plugin.fields_description['min_percent']['unit'] == 'percent'
-        assert mem_plugin.fields_description['max_percent']['unit'] == 'percent'
-        assert 'description' in mem_plugin.fields_description['min_percent']
-        assert 'description' in mem_plugin.fields_description['max_percent']
+    def test_mmm_fields_initialized(self, mem_plugin):
+        """Test that _mmm_fields is initialized for tracking."""
+        assert hasattr(mem_plugin, '_mmm_fields')
+        assert isinstance(mem_plugin._mmm_fields, dict)
+        # percent field should be in mmm_fields
+        assert 'percent' in mem_plugin._mmm_fields
 
-    def test_min_max_percent_present_after_update(self, mem_plugin):
-        """Test that min_percent and max_percent are present after an update."""
+    def test_mmm_field_structure(self, mem_plugin):
+        """Test that mmm field tracking structure is correct."""
+        assert 'percent' in mem_plugin._mmm_fields
+        mmm_info = mem_plugin._mmm_fields['percent']
+        assert 'values' in mmm_info
+        assert 'min' in mmm_info
+        assert 'max' in mmm_info
+        assert 'unit' in mmm_info
+        assert mmm_info['unit'] == 'percent'
+
+    def test_percent_min_max_mean_generated_descriptions(self, mem_plugin):
+        """Test that min/max/mean field descriptions are auto-generated."""
+        assert 'percent_min' in mem_plugin.fields_description
+        assert 'percent_max' in mem_plugin.fields_description
+        assert 'percent_mean' in mem_plugin.fields_description
+        
+        # Check descriptions exist
+        assert 'description' in mem_plugin.fields_description['percent_min']
+        assert 'description' in mem_plugin.fields_description['percent_max']
+        assert 'description' in mem_plugin.fields_description['percent_mean']
+        
+        # Check units match
+        assert mem_plugin.fields_description['percent_min']['unit'] == 'percent'
+        assert mem_plugin.fields_description['percent_max']['unit'] == 'percent'
+        assert mem_plugin.fields_description['percent_mean']['unit'] == 'percent'
+
+    def test_percent_min_max_mean_in_stats_after_update(self, mem_plugin):
+        """Test that percent_min, percent_max, and percent_mean appear in stats after update."""
         self._force_update(mem_plugin)
         stats = mem_plugin.get_raw()
-        assert 'min_percent' in stats, "min_percent missing from stats"
-        assert 'max_percent' in stats, "max_percent missing from stats"
+        assert 'percent' in stats
+        assert 'percent_min' in stats, "percent_min missing from stats"
+        assert 'percent_max' in stats, "percent_max missing from stats"
+        assert 'percent_mean' in stats, "percent_mean missing from stats"
 
-    def test_min_max_percent_values_are_numeric(self, mem_plugin):
-        """Test that min_percent and max_percent are numeric values."""
+    def test_percent_min_max_mean_are_numeric(self, mem_plugin):
+        """Test that percent_min, percent_max, and percent_mean are numeric."""
         self._force_update(mem_plugin)
         stats = mem_plugin.get_raw()
-        assert isinstance(stats['min_percent'], int | float)
-        assert isinstance(stats['max_percent'], int | float)
+        assert isinstance(stats['percent_min'], (int, float))
+        assert isinstance(stats['percent_max'], (int, float))
+        assert isinstance(stats['percent_mean'], (int, float))
 
-    def test_min_max_percent_in_valid_range(self, mem_plugin):
-        """Test that min_percent and max_percent are within 0-100."""
+    def test_percent_min_max_mean_in_valid_range(self, mem_plugin):
+        """Test that percent_min, percent_max, and percent_mean are between 0-100."""
         self._force_update(mem_plugin)
         stats = mem_plugin.get_raw()
-        assert 0 <= stats['min_percent'] <= 100
-        assert 0 <= stats['max_percent'] <= 100
+        assert 0 <= stats['percent_min'] <= 100
+        assert 0 <= stats['percent_max'] <= 100
+        assert 0 <= stats['percent_mean'] <= 100
 
     def test_min_less_than_or_equal_max(self, mem_plugin):
-        """Test that min_percent is always <= max_percent."""
+        """Test that percent_min <= percent_max."""
         self._force_update(mem_plugin)
         stats = mem_plugin.get_raw()
-        assert stats['min_percent'] <= stats['max_percent']
+        assert stats['percent_min'] <= stats['percent_max']
 
-    def test_current_percent_within_min_max_bounds(self, mem_plugin):
-        """Test that current percent falls between min_percent and max_percent."""
+    def test_mean_between_min_and_max(self, mem_plugin):
+        """Test that percent_mean falls between percent_min and percent_max."""
         self._force_update(mem_plugin)
         stats = mem_plugin.get_raw()
-        assert stats['min_percent'] <= stats['percent'] <= stats['max_percent']
+        assert stats['percent_min'] <= stats['percent_mean'] <= stats['percent_max']
 
-    def test_min_max_percent_in_api_output(self, mem_plugin):
-        """Test that min_percent and max_percent are exposed via get_api() (used by /api/4/mem)."""
+    def test_current_percent_within_bounds(self, mem_plugin):
+        """Test that current percent falls between min and max."""
+        self._force_update(mem_plugin)
+        stats = mem_plugin.get_raw()
+        # After multiple updates, current should fall within observed bounds
+        assert stats['percent_min'] <= stats['percent'] <= stats['percent_max']
+
+    def test_mmm_fields_in_api_output(self, mem_plugin):
+        """Test that MMM fields are exposed via get_api()."""
         self._force_update(mem_plugin)
         api_data = mem_plugin.get_api()
-        assert 'min_percent' in api_data
-        assert 'max_percent' in api_data
+        assert 'percent_min' in api_data
+        assert 'percent_max' in api_data
+        assert 'percent_mean' in api_data
 
-    def test_min_max_percent_in_json_output(self, mem_plugin):
-        """Test that min_percent and max_percent are in JSON output."""
+    def test_mmm_fields_in_json_output(self, mem_plugin):
+        """Test that MMM fields are in JSON output."""
         self._force_update(mem_plugin)
         stats_json = mem_plugin.get_stats()
         parsed = json.loads(stats_json)
-        assert 'min_percent' in parsed
-        assert 'max_percent' in parsed
+        assert 'percent_min' in parsed
+        assert 'percent_max' in parsed
+        assert 'percent_mean' in parsed
 
-    def test_min_max_percent_in_export_output(self, mem_plugin):
-        """Test that min_percent and max_percent are in export output."""
+    def test_mmm_fields_in_export_output(self, mem_plugin):
+        """Test that MMM fields are in export output."""
         self._force_update(mem_plugin)
         export = mem_plugin.get_export()
-        assert 'min_percent' in export
-        assert 'max_percent' in export
+        assert 'percent_min' in export
+        assert 'percent_max' in export
+        assert 'percent_mean' in export
 
-    def test_min_max_percent_survive_reset(self, mem_plugin):
-        """Test that min/max tracking survives a stats reset (since startup semantic)."""
-        self._force_update(mem_plugin)
-        prev_min = mem_plugin._min_percent
-        prev_max = mem_plugin._max_percent
-        # reset() only clears the stats dict, not the since-startup trackers
-        mem_plugin.reset()
-        assert mem_plugin._min_percent == prev_min
-        assert mem_plugin._max_percent == prev_max
+    def test_mmm_history_accumulation(self, mem_plugin):
+        """Test that MMM tracking accumulates history correctly."""
+        # Force multiple updates to build history
+        from glances.timer import Timer
+        
+        for _ in range(3):
+            mem_plugin.refresh_timer = Timer(0)
+            mem_plugin.update()
+        
+        # Check that history has accumulated
+        mmm_info = mem_plugin._mmm_fields['percent']
+        # After 3 updates, we should have at least 3 values in history
+        assert len(mmm_info['values']) >= 1
 
-    def test_track_min_max_percent_initialization(self, mem_plugin):
-        """Test _track_min_max_percent initializes trackers on first call."""
-        # Simulate a fresh startup state
-        mem_plugin._min_percent = None
-        mem_plugin._max_percent = None
-        fake_stats = {'percent': 42.5}
-        mem_plugin._track_min_max_percent(fake_stats)
-        assert mem_plugin._min_percent == 42.5
-        assert mem_plugin._max_percent == 42.5
-        assert fake_stats['min_percent'] == 42.5
-        assert fake_stats['max_percent'] == 42.5
-
-    def test_track_min_max_percent_updates_correctly(self, mem_plugin):
-        """Test _track_min_max_percent correctly updates min/max over multiple calls."""
-        # Simulate a fresh startup state
-        mem_plugin._min_percent = None
-        mem_plugin._max_percent = None
-        sequence = [45.0, 30.0, 60.5, 25.0, 70.2, 50.0]
-        for p in sequence:
-            fake_stats = {'percent': p}
-            mem_plugin._track_min_max_percent(fake_stats)
-        # min should be the smallest value seen, max the largest
-        assert mem_plugin._min_percent == 25.0
-        assert mem_plugin._max_percent == 70.2
-        assert fake_stats['min_percent'] == 25.0
-        assert fake_stats['max_percent'] == 70.2
-
-    def test_track_min_max_percent_missing_percent_key(self, mem_plugin):
-        """Test _track_min_max_percent keeps previous values when percent is missing."""
-        mem_plugin._min_percent = None
-        mem_plugin._max_percent = None
-        # Seed with a value
-        mem_plugin._track_min_max_percent({'percent': 33.3})
-        # Now call with a stats dict that has no percent key
-        fake_stats = {'total': 1000}
-        mem_plugin._track_min_max_percent(fake_stats)
-        # Previous min/max should still be exposed
-        assert fake_stats.get('min_percent') == 33.3
-        assert fake_stats.get('max_percent') == 33.3
-        # And internal trackers should be unchanged
-        assert mem_plugin._min_percent == 33.3
-        assert mem_plugin._max_percent == 33.3
-
-    def test_track_min_max_percent_never_initialized_no_percent(self, mem_plugin):
-        """Test _track_min_max_percent does not set min/max if never initialized and no percent."""
-        mem_plugin._min_percent = None
-        mem_plugin._max_percent = None
-        fake_stats = {'total': 1000}
-        mem_plugin._track_min_max_percent(fake_stats)
-        assert 'min_percent' not in fake_stats
-        assert 'max_percent' not in fake_stats
-        assert mem_plugin._min_percent is None
-        assert mem_plugin._max_percent is None
-
-    def test_track_min_max_percent_monotonic(self, mem_plugin):
-        """Test min only decreases (or stays) and max only increases (or stays)."""
-        mem_plugin._min_percent = None
-        mem_plugin._max_percent = None
+    def test_mmm_min_max_monotonic(self, mem_plugin):
+        """Test that min only decreases (or stays) and max only increases (or stays)."""
+        from glances.timer import Timer
+        
         prev_min = None
         prev_max = None
-        for p in [50.0, 40.0, 60.0, 55.0, 35.0, 45.0]:
-            fake_stats = {'percent': p}
-            mem_plugin._track_min_max_percent(fake_stats)
+        
+        for _ in range(3):
+            mem_plugin.refresh_timer = Timer(0)
+            mem_plugin.update()
+            stats = mem_plugin.get_raw()
+            
             if prev_min is not None:
-                assert fake_stats['min_percent'] <= prev_min
-                assert fake_stats['max_percent'] >= prev_max
-            prev_min = fake_stats['min_percent']
-            prev_max = fake_stats['max_percent']
+                # min should never increase, max should never decrease
+                assert stats['percent_min'] <= prev_min or prev_min is None
+                assert stats['percent_max'] >= prev_max or prev_max is None
+            
+            prev_min = stats['percent_min']
+            prev_max = stats['percent_max']
+
+    def test_mmm_history_limit(self, mem_plugin):
+        """Test that MMM history respects the size limit."""
+        mmm_info = mem_plugin._mmm_fields['percent']
+        
+        # The limit should be set to a reasonable value (28800 by default)
+        max_history_size = 28800
+        
+        # After a single update, history should be small
+        from glances.timer import Timer
+        mem_plugin.refresh_timer = Timer(0)
+        mem_plugin.update()
+        
+        # History should not exceed the limit
+        assert len(mmm_info['values']) <= max_history_size
+
+    def test_mmm_fields_with_multiple_updates(self, mem_plugin):
+        """Test MMM tracking across multiple updates."""
+        from glances.timer import Timer
+        
+        # Perform multiple updates
+        for i in range(5):
+            mem_plugin.refresh_timer = Timer(0)
+            mem_plugin.update()
+        
+        stats = mem_plugin.get_raw()
+        
+        # All MMM fields should be present
+        assert 'percent_min' in stats
+        assert 'percent_max' in stats
+        assert 'percent_mean' in stats
+        
+        # Values should be relative to each other
+        assert stats['percent_min'] <= stats['percent'] <= stats['percent_max']
+        assert stats['percent_min'] <= stats['percent_mean'] <= stats['percent_max']
+
+    def test_mmm_decorator_applied(self, mem_plugin):
+        """Test that the _manage_mmm decorator is properly applied to update method."""
+        # The update method should have the decorator applied
+        # We can verify this by checking that MMM fields appear in stats
+        self._force_update(mem_plugin)
+        stats = mem_plugin.get_raw()
+        
+        # If decorator is applied correctly, these fields should exist
+        assert 'percent_min' in stats
+        assert 'percent_max' in stats
+        assert 'percent_mean' in stats
+
+


### PR DESCRIPTION
Enhance the existing memory plugin to track runtime minimum and maximum memory usage percentage since Glances startup and expose these values through the existing /api/4/mem endpoint.

#### Description
1. Memory Plugin:
   - Introduce two new attributes: min_percent and max_percent.
   - Initialize both values using the first collected memory percentage.
   - Update them on each refresh cycle:
       min_percent = min(current, min_percent)
       max_percent = max(current, max_percent)
   - Ensure no impact on existing calculations.

2. REST API (v4):
   - Extend the existing /api/4/mem response.
   - Add two new fields:
       "min_percent"
       "max_percent"
   - Keep all existing fields unchanged.
   - Maintain full backward compatibility.

3. Testing:
   - Add unit tests verifying:
       - Proper initialization of min/max
       - Correct update behavior across multiple refresh cycles
       - API response includes new fields
   - Ensure all existing tests pass.

4. Documentation:
   - Update relevant API documentation to describe the new fields.
   
Please describe the goal of this pull request.

For any questions concerning installation or use, please open a discussion (https://github.com/nicolargo/glances/discussions), not an issue.

#### Resume

* Bug fix: yes/no - No
* New feature: yes/no - Yes
* Fixed tickets: comma-separated list of tickets fixed by the PR, if any - No
