### PR TITLE
refactor(glances_curses): add space between system info and IP when necessary

### DIFF
--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -697,12 +697,20 @@ class _GlancesCurses:
         """
         # First line
         self.new_line()
-        self.space_between_column = 0
         l_uptime = 1
         for i in ['system', 'ip', 'uptime']:
             if i in stat_display:
                 l_uptime += self.get_stats_display_width(stat_display[i])
-        self.display_plugin(stat_display["system"], display_optional=(self.term_window.getmaxyx()[1] >= l_uptime))
+
+        display_system_optional = self.term_window.getmaxyx()[1] >= l_uptime
+
+        # Calculate the initial `space_between_column` based on displayed system messages
+        msgs = stat_display["system"]["msgdict"]
+        visible_msgs = [msg for msg in msgs if display_system_optional or not msg["optional"]]
+        ends_with_space = bool(visible_msgs) and visible_msgs[-1]["msg"].endswith(" ")
+        self.space_between_column = 0 if ends_with_space else 1
+
+        self.display_plugin(stat_display["system"], display_optional=display_system_optional)
         self.space_between_column = 3
         if 'ip' in stat_display:
             self.new_column()


### PR DESCRIPTION
#### Description

Please describe the goal of this pull request.

Add one extra space between host-name and IP address when needed.

##### Root cause
https://github.com/nicolargo/glances/blob/d2b172e3fb5f53dbf1e38d22c42713c9907fb2cf/glances/outputs/glances_curses.py#L700
https://github.com/nicolargo/glances/blob/d2b172e3fb5f53dbf1e38d22c42713c9907fb2cf/glances/outputs/glances_curses.py#L1097
Bare host-name does not end with a space so the IP column `self.next_column` will render right away without any offset space in between.

##### Solution
- The easiest solution is to set `self.space_between_column=1` initially, but it will result in a UI change (a new space added) for users who have optional system info to display.
- To make the UI consistent, it only adds a space when there isn't one between system info and IP info.

##### Results
<img width="1312" height="184" alt="Screenshot from 2026-03-11 13-00-25" src="https://github.com/user-attachments/assets/78a8bfed-69d9-462f-bf17-d0fe5ddf8424" />
<img width="1138" height="179" alt="Screenshot from 2026-03-11 13-18-12" src="https://github.com/user-attachments/assets/291f1748-46ee-438b-94ba-ddfacc8126d0" />

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #3469 
