### PR TITLE
fix(webui): support Starlette TemplateResponse signature changes

### DIFF
--- a/glances/outputs/glances_restful_api.py
+++ b/glances/outputs/glances_restful_api.py
@@ -8,6 +8,7 @@
 
 """RestFul API interface class."""
 
+import inspect
 import os
 import socket
 import sys
@@ -667,6 +668,25 @@ class GlancesRestfulApi:
             self.autodiscover_client.close()
         logger.info("Close the Web server")
 
+    def _template_response_requires_request(self):
+        """Return True when the installed Starlette expects request as first argument."""
+        try:
+            parameters = tuple(inspect.signature(self._templates.TemplateResponse).parameters)
+        except (TypeError, ValueError):
+            return False
+
+        return bool(parameters) and parameters[0] == 'request'
+
+    def _template_response(self, request: Request, template_name: str, context: dict[str, Any]):
+        """Render a template using the supported Starlette TemplateResponse signature."""
+        if not hasattr(self, '_template_response_use_request_first'):
+            self._template_response_use_request_first = self._template_response_requires_request()
+
+        if self._template_response_use_request_first:
+            return self._templates.TemplateResponse(request, template_name, context)
+
+        return self._templates.TemplateResponse(template_name, context)
+
     def _index(self, request: Request):
         """Return main index.html (/) file.
 
@@ -678,7 +698,7 @@ class GlancesRestfulApi:
         refresh_time = request.query_params.get('refresh', default=max(1, int(self.args.time)))
 
         # Display
-        return self._templates.TemplateResponse("index.html", {"request": request, "refresh_time": refresh_time})
+        return self._template_response(request, "index.html", {"request": request, "refresh_time": refresh_time})
 
     def _browser(self, request: Request):
         """Return main browser.html (/browser) file.
@@ -688,7 +708,7 @@ class GlancesRestfulApi:
         refresh_time = request.query_params.get('refresh', default=max(1, int(self.args.time)))
 
         # Display
-        return self._templates.TemplateResponse("browser.html", {"request": request, "refresh_time": refresh_time})
+        return self._template_response(request, "browser.html", {"request": request, "refresh_time": refresh_time})
 
     def _api_status(self):
         """Glances API RESTful implementation.

--- a/glances/outputs/glances_restful_api.py
+++ b/glances/outputs/glances_restful_api.py
@@ -669,21 +669,32 @@ class GlancesRestfulApi:
         logger.info("Close the Web server")
 
     def _template_response_requires_request(self):
-        """Return True when the installed Starlette expects request as first argument."""
+        """Return True when Starlette expects request as the first argument."""
         try:
-            parameters = tuple(inspect.signature(self._templates.TemplateResponse).parameters)
+            parameters = tuple(
+                inspect.signature(self._templates.TemplateResponse).parameters
+            )
         except (TypeError, ValueError):
             return False
 
         return bool(parameters) and parameters[0] == 'request'
 
-    def _template_response(self, request: Request, template_name: str, context: dict[str, Any]):
-        """Render a template using the supported Starlette TemplateResponse signature."""
+    def _template_response(
+        self,
+        request: Request,
+        template_name: str,
+        context: dict[str, Any],
+    ):
+        """Render a template using the supported TemplateResponse signature."""
         if not hasattr(self, '_template_response_use_request_first'):
-            self._template_response_use_request_first = self._template_response_requires_request()
+            self._template_response_use_request_first = (
+                self._template_response_requires_request()
+            )
 
         if self._template_response_use_request_first:
-            return self._templates.TemplateResponse(request, template_name, context)
+            return self._templates.TemplateResponse(
+                request, template_name, context
+            )
 
         return self._templates.TemplateResponse(template_name, context)
 
@@ -695,20 +706,32 @@ class GlancesRestfulApi:
 
         Note: This function is only called the first time the page is loaded.
         """
-        refresh_time = request.query_params.get('refresh', default=max(1, int(self.args.time)))
+        refresh_time = request.query_params.get(
+            'refresh', default=max(1, int(self.args.time))
+        )
 
         # Display
