### PR TITLE
fix: logging configuration to use boolean value

### DIFF
--- a/glances/logger.py
+++ b/glances/logger.py
@@ -40,7 +40,7 @@ else:
 # Define the logging configuration
 LOGGING_CFG = {
     "version": 1,
-    "disable_existing_loggers": "False",
+    "disable_existing_loggers": False,
     "root": {"level": "INFO", "handlers": ["file", "console"]},
     "formatters": {
         "standard": {"format": "%(asctime)s -- %(levelname)s -- %(message)s"},


### PR DESCRIPTION
#### Description

When I use Glances as an embedded backend for my application, after glances's logger initialized, my logger was disabled (e.g. my_logger = logging.getLogger("Foo"))

So I print it and get: 
```python
{'filters': [], 'name': 'uvicorn.error', 'level': 20, 'parent': <RootLogger root (NOTSET)>, 'propagate': True, 'handlers': [], 'disabled': 'False', '_cache': {}, 'manager': <logging.Manager object at 0x78d5884af7d0>}
```

I actually didn't spot the problem right away, so I went directly into the `logging` module using Debug to inspect `isEnabled`, in here (https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L1772):
```python
    def isEnabledFor(self, level):
        """
        Is this logger enabled for level 'level'?
        """
        if self.disabled:  # <---- Here
            return False
        ...
```

Now we can see the problem: the `Logger.disabled` attribute has been assigned the string value `"False"`, which—in terms of logical evaluation—is always true.

Then I found that: Glances's default logging config set `disable_existing_loggers` as string value `"False"` instead of boolean value `False`, caused all other loggers are disabled.

I think this is a relatively important issue.

#### Resume

* Bug fix: yes
* New feature: no
