### PR TITLE
Fix AMD GPU detection for multi-digit DRM card numbers

### DIFF
--- a/glances/plugins/gpu/cards/amd.py
+++ b/glances/plugins/gpu/cards/amd.py
@@ -45,7 +45,7 @@ import os
 import re
 
 DRM_ROOT_FOLDER: str = '/sys/class/drm'
-DEVICE_FOLDER_PATTERN: str = 'card[0-9]/device'
+DEVICE_FOLDER_PATTERN: str = 'card[0-9]*/device'
 AMDGPU_IDS_FILE: str = '/usr/share/libdrm/amdgpu.ids'
 PCI_DEVICE_ID: str = 'device'
 PCI_REVISION_ID: str = 'revision'


### PR DESCRIPTION
#### Description

Currently, the AMD GPU card-discovery glob only matched single-digit DRM card numbers (`card0`-`card9`), so sometimes AMD GPUs are never found fully.

Linux DRM `cardN` names are DRM device nodes, not AMD GPU IDs. The [kernel DRM docs](https://docs.kernel.org/gpu/drm-uapi.html) describe `card` as the primary DRM node, while [AMD SMI](https://rocm.docs.amd.com/projects/amdsmi/en/develop/conceptual/partition.html) anchors physical AMD GPU identity around PCI BDF/UUID and models MI300/MI350 partitioning as logical devices under a physical GPU package. Newer AMD SMI versions can also expose explicit DRM card/render-node mappings through enumeration output, but the important point is that `cardN` itself is not the GPU ordinal. That means code should not assume AMD GPU 0 maps to `card0`, GPU 1 maps to `card1`, or that all physical GPUs must appear below `card9`.


On our AMD Instinct MI350X system as an example that surfaced this issue, the 8 physical Instinct GPUs appeared as: `card1, card9, card17, card25, card33, card41, card49, card57`. The gaps came from other DRM nodes in the same namespace, including the onboard BMC/display node and MI300 XCP/partition-related nodes. The old `card[0-9]` glob only considered `card1` and `card9`, so glances reported 2 of 8 GPUs. 

#### Resume

* Bug fix: yes
* New feature: no