-        return self._template_response(request, "index.html", {"request": request, "refresh_time": refresh_time})
+        return self._template_response(
+            request,
+            "index.html",
+            {"request": request, "refresh_time": refresh_time},
+        )
 
     def _browser(self, request: Request):
         """Return main browser.html (/browser) file.
 
         Note: This function is only called the first time the page is loaded.
         """
-        refresh_time = request.query_params.get('refresh', default=max(1, int(self.args.time)))
+        refresh_time = request.query_params.get(
+            'refresh', default=max(1, int(self.args.time))
+        )
 
         # Display
-        return self._template_response(request, "browser.html", {"request": request, "refresh_time": refresh_time})
+        return self._template_response(
+            request,
+            "browser.html",
+            {"request": request, "refresh_time": refresh_time},
+        )
 
     def _api_status(self):
         """Glances API RESTful implementation.

--- a/tests/test_webui_template_response.py
+++ b/tests/test_webui_template_response.py
@@ -16,29 +16,39 @@ from glances.outputs.glances_restful_api import GlancesRestfulApi
 
 
 class QueryParamsStub(dict):
+    """Provide the subset of request query params used by the handlers."""
+
     def get(self, key, default=None):
+        """Mirror dict.get for request stub compatibility."""
         return super().get(key, default)
 
 
 class OldStyleTemplates:
+    """Mimic the legacy Starlette TemplateResponse signature."""
+
     def __init__(self):
         self.calls = []
 
     def TemplateResponse(self, name, context):
+        """Record legacy TemplateResponse calls."""
         self.calls.append((name, context))
         return context
 
 
 class NewStyleTemplates:
+    """Mimic the current Starlette TemplateResponse signature."""
+
     def __init__(self):
         self.calls = []
 
     def TemplateResponse(self, request, name, context=None):
+        """Record request-first TemplateResponse calls."""
         self.calls.append((request, name, context))
         return context
 
 
 def make_api(templates):
+    """Build a lightweight GlancesRestfulApi instance for template tests."""
     api = GlancesRestfulApi.__new__(GlancesRestfulApi)
     api._templates = templates
     api.args = SimpleNamespace(time='3')
@@ -46,6 +56,7 @@ def make_api(templates):
 
 
 def test_template_response_supports_old_starlette_signature():
+    """Use the legacy signature when the template backend expects it."""
     api = make_api(OldStyleTemplates())
     request = object()
     context = {"request": request, "refresh_time": "5"}
@@ -56,6 +67,7 @@ def test_template_response_supports_old_starlette_signature():
 
 
 def test_template_response_supports_new_starlette_signature():
+    """Use the request-first signature when the backend requires it."""
     api = make_api(NewStyleTemplates())
     request = object()
     context = {"request": request, "refresh_time": "5"}
@@ -66,6 +78,7 @@ def test_template_response_supports_new_starlette_signature():
 
 
 def test_index_uses_template_helper_for_new_starlette_signature():
+    """Route the index view through the compatibility helper."""
     api = make_api(NewStyleTemplates())
     request = SimpleNamespace(query_params=QueryParamsStub(refresh='7'))
 
@@ -78,6 +91,7 @@ def test_index_uses_template_helper_for_new_starlette_signature():
 
 
 def test_browser_uses_template_helper_for_old_starlette_signature():
+    """Keep browser view rendering compatible with the legacy signature."""
     api = make_api(OldStyleTemplates())
     request = SimpleNamespace(query_params=QueryParamsStub())
 
@@ -90,6 +104,7 @@ def test_browser_uses_template_helper_for_old_starlette_signature():
 
 
 def test_index_renders_with_installed_jinja2_templates(tmp_path):
+    """Render the index view with the installed Jinja2Templates backend."""
     (tmp_path / "index.html").write_text(
         "refresh={{ refresh_time }}", encoding="utf-8"
     )

--- a/tests/test_webui_template_response.py
+++ b/tests/test_webui_template_response.py
@@ -1,0 +1,97 @@
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Jeongwoo Kim <corc411@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Regression tests for WebUI template rendering."""
+
+from types import SimpleNamespace
+
+from fastapi.templating import Jinja2Templates
+
+from glances.outputs.glances_restful_api import GlancesRestfulApi
+
+
+class QueryParamsStub(dict):
+    def get(self, key, default=None):
+        return super().get(key, default)
+
+
+class OldStyleTemplates:
+    def __init__(self):
+        self.calls = []
+
+    def TemplateResponse(self, name, context):
+        self.calls.append((name, context))
+        return context
+
+
+class NewStyleTemplates:
+    def __init__(self):
+        self.calls = []
+
+    def TemplateResponse(self, request, name, context=None):
+        self.calls.append((request, name, context))
+        return context
+
+
+def make_api(templates):
+    api = GlancesRestfulApi.__new__(GlancesRestfulApi)
+    api._templates = templates
+    api.args = SimpleNamespace(time='3')
+    return api
+
+
+def test_template_response_supports_old_starlette_signature():
+    api = make_api(OldStyleTemplates())
+    request = object()
+    context = {"request": request, "refresh_time": "5"}
+
+    assert api._template_response_requires_request() is False
+    assert api._template_response(request, "index.html", context) == context
+    assert api._templates.calls == [("index.html", context)]
+
+
+def test_template_response_supports_new_starlette_signature():
+    api = make_api(NewStyleTemplates())
+    request = object()
+    context = {"request": request, "refresh_time": "5"}
+
+    assert api._template_response_requires_request() is True
+    assert api._template_response(request, "index.html", context) == context
+    assert api._templates.calls == [(request, "index.html", context)]
+
+
+def test_index_uses_template_helper_for_new_starlette_signature():
+    api = make_api(NewStyleTemplates())
+    request = SimpleNamespace(query_params=QueryParamsStub(refresh='7'))
+
+    response = api._index(request)
+
+    assert response["refresh_time"] == '7'
+    assert api._templates.calls == [(request, "index.html", {"request": request, "refresh_time": '7'})]
+
+
+def test_browser_uses_template_helper_for_old_starlette_signature():
+    api = make_api(OldStyleTemplates())
+    request = SimpleNamespace(query_params=QueryParamsStub())
+
+    response = api._browser(request)
+
+    assert response["refresh_time"] == 3
+    assert api._templates.calls == [("browser.html", {"request": request, "refresh_time": 3})]
+
+
+def test_index_renders_with_installed_jinja2_templates(tmp_path):
+    (tmp_path / "index.html").write_text("refresh={{ refresh_time }}", encoding="utf-8")
+    api = make_api(Jinja2Templates(directory=tmp_path))
+    request = SimpleNamespace(query_params=QueryParamsStub(refresh='9'))
+
+    response = api._index(request)
+
+    assert response.template.name == "index.html"
+    assert response.context["request"] is request
+    assert response.context["refresh_time"] == '9'

