### PR TITLE
refactor: reduce cyclomatic complexity of load_additional_plugins

### DIFF
--- a/glances/stats.py
+++ b/glances/stats.py
@@ -144,61 +144,69 @@ please rename it to "{plugin_path.capitalize()}Plugin"'
         # Log plugins list
         logger.debug(f"Active plugins list: {self.getPluginsList()}")
 
-    def load_additional_plugins(self, args=None, config=None):
-        """Load additional plugins if defined"""
-
-        def get_addl_plugins(self, plugin_path):
-            """Get list of additional plugins"""
-            _plugin_list = []
-            for plugin in os.listdir(plugin_path):
-                path = os.path.join(plugin_path, plugin)
-                if os.path.isdir(path) and not path.startswith('__'):
-                    # Poor man's walk_pkgs - can't use pkgutil as the module would be already imported here!
-                    for fil in pathlib.Path(path).glob('*.py'):
-                        if fil.is_file():
-                            with open(fil) as fd:
-                                # The first test should be removed in Glances 5.x - see #3170
-                                if 'PluginModel' in fd.read() or plugin.capitalize() + 'Plugin' in fd.read():
-                                    _plugin_list.append(plugin)
-                                    break
-
-            return _plugin_list
-
+    def _resolve_additional_plugin_path(self, args=None, config=None):
+        """Return the additional plugin directory path, or None if not configured."""
         path = None
         # Skip section check as implied by has_option
         if config and config.parser.has_option('global', 'plugin_dir'):
             path = config.parser['global']['plugin_dir']
-
         if args and 'plugin_dir' in args and args.plugin_dir:
             path = args.plugin_dir
+        return path
 
-        if path:
-            # Get list before starting the counter
-            _sys_path = sys.path
-            start_duration = Counter()
-            # Ensure that plugins can be found in plugin_dir
-            sys.path.insert(0, path)
-            for plugin in get_addl_plugins(self, path):
-                if plugin in sys.modules:
-                    logger.warn(f"Plugin {plugin} already in sys.modules, skipping (workaround: rename plugin)")
-                else:
-                    start_duration.reset()
-                    try:
-                        _mod_loaded = import_module(plugin + '.model')
-                        self._plugins[plugin] = _mod_loaded.PluginModel(args=args, config=config)
-                        logger.debug(f"Plugin {plugin} started in {start_duration.get()} seconds")
-                    except Exception as e:
-                        # If a plugin can not be loaded, display a critical message
-                        # on the console but do not crash
-                        logger.critical(f"Error while initializing the {plugin} plugin ({e})")
-                        logger.error(traceback.format_exc())
-                        # An error occurred, disable the plugin
-                        if args:
-                            setattr(args, 'disable_' + plugin, False)
+    def _get_additional_plugin_list(self, plugin_path):
+        """Return a list of valid additional plugin names found in plugin_path."""
+        plugin_list = []
+        for plugin in os.listdir(plugin_path):
+            path = os.path.join(plugin_path, plugin)
+            if not os.path.isdir(path) or path.startswith('__'):
+                continue
+            # Poor man's walk_pkgs - can't use pkgutil as the module would be already imported here!
+            for fil in pathlib.Path(path).glob('*.py'):
+                if not fil.is_file():
+                    continue
+                with open(fil) as fd:
+                    content = fd.read()
+                # The first test should be removed in Glances 5.x - see #3170
+                if 'PluginModel' in content or plugin.capitalize() + 'Plugin' in content:
+                    plugin_list.append(plugin)
+                    break
+        return plugin_list
 
-            sys.path = _sys_path
-            # Log plugins list
-            logger.debug(f"Active additional plugins list: {self.getPluginsList()}")
+    def _load_plugin_from_path(self, plugin, args=None, config=None):
+        """Load a single additional plugin by name. Skips if already imported."""
+        if plugin in sys.modules:
+            logger.warn(f"Plugin {plugin} already in sys.modules, skipping (workaround: rename plugin)")
+            return
+        start_duration = Counter()
+        try:
+            _mod_loaded = import_module(plugin + '.model')
+            self._plugins[plugin] = _mod_loaded.PluginModel(args=args, config=config)
+            logger.debug(f"Plugin {plugin} started in {start_duration.get()} seconds")
+        except Exception as e:
+            # If a plugin can not be loaded, display a critical message
+            # on the console but do not crash
+            logger.critical(f"Error while initializing the {plugin} plugin ({e})")
+            logger.error(traceback.format_exc())
+            # An error occurred, disable the plugin
+            if args:
+                setattr(args, 'disable_' + plugin, False)
+
+    def load_additional_plugins(self, args=None, config=None):
+        """Load additional plugins if defined."""
+        path = self._resolve_additional_plugin_path(args=args, config=config)
+        if not path:
+            return
+
+        _sys_path = sys.path
+        # Ensure that plugins can be found in plugin_dir
+        sys.path.insert(0, path)
+        for plugin in self._get_additional_plugin_list(path):
+            self._load_plugin_from_path(plugin, args=args, config=config)
+        sys.path = _sys_path
+
+        # Log plugins list
+        logger.debug(f"Active additional plugins list: {self.getPluginsList()}")
 
     def load_exports(self, args=None):
         """Load all exporters in the 'exports' folder."""


### PR DESCRIPTION
## Summary

Reduces the cyclomatic complexity of `load_additional_plugins()` in `glances/stats.py` from 19 to well below the 15 threshold by splitting it into three focused helper methods:

- `_resolve_additional_plugin_path(args, config)` — resolves the plugin directory from config file or CLI args
- `_get_additional_plugin_list(plugin_path)` — scans the directory and returns names of valid plugins (replaces the inner `get_addl_plugins` closure)
- `_load_plugin_from_path(plugin, args, config)` — imports and registers a single plugin, with error handling

`load_additional_plugins()` itself becomes a simple early-return orchestrator (~6 lines).

No behavioral changes — pure refactoring.

Fixes #3460