### PR TITLE
feat: show slowest plugins in --issue output

### DIFF
--- a/glances/outputs/glances_stdout_issue.py
+++ b/glances/outputs/glances_stdout_issue.py
@@ -62,6 +62,14 @@ class GlancesStdoutIssue:
         sys.stdout.write(colors.NO + '\n')
         sys.stdout.flush()
 
+    def print_top_slowest_plugins(self, plugin_durations):
+        """Display the ten slowest plugin updates."""
+        sys.stdout.write('Top 10 slowest plugins:\n')
+        sys.stdout.write(f'{"Plugin":<30} {"Update duration":>15}\n')
+        for plugin, duration in sorted(plugin_durations, key=lambda item: item[1], reverse=True)[:10]:
+            sys.stdout.write(f'{plugin:<30} {duration:>14.5f}s\n')
+        sys.stdout.flush()
+
     def update(self, stats, duration=3):
         """Display issue"""
         self.print_version()
@@ -78,6 +86,7 @@ class GlancesStdoutIssue:
         time.sleep(2)
 
         counter_total = Counter()
+        plugin_durations = []
         for plugin in sorted(stats._plugins):
             if stats._plugins[plugin].is_disabled():
                 # If current plugin is disable
@@ -102,8 +111,10 @@ class GlancesStdoutIssue:
                         stat[key] = '***'
             except Exception as e:
                 stat_error = e
+            plugin_duration = counter.get()
+            plugin_durations.append((plugin, plugin_duration))
             if stat_error is None:
-                result = (colors.GREEN + '[OK]   ' + colors.BLUE + f' {counter.get():.5f}s ').rjust(41 - len(plugin))
+                result = (colors.GREEN + '[OK]   ' + colors.BLUE + f' {plugin_duration:.5f}s ').rjust(41 - len(plugin))
                 if isinstance(stat, list) and len(stat) > 0 and 'key' in stat[0]:
                     key = 'key={} '.format(stat[0]['key'])
                     stat_output = pprint.pformat([stat[0]], compact=True, width=120, depth=3)
@@ -111,7 +122,7 @@ class GlancesStdoutIssue:
                 else:
                     message = '\n' + colors.NO + pprint.pformat(stat, compact=True, width=120, depth=2)
             else:
-                result = (colors.RED + '[ERROR]' + colors.BLUE + f' {counter.get():.5f}s ').rjust(41 - len(plugin))
+                result = (colors.RED + '[ERROR]' + colors.BLUE + f' {plugin_duration:.5f}s ').rjust(41 - len(plugin))
                 message = colors.NO + str(stat_error)[0 : TERMINAL_WIDTH - 41]
 
             # Display the result
@@ -120,6 +131,7 @@ class GlancesStdoutIssue:
         # Display total time need to update all plugins
         sys.stdout.write('=' * TERMINAL_WIDTH + '\n')
         print(f"Total time to update all stats: {colors.BLUE}{counter_total.get():.5f}s{colors.NO}")
+        self.print_top_slowest_plugins(plugin_durations)
         sys.stdout.write('=' * TERMINAL_WIDTH + '\n')
 
         # Return True to exit directly (no refresh)

--- a/tests/test_stdout_issue.py
+++ b/tests/test_stdout_issue.py
@@ -18,8 +18,8 @@ def test_top_slowest_plugins_are_sorted_and_limited(capsys):
     screen.print_top_slowest_plugins(durations)
 
     lines = capsys.readouterr().out.splitlines()
-    assert lines[:2] == ["Top 10 slowest plugins:", "Plugin                         Update duration"]
-    assert lines[2].split() == ["plugin-11", "11.00000s"]
-    assert lines[-1].split() == ["plugin-2", "2.00000s"]
-    assert "plugin-1" not in lines
-    assert "plugin-0" not in lines
+    assert lines[:2] == ["Top 10 slowest plugins:", "Plugin                         Update duration"]  # nosec B101
+    assert lines[2].split() == ["plugin-11", "11.00000s"]  # nosec B101
+    assert lines[-1].split() == ["plugin-2", "2.00000s"]  # nosec B101
+    assert "plugin-1" not in lines  # nosec B101
+    assert "plugin-0" not in lines  # nosec B101

--- a/tests/test_stdout_issue.py
+++ b/tests/test_stdout_issue.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the --issue diagnostic output."""
+
+from glances.outputs.glances_stdout_issue import GlancesStdoutIssue
+
+
+def test_top_slowest_plugins_are_sorted_and_limited(capsys):
+    """The diagnostic table displays at most ten plugins, slowest first."""
+    screen = GlancesStdoutIssue()
+    durations = [(f"plugin-{index}", float(index)) for index in range(12)]
+
+    screen.print_top_slowest_plugins(durations)
+
+    lines = capsys.readouterr().out.splitlines()
+    assert lines[:2] == ["Top 10 slowest plugins:", "Plugin                         Update duration"]
+    assert lines[2].split() == ["plugin-11", "11.00000s"]
+    assert lines[-1].split() == ["plugin-2", "2.00000s"]
+    assert "plugin-1" not in lines
+    assert "plugin-0" not in lines


### PR DESCRIPTION
## Summary
- record each enabled plugin update duration during `--issue` diagnostics
- print a sorted top-10 slowest-plugin table after the total duration
- add focused coverage for sorting and the 10-row limit

## Tests
- `.venv/bin/python -m ruff check glances/outputs/glances_stdout_issue.py tests/test_stdout_issue.py`
- `.venv/bin/pytest tests/test_stdout_issue.py -q`

Closes #3571