### PR TITLE
Reduce Cyclomatic complexity of display_popup()

### DIFF
--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -957,33 +957,7 @@ class _GlancesCurses:
         if popup_type == 'input':
             logger.info(popup_type)
             logger.info(is_password)
-            # Create a sub-window for the text field
-            sub_pop = popup.derwin(1, input_size, 2, 2 + len(m))
-            sub_pop.attron(self.colors_list['FILTER'])
-            # Init the field with the current value
-            if input_value is not None:
-                sub_pop.addnstr(0, 0, input_value, len(input_value))
-            # Display the popup
-            popup.refresh()
-            sub_pop.refresh()
-            # Create the textbox inside the sub-windows
-            self.set_cursor(2)
-            self.term_window.keypad(1)
-            if is_password:
-                textbox = getpass.getpass('')
-                self.set_cursor(0)
-                if textbox != '':
-                    return textbox
-                return None
-
-            # No password
-            textbox = GlancesTextbox(sub_pop, insert_mode=True)
-            textbox.edit()
-            self.set_cursor(0)
-            if textbox.gather() != '':
-                return textbox.gather()[:-1]
-            return None
-        #            return self._handle_input_popup(m, input_size, input_value, popup, is_password)
+            return self._handle_input_popup(m, input_size, input_value, popup, is_password)
 
         # Popup accepts a user input as Y or N for yes no
         if popup_type == 'yesno':

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -957,7 +957,33 @@ class _GlancesCurses:
         if popup_type == 'input':
             logger.info(popup_type)
             logger.info(is_password)
-            return self._handle_input_popup(m, input_size, input_value, popup, is_password)
+            # Create a sub-window for the text field
+            sub_pop = popup.derwin(1, input_size, 2, 2 + len(m))
+            sub_pop.attron(self.colors_list['FILTER'])
+            # Init the field with the current value
+            if input_value is not None:
+                sub_pop.addnstr(0, 0, input_value, len(input_value))
+            # Display the popup
+            popup.refresh()
+            sub_pop.refresh()
+            # Create the textbox inside the sub-windows
+            self.set_cursor(2)
+            self.term_window.keypad(1)
+            if is_password:
+                textbox = getpass.getpass('')
+                self.set_cursor(0)
+                if textbox != '':
+                    return textbox
+                return None
+
+            # No password
+            textbox = GlancesTextbox(sub_pop, insert_mode=True)
+            textbox.edit()
+            self.set_cursor(0)
+            if textbox.gather() != '':
+                return textbox.gather()[:-1]
+            return None
+        #            return self._handle_input_popup(m, input_size, input_value, popup, is_password)
 
         # Popup accepts a user input as Y or N for yes no
         if popup_type == 'yesno':
@@ -985,8 +1011,6 @@ class _GlancesCurses:
         # Password input: bypass curses textbox and use standard terminal input
         # (input is not displayed in the sub-window)
         if is_password:
-            if not sys.stdin.isatty():
-                return None
             textbox = getpass.getpass('')
             self.set_cursor(0)
             if textbox != '':

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -651,7 +651,7 @@ class _GlancesCurses:
             else:
                 logger.warning('Graph export module is disable. Run Glances with --export graph to enable it.')
                 self.args.generate_graph = False
-        self.display_popup("Test popup\nSecond line", popup_type='yesno')  # Monisha - for testing
+        self.display_popup("Test popup", popup_type='input')  # Monisha - for testing
         return True
 
     def nice_increase(self, process):
@@ -957,36 +957,39 @@ class _GlancesCurses:
         if popup_type == 'input':
             logger.info(popup_type)
             logger.info(is_password)
-            # Create a sub-window for the text field
-            sub_pop = popup.derwin(1, input_size, 2, 2 + len(m))
-            sub_pop.attron(self.colors_list['FILTER'])
-            # Init the field with the current value
-            if input_value is not None:
-                sub_pop.addnstr(0, 0, input_value, len(input_value))
-            # Display the popup
-            popup.refresh()
-            sub_pop.refresh()
-            # Create the textbox inside the sub-windows
-            self.set_cursor(2)
-            self.term_window.keypad(1)
-            if is_password:
-                textbox = getpass.getpass('')
-                self.set_cursor(0)
-                if textbox != '':
-                    return textbox
-                return None
-
-            # No password
-            textbox = GlancesTextbox(sub_pop, insert_mode=True)
-            textbox.edit()
-            self.set_cursor(0)
-            if textbox.gather() != '':
-                return textbox.gather()[:-1]
-            return None
+            return self._handle_input_popup(m, input_size, input_value, popup, is_password)
 
         # Popup accepts a user input as Y or N for yes no
         if popup_type == 'yesno':
             return self._handle_yesno_popup(popup, sentence_list, m)