--- a/tests/test_webui_template_response.py
+++ b/tests/test_webui_template_response.py
@@ -8,6 +8,8 @@
 
 """Regression tests for WebUI template rendering."""
 
+# pylint: disable=invalid-name,protected-access,too-few-public-methods
+
 from types import SimpleNamespace
 
 from fastapi.templating import Jinja2Templates

--- a/tests/test_webui_template_response.py
+++ b/tests/test_webui_template_response.py
@@ -63,9 +63,9 @@ def test_template_response_supports_old_starlette_signature():
     request = object()
     context = {"request": request, "refresh_time": "5"}
 
-    assert api._template_response_requires_request() is False
-    assert api._template_response(request, "index.html", context) == context
-    assert api._templates.calls == [("index.html", context)]
+    assert api._template_response_requires_request() is False  # nosec B101
+    assert api._template_response(request, "index.html", context) == context  # nosec B101
+    assert api._templates.calls == [("index.html", context)]  # nosec B101
 
 
 def test_template_response_supports_new_starlette_signature():
@@ -74,9 +74,9 @@ def test_template_response_supports_new_starlette_signature():
     request = object()
     context = {"request": request, "refresh_time": "5"}
 
-    assert api._template_response_requires_request() is True
-    assert api._template_response(request, "index.html", context) == context
-    assert api._templates.calls == [(request, "index.html", context)]
+    assert api._template_response_requires_request() is True  # nosec B101
+    assert api._template_response(request, "index.html", context) == context  # nosec B101
+    assert api._templates.calls == [(request, "index.html", context)]  # nosec B101
 
 
 def test_index_uses_template_helper_for_new_starlette_signature():
