### PR TITLE
refactor: reduce cyclomatic complexity of RAID plugin msg_curse (#3460)

### DIFF
--- a/glances/plugins/raid/__init__.py
+++ b/glances/plugins/raid/__init__.py
@@ -67,90 +67,98 @@ class RaidPlugin(GlancesPluginModel):
 
     def msg_curse(self, args=None, max_width=None):
         """Return the dict to display in the curse interface."""
-        # Init the return message
         ret = []
 
-        # Only process if stats exist...
         if not self.stats or self.is_disabled():
             return ret
 
-        # Max size for the interface name
-        if max_width:
-            name_max_width = max_width - 12
-        else:
-            # No max_width defined, return an empty curse message
+        if not max_width:
             logger.debug(f"No max_width defined for the {self.plugin_name} plugin, it will not be displayed.")
             return ret
+
+        name_max_width = max_width - 12
 
         # Header
         msg = '{:{width}}'.format('RAID disks', width=name_max_width)
         ret.append(self.curse_add_line(msg, "TITLE"))
-        msg = '{:>7}'.format('Used')
-        ret.append(self.curse_add_line(msg))
-        msg = '{:>7}'.format('Avail')
-        ret.append(self.curse_add_line(msg))
+        ret.append(self.curse_add_line('{:>7}'.format('Used')))
+        ret.append(self.curse_add_line('{:>7}'.format('Avail')))
+
         # Data
-        arrays = sorted(self.stats.keys())
-        for array in arrays:
+        for array in sorted(self.stats.keys()):
             array_stats = self.stats[array]
+            if isinstance(array_stats, dict):
+                ret.extend(self._msg_curse_array(array, array_stats, name_max_width))
 
-            if not isinstance(array_stats, dict):
-                continue
+        return ret
 
-            # Display the current status
-            status = self.raid_alert(
-                array_stats['status'],
-                array_stats['used'],
-                array_stats['available'],
-                array_stats['type'],
-            )
+    def _msg_curse_array(self, array, array_stats, name_max_width):
+        """Return curse lines for a single RAID array."""
+        ret = []
 
-            # New line
+        status = self.raid_alert(
+            array_stats['status'],
+            array_stats['used'],
+            array_stats['available'],
+            array_stats['type'],
+        )
+
+        array_type = array_stats['type'].upper() if array_stats['type'] is not None else 'UNKNOWN'
+        full_name = f'{array_type} {array}'
+
+        ret.append(self.curse_new_line())
+        ret.append(self.curse_add_line('{:{width}}'.format(full_name, width=name_max_width)))
+
+        if array_stats['type'] == 'raid0' and array_stats['status'] == 'active':
+            ret.extend(self._msg_curse_raid0_active(array_stats, status))
+        elif array_stats['status'] == 'active':
+            ret.extend(self._msg_curse_active(array_stats, status))
+        elif array_stats['status'] == 'inactive':
+            ret.extend(self._msg_curse_inactive(array_stats, status))
+
+        ret.extend(self._msg_curse_degraded(array_stats, status))
+
+        return ret
+
+    def _msg_curse_raid0_active(self, array_stats, status):
+        """Return curse lines for an active RAID-0 array."""
+        return [
+            self.curse_add_line('{:>7}'.format(len(array_stats['components'])), status),
+            self.curse_add_line('{:>7}'.format('-'), status),
+        ]
+
+    def _msg_curse_active(self, array_stats, status):
+        """Return curse lines for a non-RAID-0 active array."""
+        return [
+            self.curse_add_line('{:>7}'.format(array_stats['used']), status),
+            self.curse_add_line('{:>7}'.format(array_stats['available']), status),
+        ]
+
+    def _msg_curse_inactive(self, array_stats, status):
+        """Return curse lines for an inactive array with component listing."""
+        ret = [
+            self.curse_new_line(),
+            self.curse_add_line('└─ Status {}'.format(array_stats['status']), status),
+        ]
+        components = sorted(array_stats['components'].keys())
+        for i, component in enumerate(components):
+            tree_char = '└─' if i == len(components) - 1 else '├─'
             ret.append(self.curse_new_line())
-            # Data: RAID type name | disk used | disk available
-            array_type = array_stats['type'].upper() if array_stats['type'] is not None else 'UNKNOWN'
-            # Build the full name = array type + array name
-            full_name = f'{array_type} {array}'
-            msg = '{:{width}}'.format(full_name, width=name_max_width)
-            ret.append(self.curse_add_line(msg))
-            if array_stats['type'] == 'raid0' and array_stats['status'] == 'active':
-                msg = '{:>7}'.format(len(array_stats['components']))
-                ret.append(self.curse_add_line(msg, status))
-                msg = '{:>7}'.format('-')
-                ret.append(self.curse_add_line(msg, status))
-            elif array_stats['status'] == 'active':
-                msg = '{:>7}'.format(array_stats['used'])
-                ret.append(self.curse_add_line(msg, status))
-                msg = '{:>7}'.format(array_stats['available'])
-                ret.append(self.curse_add_line(msg, status))
-            elif array_stats['status'] == 'inactive':
-                ret.append(self.curse_new_line())
-                msg = '└─ Status {}'.format(array_stats['status'])
-                ret.append(self.curse_add_line(msg, status))
-                components = sorted(array_stats['components'].keys())
-                for i, component in enumerate(components):
-                    if i == len(components) - 1:
-                        tree_char = '└─'
-                    else:
-                        tree_char = '├─'
-                    ret.append(self.curse_new_line())
-                    msg = '   {} disk {}: '.format(tree_char, array_stats['components'][component])
-                    ret.append(self.curse_add_line(msg))
-                    msg = f'{component}'
-                    ret.append(self.curse_add_line(msg))
+            ret.append(self.curse_add_line('   {} disk {}: '.format(tree_char, array_stats['components'][component])))
+            ret.append(self.curse_add_line(f'{component}'))
+        return ret
 
-            if array_stats['type'] != 'raid0' and (
-                array_stats['used'] and array_stats['available'] and array_stats['used'] < array_stats['available']
-            ):
-                # Display current array configuration
+    def _msg_curse_degraded(self, array_stats, status):
+        """Return curse lines when a non-RAID-0 array is in degraded mode."""
+        ret = []
+        if array_stats['type'] != 'raid0' and (
+            array_stats['used'] and array_stats['available'] and array_stats['used'] < array_stats['available']
+        ):
+            ret.append(self.curse_new_line())
+            ret.append(self.curse_add_line('└─ Degraded mode', status))
+            if len(array_stats['config']) < 17:
                 ret.append(self.curse_new_line())
-                msg = '└─ Degraded mode'
-                ret.append(self.curse_add_line(msg, status))
-                if len(array_stats['config']) < 17:
-                    ret.append(self.curse_new_line())
-                    msg = '   └─ {}'.format(array_stats['config'].replace('_', 'A'))
-                    ret.append(self.curse_add_line(msg))
-
+                ret.append(self.curse_add_line('   └─ {}'.format(array_stats['config'].replace('_', 'A'))))
         return ret
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes part of #3460 — reduces cyclomatic complexity of `msg_curse` in `glances/plugins/raid/__init__.py` from **15** down to **~4** by extracting focused helper methods.

### What changed

The monolithic `msg_curse` method is refactored into five helpers:

| Helper | Responsibility |
|--------|---------------|
| `_msg_curse_array` | Renders a single RAID array entry (new line + name + delegates to status helpers) |
| `_msg_curse_raid0_active` | Lines for an active RAID-0 array |
| `_msg_curse_active` | Lines for a non-RAID-0 active array |
| `_msg_curse_inactive` | Lines for an inactive array with component tree |
| `_msg_curse_degraded` | Lines for degraded-mode arrays |

`msg_curse` itself now only handles the guard clauses, the header, and the loop — keeping each method single-purpose and easy to test independently.

### No behaviour change

The output produced is identical to the original; only the internal structure changed.

## Test plan

- [ ] Run `python -m pytest` (unit tests pass)
- [ ] Manual smoke-test: start glances on a machine with `/proc/mdstat` and confirm RAID section renders correctly