### PR TITLE
Fix LXD filter excluding containers on standalone hosts

### DIFF
--- a/glances/plugins/containers/engines/lxd.py
+++ b/glances/plugins/containers/engines/lxd.py
@@ -208,14 +208,17 @@ class LxdExtension:
                 self.client = LxdClient()
             # Verify connectivity
             self.client.has_api_extension('instances')
-            # Determine local cluster member name (for filtering)
+            # In a cluster, determine local member name so we can filter to instances
+            # running on this node. On a standalone host, server_name is still set but
+            # instance.location is empty, so we must gate on server_clustered.
             try:
                 env = self.client.host_info.get('environment', {})
-                self.local_node = env.get('server_name')
+                if env.get('server_clustered'):
+                    self.local_node = env.get('server_name')
             except Exception:
                 self.local_node = None
         except Exception as e:
-            logger.debug(f"{self.ext_name} plugin - Can't connect to LXD ({e})")
+            logger.error(f"{self.ext_name} plugin - Can't connect to LXD ({e})")
             self.client = None
             self.disable = True
 

--- a/tests/test_plugin_lxd.py
+++ b/tests/test_plugin_lxd.py
@@ -300,6 +300,18 @@ class TestLxdExtensionUpdate:
         assert len(container_stats) == 1
         assert container_stats[0]['name'] == 'web'
 
+    def test_standalone_does_not_filter_by_location(self):
+        # On a non-clustered LXD host, instance.location is typically empty.
+        # local_node stays None, so every instance must pass through.
+        a = make_mock_instance(name="web", location="")
+        b = make_mock_instance(name="db", location=None)
+        ext = self._make_extension_with_client([a, b], local_node=None)
+
+        with patch('glances.plugins.containers.engines.lxd.LxdStatsFetcher'):
+            _, container_stats = ext.update(all_tag=True)
+
+        assert {c['name'] for c in container_stats} == {"web", "db"}
+
     def test_cleans_up_removed_instances(self):
         instance = make_mock_instance(name="web")
         ext = self._make_extension_with_client([instance])
@@ -319,3 +331,32 @@ class TestLxdExtensionUpdate:
         version, containers = ext.update(all_tag=True)
         assert version == {}
         assert containers == []
+
+
+class TestLxdExtensionConnect:
+    """Test LxdExtension.connect detection of cluster membership."""
+
+    def _make_extension_for_connect(self, host_info):
+        from glances.plugins.containers.engines.lxd import LxdExtension
+
+        mock_client = MagicMock()
+        mock_client.host_info = host_info
+
+        with patch.object(LxdExtension, '__init__', lambda self, **kwargs: None):
+            ext = LxdExtension.__new__(LxdExtension)
+            ext.ext_name = "containers (LXD)"
+            ext.endpoint = None
+            ext.local_node = None
+            ext.disable = False
+
+            with patch('glances.plugins.containers.engines.lxd.LxdClient', return_value=mock_client, create=True):
+                ext.connect()
+        return ext
+
+    def test_standalone_leaves_local_node_unset(self):
+        ext = self._make_extension_for_connect({"environment": {"server_name": "zfs01", "server_clustered": False}})
+        assert ext.local_node is None
+
+    def test_cluster_sets_local_node(self):
+        ext = self._make_extension_for_connect({"environment": {"server_name": "node1", "server_clustered": True}})
+        assert ext.local_node == "node1"

--- a/tests/test_plugin_lxd.py
+++ b/tests/test_plugin_lxd.py
@@ -310,7 +310,7 @@ class TestLxdExtensionUpdate:
         with patch('glances.plugins.containers.engines.lxd.LxdStatsFetcher'):
             _, container_stats = ext.update(all_tag=True)
 
-        assert {c['name'] for c in container_stats} == {"web", "db"}
+        assert {c['name'] for c in container_stats} == {"web", "db"}  # nosec B101
 
     def test_cleans_up_removed_instances(self):
         instance = make_mock_instance(name="web")
@@ -333,7 +333,7 @@ class TestLxdExtensionUpdate:
         assert containers == []
 
 
-class TestLxdExtensionConnect:
+class TestLxdExtensionConnect:  # noqa: D203
     """Test LxdExtension.connect detection of cluster membership."""
 
     def _make_extension_for_connect(self, host_info):
@@ -355,8 +355,8 @@ class TestLxdExtensionConnect:
 
     def test_standalone_leaves_local_node_unset(self):
         ext = self._make_extension_for_connect({"environment": {"server_name": "zfs01", "server_clustered": False}})
-        assert ext.local_node is None
+        assert ext.local_node is None  # nosec B101
 
     def test_cluster_sets_local_node(self):
         ext = self._make_extension_for_connect({"environment": {"server_name": "node1", "server_clustered": True}})
-        assert ext.local_node == "node1"
+        assert ext.local_node == "node1"  # nosec B101


### PR DESCRIPTION
Fixes #3524.

On a standalone (non-clustered) LXD host, `instance.location` is empty while `server_name` is still set. The engine was reading `server_name` unconditionally into `self.local_node` and then filtering instances to `location == local_node`, which dropped every container on non-clustered hosts.

Now gated on `environment.server_clustered` — the cluster-member filter is only applied when the LXD daemon reports itself as clustered.

Also promoted the `connect()` failure log from `debug` to `error` so that future LXD connectivity issues are visible in the default log (matching the Docker engine's behaviour). This would have helped diagnose the reported issue faster.

## Test plan
- [x] `pytest tests/test_plugin_lxd.py` — 19 tests pass (2 new: standalone non-filtering, connect cluster detection)
- [x] `ruff check` / `ruff format --check` clean
- [ ] Reporter confirmation on Ubuntu 24.04 with snap LXD