@@ -86,8 +86,8 @@ def test_index_uses_template_helper_for_new_starlette_signature():
 
     response = api._index(request)
 
-    assert response["refresh_time"] == '7'
-    assert api._templates.calls == [
+    assert response["refresh_time"] == '7'  # nosec B101
+    assert api._templates.calls == [  # nosec B101
         (request, "index.html", {"request": request, "refresh_time": '7'})
     ]
 
@@ -99,8 +99,8 @@ def test_browser_uses_template_helper_for_old_starlette_signature():
 
     response = api._browser(request)
 
-    assert response["refresh_time"] == 3
-    assert api._templates.calls == [
+    assert response["refresh_time"] == 3  # nosec B101
+    assert api._templates.calls == [  # nosec B101
         ("browser.html", {"request": request, "refresh_time": 3})
     ]
 
@@ -115,6 +115,6 @@ def test_index_renders_with_installed_jinja2_templates(tmp_path):
 
     response = api._index(request)
 
-    assert response.template.name == "index.html"
-    assert response.context["request"] is request
-    assert response.context["refresh_time"] == '9'
+    assert response.template.name == "index.html"  # nosec B101
+    assert response.context["request"] is request  # nosec B101
+    assert response.context["refresh_time"] == '9'  # nosec B101

--- a/tests/test_webui_template_response.py
+++ b/tests/test_webui_template_response.py
@@ -72,7 +72,9 @@ def test_index_uses_template_helper_for_new_starlette_signature():
     response = api._index(request)
 
     assert response["refresh_time"] == '7'
-    assert api._templates.calls == [(request, "index.html", {"request": request, "refresh_time": '7'})]
+    assert api._templates.calls == [
+        (request, "index.html", {"request": request, "refresh_time": '7'})
+    ]
 
 
 def test_browser_uses_template_helper_for_old_starlette_signature():
@@ -82,11 +84,15 @@ def test_browser_uses_template_helper_for_old_starlette_signature():
     response = api._browser(request)
 
     assert response["refresh_time"] == 3
-    assert api._templates.calls == [("browser.html", {"request": request, "refresh_time": 3})]
+    assert api._templates.calls == [
+        ("browser.html", {"request": request, "refresh_time": 3})
+    ]
 
 
 def test_index_renders_with_installed_jinja2_templates(tmp_path):
-    (tmp_path / "index.html").write_text("refresh={{ refresh_time }}", encoding="utf-8")
+    (tmp_path / "index.html").write_text(
+        "refresh={{ refresh_time }}", encoding="utf-8"
+    )
     api = make_api(Jinja2Templates(directory=tmp_path))
     request = SimpleNamespace(query_params=QueryParamsStub(refresh='9'))
 


### PR DESCRIPTION
## Summary
- support both legacy and current Starlette `TemplateResponse` call signatures in the WebUI
- route the `/` and `/browser` handlers through a compatibility helper to avoid `500 Internal Server Error` on newer Starlette versions
- add regression tests that cover legacy stubs, current-style stubs, and the installed `Jinja2Templates` integration

## Testing
- `/tmp/glances-codex/.venv/bin/pytest /tmp/glances-codex/tests/test_webui_template_response.py`

Closes #3502.