+        return None
+
+    def _handle_input_popup(self, m, input_size, input_value, popup, is_password):
+        # Create a sub-window for the text field
+        sub_pop = popup.derwin(1, input_size, 2, 2 + len(m))
+        sub_pop.attron(self.colors_list['FILTER'])
+        # Init the field with the current value
+        if input_value is not None:
+            sub_pop.addnstr(0, 0, input_value, len(input_value))
+        # Display the popup
+        popup.refresh()
+        sub_pop.refresh()
+        # Create the textbox inside the sub-windows
+        self.set_cursor(2)
+        self.term_window.keypad(1)
+        if is_password:
+            textbox = getpass.getpass('')
+            self.set_cursor(0)
+            if textbox != '':
+                return textbox
+            return None
+
+        # No password
+        textbox = GlancesTextbox(sub_pop, insert_mode=True)
+        textbox.edit()
+        self.set_cursor(0)
+        if textbox.gather() != '':
+            return textbox.gather()[:-1]
         return None
 
     def _handle_yesno_popup(self, popup, sentence_list, m):

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -651,7 +651,7 @@ class _GlancesCurses:
             else:
                 logger.warning('Graph export module is disable. Run Glances with --export graph to enable it.')
                 self.args.generate_graph = False
-        self.display_popup("Test popup", popup_type='input')  # Monisha - for testing
+
         return True
 
     def nice_increase(self, process):

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -965,18 +965,25 @@ class _GlancesCurses:
         return None
 
     def _handle_input_popup(self, m, input_size, input_value, popup, is_password):
-        # Create a sub-window for the text field
+        # Create a single-line input sub-window positioned relative to the
+        # rendered message length (m) within the parent popup
         sub_pop = popup.derwin(1, input_size, 2, 2 + len(m))
         sub_pop.attron(self.colors_list['FILTER'])
-        # Init the field with the current value
+
+        # Pre-populate the field if an initial value is provided
         if input_value is not None:
             sub_pop.addnstr(0, 0, input_value, len(input_value))
-        # Display the popup
+
+        # Render both the popup and input field before capturing input
         popup.refresh()
         sub_pop.refresh()
-        # Create the textbox inside the sub-windows
+
+        # Enable cursor visibility and keypad mode for user interaction
         self.set_cursor(2)
         self.term_window.keypad(1)
+
+        # Password input: bypass curses textbox and use standard terminal input
+        # (input is not displayed in the sub-window)
         if is_password:
             textbox = getpass.getpass('')
             self.set_cursor(0)
@@ -984,10 +991,14 @@ class _GlancesCurses:
                 return textbox
             return None
 
-        # No password
+        # Standard text input using curses textbox within the sub-window
         textbox = GlancesTextbox(sub_pop, insert_mode=True)
         textbox.edit()
+
+        # Restore cursor state after input completes
         self.set_cursor(0)
+
+        # Extract value; curses textbox appends a trailing newline, so strip it
         if textbox.gather() != '':
             return textbox.gather()[:-1]
         return None

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -651,7 +651,7 @@ class _GlancesCurses:
             else:
                 logger.warning('Graph export module is disable. Run Glances with --export graph to enable it.')
                 self.args.generate_graph = False
-
+        self.display_popup("Test popup\nSecond line", popup_type='yesno')  # Monisha - for testing
         return True
 
     def nice_increase(self, process):
@@ -869,6 +869,21 @@ class _GlancesCurses:
                 else:
                     self.display_plugin(stat_display[p])
 
