### PR TITLE
Fix filesystem aliases for mixed-case mount points

### DIFF
--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -1072,7 +1072,7 @@ class GlancesPluginModel:
         return {}
 
     def has_alias(self, header):
-        """Return the alias name for the relative header it it exists otherwise None."""
+        """Return the alias name for the relative header if it exists, otherwise None."""
         if isinstance(header, str):
             header = header.lower()
         return self.alias.get(header, None)

--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -1073,6 +1073,8 @@ class GlancesPluginModel:
 
     def has_alias(self, header):
         """Return the alias name for the relative header it it exists otherwise None."""
+        if isinstance(header, str):
+            header = header.lower()
         return self.alias.get(header, None)
 
     def msg_curse(self, args=None, max_width=None):

--- a/tests/test_plugin_fs.py
+++ b/tests/test_plugin_fs.py
@@ -10,6 +10,7 @@
 """Tests for the FileSystem plugin."""
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -297,6 +298,21 @@ class TestFsPluginAlias:
         for fs in stats:
             if 'alias' in fs:
                 assert fs['alias'] is None or isinstance(fs['alias'], str)
+
+    def test_alias_matches_mixed_case_mount_point(self, fs_plugin, monkeypatch):
+        """Test that aliases match mount points even when the path contains uppercase characters."""
+        partition = SimpleNamespace(device='/dev/disk7s1', mountpoint='/Volumes/SSD', fstype='apfs', opts='rw')
+        usage = SimpleNamespace(total=100, used=20, free=80, percent=20.0)
+
+        monkeypatch.setattr(fs_plugin, 'get_disk_partitions', lambda fetch_all=False: [partition])
+        monkeypatch.setattr('glances.plugins.fs.get_disk_usage', lambda fs: usage)
+
+        fs_plugin._limits['fs_alias'] = ['/Volumes/SSD:SSD']
+        fs_plugin.alias = fs_plugin.read_alias()
+
+        stats = fs_plugin.update_local()
+
+        assert stats[0]['alias'] == 'SSD'
 
 
 class TestFsPluginDiskPartitions:


### PR DESCRIPTION
Fixes #3370.

Filesystem aliases are stored with lowercased keys, but `has_alias()` was looking them up with the original header string. That meant mixed-case mount points such as `/Volumes/SSD` never matched their configured aliases even though the alias map already contained the normalized key.

This normalizes string headers during alias lookup so filesystem aliases work for mixed-case mount points, and adds a regression test that exercises the reported `/Volumes/SSD` case through the fs plugin update path.

## Test plan
- [x] `pytest tests/test_plugin_fs.py`
- [x] `pytest tests/test_plugin_network.py tests/test_plugin_diskio.py`
- [x] `ruff check glances/plugins/plugin/model.py tests/test_plugin_fs.py`
- [x] `ruff format --check glances/plugins/plugin/model.py tests/test_plugin_fs.py`
