### PR TITLE
docs: fix typos

### DIFF
--- a/README-pypi.rst
+++ b/README-pypi.rst
@@ -230,7 +230,7 @@ To install it, use the following command:
 
     pip install --user 'glances[web]'
 
-For a full installation (with all features, see features list bellow):
+For a full installation (with all features, see features list below):
 
 .. code-block:: console
 

--- a/README.rst
+++ b/README.rst
@@ -290,7 +290,7 @@ To install it, use the following command:
 
     pip install 'glances[web]'
 
-For a full installation (with all features, see features list bellow):
+For a full installation (with all features, see features list below):
 
 .. code-block:: console
 

--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -972,7 +972,7 @@ class _GlancesCurses:
                     self.display_plugin(stat_display[p])
 
     def get_popup_size(self, message, size_x, size_y, popup_type, input_size):
-        # Split the message into lines (seperated by \n)
+        # Split the message into lines (separated by \n)
         sentence_list = message.split('\n')
         # If length size_x has not been give, calculate the same
         # as a calculation of the max sentence length


### PR DESCRIPTION
## Summary
- Fix a small set of spelling mistakes in documentation/comments.
- Keep the change scoped to text-only cleanup.

## Validation
- git diff --check