+    def get_popup_size(self, message, size_x, size_y, popup_type, input_size):
+        sentence_list = message.split('\n')
+        if size_x is None:
+            size_x = len(max(sentence_list, key=len)) + 4
+            # Add space for the input field
+            if popup_type == 'input':
+                size_x += input_size
+        if size_y is None:
+            size_y = len(sentence_list) + 4
+        screen_x = self.term_window.getmaxyx()[1]
+        screen_y = self.term_window.getmaxyx()[0]
+        pos_x = int((screen_x - size_x) / 2)
+        pos_y = int((screen_y - size_y) / 2)
+        return sentence_list, pos_x, pos_y, screen_x, screen_y, size_x, size_y
+
     def display_popup(
         self,
         message,
@@ -903,21 +918,13 @@ class _GlancesCurses:
          Return True (yes) or False (no)
         """
         # Center the popup
-        sentence_list = message.split('\n')
-        if size_x is None:
-            size_x = len(max(sentence_list, key=len)) + 4
-            # Add space for the input field
-            if popup_type == 'input':
-                size_x += input_size
-        if size_y is None:
-            size_y = len(sentence_list) + 4
-        screen_x = self.term_window.getmaxyx()[1]
-        screen_y = self.term_window.getmaxyx()[0]
+        sentence_list, pos_x, pos_y, screen_x, screen_y, size_x, size_y = self.get_popup_size(
+            message, size_x, size_y, popup_type, input_size
+        )
+
         if size_x > screen_x or size_y > screen_y:
             # No size to display the popup => abord
             return False
-        pos_x = int((screen_x - size_x) / 2)
-        pos_y = int((screen_y - size_y) / 2)
 
         # Create the popup
         popup = curses.newwin(size_y, size_x, pos_y, pos_x)
@@ -967,27 +974,29 @@ class _GlancesCurses:
             return None
 
         if popup_type == 'yesno':
-            # Create a sub-window for the text field
-            sub_pop = popup.derwin(1, 2, len(sentence_list) + 1, len(m) + 2)
-            sub_pop.attron(self.colors_list['FILTER'])
-            # Init the field with the current value
-            try:
-                sub_pop.addnstr(0, 0, '', 0)
-            except curses.error:
-                pass
-            # Display the popup
-            popup.refresh()
-            sub_pop.refresh()
-            # Create the textbox inside the sub-windows
-            self.set_cursor(2)
-            self.term_window.keypad(1)
-            textbox = GlancesTextboxYesNo(sub_pop, insert_mode=False)
-            textbox.edit()
-            self.set_cursor(0)
-            # self.term_window.keypad(0)
-            return textbox.gather()
-
+            return self._handle_yesno_popup(popup, sentence_list, m)
         return None
+
+    def _handle_yesno_popup(self, popup, sentence_list, m):
+        # Create a sub-window for the text field
+        sub_pop = popup.derwin(1, 2, len(sentence_list) + 1, len(m) + 2)
+        sub_pop.attron(self.colors_list['FILTER'])
+        # Init the field with the current value
+        try:
+            sub_pop.addnstr(0, 0, '', 0)
+        except curses.error:
+            pass
+        # Display the popup
+        popup.refresh()
+        sub_pop.refresh()
+        # Create the textbox inside the sub-windows
+        self.set_cursor(2)
+        self.term_window.keypad(1)
+        textbox = GlancesTextboxYesNo(sub_pop, insert_mode=False)
+        textbox.edit()
+        self.set_cursor(0)
+        # self.term_window.keypad(0)
+        return textbox.gather()
 
     def setup_upper_left_pos(self, plugin_stats):
         screen_y, screen_x = self.term_window.getmaxyx()

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -870,18 +870,27 @@ class _GlancesCurses:
                     self.display_plugin(stat_display[p])
 
     def get_popup_size(self, message, size_x, size_y, popup_type, input_size):
+        # Split the message into lines (seperated by \n)
         sentence_list = message.split('\n')
+        # If length size_x has not been give, calculate the same
+        # as a calculation of the max sentence length
         if size_x is None:
             size_x = len(max(sentence_list, key=len)) + 4
             # Add space for the input field
             if popup_type == 'input':
                 size_x += input_size
+        # if height size_y has not been given, calculate this depending on
+        # the no of lines in sentence
         if size_y is None:
             size_y = len(sentence_list) + 4
+        # Calculate screen size
         screen_x = self.term_window.getmaxyx()[1]
         screen_y = self.term_window.getmaxyx()[0]
+        # Identify the centre position for the popup on the screen
         pos_x = int((screen_x - size_x) / 2)
         pos_y = int((screen_y - size_y) / 2)
+        # return sentence_list message to be displayed, x & y pos of popup,
+        # screen size in x, y and popup size in x, y
         return sentence_list, pos_x, pos_y, screen_x, screen_y, size_x, size_y
 
     def display_popup(
@@ -917,13 +926,13 @@ class _GlancesCurses:
          else set it automatically
          Return True (yes) or False (no)
         """
-        # Center the popup
+        # Calculate the centre and content of the popup
         sentence_list, pos_x, pos_y, screen_x, screen_y, size_x, size_y = self.get_popup_size(
             message, size_x, size_y, popup_type, input_size
         )
 
         if size_x > screen_x or size_y > screen_y:
-            # No size to display the popup => abord
+            # No size to display the popup => abort
             return False
 
         # Create the popup
@@ -937,12 +946,14 @@ class _GlancesCurses:
             if m:
                 popup.addnstr(2 + y, 2, m, len(m))
 
+        # Popup is for 'info' ie display only
         if popup_type == 'info':
             # Display the popup
             popup.refresh()
             self.wait(duration * 1000)
             return True
 
+        # Popup accepts a input
         if popup_type == 'input':
             logger.info(popup_type)
             logger.info(is_password)
@@ -973,29 +984,40 @@ class _GlancesCurses:
                 return textbox.gather()[:-1]
             return None
 
+        # Popup accepts a user input as Y or N for yes no
         if popup_type == 'yesno':
             return self._handle_yesno_popup(popup, sentence_list, m)
         return None
 
     def _handle_yesno_popup(self, popup, sentence_list, m):
-        # Create a sub-window for the text field
+        # Create a 1x2 sub-window positioned after the last line of text;
+        # width/offset is based on the rendered message length (m)
         sub_pop = popup.derwin(1, 2, len(sentence_list) + 1, len(m) + 2)
+
+        # Apply input field styling (uses FILTER color scheme)
         sub_pop.attron(self.colors_list['FILTER'])
-        # Init the field with the current value
+
+        # Initialize the field (defensive: curses may raise on small windows)
         try:
             sub_pop.addnstr(0, 0, '', 0)
         except curses.error:
             pass
-        # Display the popup
+
+        # Ensure both parent popup and input field are rendered
         popup.refresh()
         sub_pop.refresh()
-        # Create the textbox inside the sub-windows
+
+        # Enable cursor + keypad for user input within the popup
         self.set_cursor(2)
         self.term_window.keypad(1)
+
+        # Create and run the Yes/No textbox (single-line input)
         textbox = GlancesTextboxYesNo(sub_pop, insert_mode=False)
         textbox.edit()
+
+        # Restore cursor state after input completes
         self.set_cursor(0)
-        # self.term_window.keypad(0)
+        # Return the captured user input
         return textbox.gather()
 
     def setup_upper_left_pos(self, plugin_stats):

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -985,6 +985,8 @@ class _GlancesCurses:
         # Password input: bypass curses textbox and use standard terminal input
         # (input is not displayed in the sub-window)
         if is_password:
+            if not sys.stdin.isatty():
+                return None
             textbox = getpass.getpass('')
             self.set_cursor(0)
             if textbox != '':


### PR DESCRIPTION
#### Description

This pull request refactors the display_popup method to reduce cyclomatic complexity and improve readability, while preserving existing behaviour.

The refactor extracts specific popup handling logic into dedicated fuctionality methods:

get_popup_size - to get the popup size 
_handle_yesno_popup - to handle popups which have a Y N user input requirement 
_handle_input_popup - to handle popups which need a user input with or without password

This reduces branching within display_popup and makes the code easier to understand and maintain.

The complexity score has significantly reduced from 16 to 8, indicative of a successful refactor. This change required particular care as display_popup operates within a curses-based terminal UI, where behaviour is tightly coupled to rendering, cursor state, and user input handling. As a result, the refactor was performed incrementally to ensure that the exact interaction flow and visual behaviour remained unchanged.

Additionally, comments within the code were upgraded across all these functions and in display_popup for ease of readability and future maintainability / scalability. 

No functional changes were introduced. The refactor was validated through existing tests (make test) which ran with no issues and manual testing of the curses-based UI. 

There were 3 levels of manual tests done : 

1. Test for popups which are 'info' and have a display component only 
2. Test for popups which are 'yesno' and have user input as a Y or N 
3. Test for popups which are 'input' type and need user input in the popup

#### Resume

* Bug fix: no
* New feature: no
* Fixed tickets: #3460 for function display_popup
