### PR TITLE
Keep auto_unit within limits, so columns stay aligned

### DIFF
--- a/glances/globals.py
+++ b/glances/globals.py
@@ -470,9 +470,9 @@ def auto_unit(number, low_precision=False, min_symbol='K', none_symbol='-'):
         value = float(number) / prefix[symbol]
         if value > 1:
             decimal_precision = 0
-            if value < 10:
+            if value <= 9.995:
                 decimal_precision = 2
-            elif value < 100:
+            elif value < 99.95:
                 decimal_precision = 1
             if low_precision:
                 if symbol in 'MK':

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -779,6 +779,30 @@ class TestGlances(unittest.TestCase):
         self.assertEqual(auto_unit(1073741824, low_precision=True), '1024M')
         self.assertEqual(auto_unit(1181116006), '1.10G')
         self.assertEqual(auto_unit(1181116006, low_precision=True), '1.1G')
+        # Edge cases:
+        m = 2**20
+        g = 2**30
+        self.assertEqual(auto_unit(9.9 * m), '9.90M')
+        self.assertEqual(auto_unit(9.99 * m), '9.99M')
+        self.assertEqual(auto_unit(9.991 * m), '9.99M')
+        self.assertEqual(auto_unit(9.994 * m), '9.99M')
+        self.assertEqual(auto_unit(9.995 * m), '9.99M')
+        self.assertEqual(auto_unit(10 * m), '10.0M')
+        self.assertEqual(auto_unit(99 * m), '99.0M')
+        self.assertEqual(auto_unit(99.9 * m), '99.9M')
+        self.assertEqual(auto_unit(99.91 * m), '99.9M')
+        self.assertEqual(auto_unit(99.94 * m), '99.9M')
+        self.assertEqual(auto_unit(100 * m), '100M')
+        # Special cases that used to overflow and misalign columns
+        self.assertEqual(auto_unit(9.996 * m), '10.0M')  # was 10.00M
+        self.assertEqual(auto_unit(9.999 * m), '10.0M')  # was 10.00M
+        self.assertEqual(auto_unit(99.95 * m), '100M')  # was 100.0M
+        self.assertEqual(auto_unit(99.96 * m), '100M')  # was 100.0M
+        self.assertEqual(auto_unit(99.99 * m), '100M')  # was 100.0M
+        self.assertEqual(auto_unit(10 * m - 1), '10.0M')  # was 10.00M
+        self.assertEqual(auto_unit(100 * m - 1), '100M')  # was 100.0M
+        self.assertEqual(auto_unit(10 * g - 1), '10.0G')  # was 10.00G
+        self.assertEqual(auto_unit(100 * g - 1), '100G')  # was 100.0G
 
     def test_094_thresholds(self):
         """Test thresholds classes"""


### PR DESCRIPTION
#### Description

Occasionally, columns got misaligned, because auto_unit returned too many decimals when the number was slightly below 10 or 100. Actually, when (9.995 <= n < 10) and (99.95 < n < 100).

For example,
`10*2**20-1` returned `10.00M` instead of `10.0M` and
`100*2**20-1` returned `100.0M` instead of `100M`.

Tests added to verify correctness.

#### Resume

* Bug fix: yes
