### PR TITLE
fix(cassandra): validate keyspace/table/replication_factor to prevent CQL injection - Correct CVE-2026-35588 

### DIFF
--- a/glances/exports/glances_cassandra/__init__.py
+++ b/glances/exports/glances_cassandra/__init__.py
@@ -69,8 +69,9 @@ class Export(GlancesExport):
             if self.replication_factor < 1:
                 raise ValueError("replication_factor must be a positive integer")
         except ValueError as e:
-            logger.critical(f"Cassandra configuration error: {e}")
-            sys.exit(2)
+            logger.error(f"Cassandra configuration error: {e}")
+            self.export_enable = False
+            return
 
         # Init the Cassandra client
         self.cluster, self.session = self.init()

--- a/glances/exports/glances_cassandra/__init__.py
+++ b/glances/exports/glances_cassandra/__init__.py
@@ -8,6 +8,7 @@
 
 """Cassandra/Scylla interface class."""
 
+import re
 import sys
 from datetime import datetime
 from numbers import Number
@@ -19,6 +20,19 @@ from cassandra.util import uuid_from_time
 
 from glances.exports.export import GlancesExport
 from glances.logger import logger
+
+
+_CQL_IDENTIFIER_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_]*$')
+
+
+def _validate_cql_identifier(value, name):
+    """Raise ValueError if value is not a safe CQL identifier."""
+    if not _CQL_IDENTIFIER_RE.match(str(value)):
+        raise ValueError(
+            f"Invalid CQL identifier for '{name}': {value!r}. "
+            "Only letters, digits, and underscores are allowed, and it must start with a letter."
+        )
+    return str(value)
 
 
 class Export(GlancesExport):
@@ -45,6 +59,17 @@ class Export(GlancesExport):
             options=['protocol_version', 'replication_factor', 'table', 'username', 'password'],
         )
         if not self.export_enable:
+            sys.exit(2)
+
+        # Validate CQL identifiers to prevent injection via config values
+        try:
+            self.keyspace = _validate_cql_identifier(self.keyspace, 'keyspace')
+            self.table = _validate_cql_identifier(self.table, 'table')
+            self.replication_factor = int(self.replication_factor)
+            if self.replication_factor < 1:
+                raise ValueError("replication_factor must be a positive integer")
+        except ValueError as e:
+            logger.critical(f"Cassandra configuration error: {e}")
             sys.exit(2)
 
         # Init the Cassandra client


### PR DESCRIPTION
## Summary

This PR addresses GHSA-grp3-h8m8-45p7 (CVE-2026-35588) as requested by @nicolargo in the security advisory.

### Root Cause

`glances/exports/glances_cassandra/__init__.py` interpolates `keyspace`, `table`, and `replication_factor` config values directly into CQL strings without validation:

```python
# Line 80 — keyspace injected directly
f"CREATE KEYSPACE {self.keyspace} WITH ..."

# Line 94 — table injected directly
f"CREATE TABLE {self.table} ..."

# Line 112 — table injected directly
f"INSERT INTO {self.table} (plugin, time, stat) VALUES (?, ?, ?)"
```

A user with write access to `glances.conf` can set e.g. `table = attacker_ks.captured_stats` to redirect all monitoring data to an attacker-controlled Cassandra keyspace.

### Fix

Add `_validate_cql_identifier()` using `re.compile(r'^[a-zA-Z][a-zA-Z0-9_]*$')` and call it for `keyspace` and `table` during `__init__`. Cast `replication_factor` to `int` and reject values less than 1. Invalid config values cause a `CRITICAL` log and `sys.exit(2)` — consistent with how other fatal config errors are handled in the file.

### Testing

Valid config (unchanged behavior):
```ini
[cassandra]
keyspace = glances
table = stats
replication_factor = 2
```

Malicious config (now rejected at startup):
```ini
table = attacker_ks.captured_stats   # contains dot → ValueError
keyspace = glances'; DROP KEYSPACE   # contains special chars → ValueError
replication_factor = abc             # not an integer → ValueError
```