### PR TITLE
fix: clamp memory used/percent to non-negative values for LXC containers

### DIFF
--- a/glances/plugins/mem/__init__.py
+++ b/glances/plugins/mem/__init__.py
@@ -209,7 +209,13 @@ class MemPlugin(GlancesPluginModel):
             # Update percent to reflect new 'available' value
             stats['percent'] = round(float((stats['total'] - stats['available']) / stats['total'] * 100), 1)
 
-        stats['used'] = stats['total'] - stats['available']
+        # In LXC/cgroup-v2 containers the kernel may report
+        # ``available`` > ``total`` (memory over-commit / cgroup accounting
+        # quirks).  Clamp ``used`` and ``percent`` to [0, total] so they are
+        # never displayed as negative numbers.
+        stats['used'] = max(0, stats['total'] - stats['available'])
+        if stats.get('percent') is not None:
+            stats['percent'] = max(0.0, min(100.0, stats['percent']))
 
         return stats
 


### PR DESCRIPTION
## Summary

Fixes #3358.

In LXC containers using cgroup v2, `psutil` may report `available` memory **greater than** `total` due to kernel memory over-commit accounting. This caused:

```python
used = total - available  # → negative
percent = (total - available) / total * 100  # → negative
```

Both values were then displayed as negative numbers in the Glances UI.

## Fix

Clamp `used` and `percent` to sane bounds after calculation:

```python
stats['used'] = max(0, stats['total'] - stats['available'])
stats['percent'] = max(0.0, min(100.0, stats['percent']))
```

This is purely defensive — it does not change values on normal systems where `available ≤ total`.