### PR TITLE
Add sensors temperature mean option

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -498,6 +498,8 @@ refresh=10
 hide=unknown.*
 # Show only the following sensors (comma separated list of regexp)
 #show=CPU.*
+# Display CPU core temperatures as a single mean value (default is false)
+temperature_core_mean=false
 # Sensors core thresholds (in Celsius...)
 # Note: By default values are grabbed from the system (if values are available)
 # Core temperature thresholds in °C

--- a/docker-compose/glances.conf
+++ b/docker-compose/glances.conf
@@ -498,6 +498,8 @@ refresh=10
 hide=unknown.*
 # Show only the following sensors (comma separated list of regexp)
 #show=CPU.*
+# Display CPU core temperatures as a single mean value (default is false)
+temperature_core_mean=false
 # Sensors core thresholds (in Celsius...)
 # Note: By default values are grabbed from the system (if values are available)
 # Core temperature thresholds in °C

--- a/docs/aoa/sensors.rst
+++ b/docs/aoa/sensors.rst
@@ -22,6 +22,8 @@ thresholds (default behavor).
 .. code-block:: ini
 
     [sensors]
+    # Display CPU core temperatures as a single mean value (default is false)
+    temperature_core_mean=false
     # Sensors core thresholds (in Celsius...)
     # Note: By default values are grabbed from the system (if values are available)
     # Core temperature thresholds in °C

--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -8,6 +8,7 @@
 
 """Sensors plugin."""
 
+import re
 import warnings
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
@@ -134,8 +135,31 @@ class SensorsPlugin(GlancesPluginModel):
             stats_transformed.append(stat)
         # Remove duplicates thanks to https://stackoverflow.com/a/9427216/1919431
         stats_transformed = [dict(t) for t in {tuple(d.items()) for d in stats_transformed}]
+        stats_transformed = self.__mean_temperature_core_sensors(stats_transformed)
         # Sort by label
         return sorted(stats_transformed, key=lambda d: natural_keys(d['label']))
+
+    def __mean_temperature_core_sensors(self, stats: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        if self.get_conf_value('mean', header='temperature_core', default=['false'])[0].lower() != 'true':
+            return stats
+
+        core_stats = []
+        other_stats = []
+        for stat in stats:
+            if stat.get('type') == sensors_definition.get('cpu_temp').get('type') and re.fullmatch(
+                r'Core \d+', stat.get('label', '')
+            ):
+                core_stats.append(stat)
+            else:
+                other_stats.append(stat)
+
+        if not core_stats:
+            return stats
+
+        mean_sensor = core_stats[0].copy()
+        mean_sensor['label'] = 'Core (mean)'
+        mean_sensor['value'] = int(round(sum(stat['value'] for stat in core_stats) / len(core_stats)))
+        return [*other_stats, mean_sensor]
 
     @GlancesPluginModel._check_decorator
     @GlancesPluginModel._log_result_decorator

--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -158,7 +158,7 @@ class SensorsPlugin(GlancesPluginModel):
 
         mean_sensor = core_stats[0].copy()
         mean_sensor['label'] = 'Core (mean)'
-        mean_sensor['value'] = int(round(sum(stat['value'] for stat in core_stats) / len(core_stats)))
+        mean_sensor['value'] = int((sum(stat['value'] for stat in core_stats) / len(core_stats)) + 0.5)
         return [*other_stats, mean_sensor]
 
     @GlancesPluginModel._check_decorator

--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -331,7 +331,7 @@ class SensorsPlugin(GlancesPluginModel):
         return ret
 
 
-class GlancesGrabSensors:
+class GlancesGrabSensors:  # pylint: disable=too-few-public-methods
     """Get sensors stats."""
 
     def __init__(self, sensor_def: dict):

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -340,22 +340,21 @@ def test_temperature_core_mean_option_groups_core_temperatures(sensors_plugin, c
             return ['true']
         return []
 
-    def update_sensors():
-        """Return test core temperature values."""
-        return [
-            {'label': f'Core {index}', 'unit': 'C', 'value': value, 'warning': 80, 'critical': 100}
-            for index, value in enumerate(core_values)
-        ]
-
     class TemperatureGrabber:
+        def __init__(self, values):
+            self.values = values
+
         def update(self):
             """Return test core temperature values."""
-            return update_sensors()
+            return [
+                {'label': f'Core {index}', 'unit': 'C', 'value': value, 'warning': 80, 'critical': 100}
+                for index, value in enumerate(self.values)
+            ]
 
     plugin_args = copy(sensors_plugin.args)
     plugin_args.disable_sensors = False
     plugin = SensorsPlugin(args=plugin_args)
-    plugin.sensors_grab_map = {'temperature_core': TemperatureGrabber()}
+    plugin.sensors_grab_map = {'temperature_core': TemperatureGrabber(core_values)}
     plugin.get_conf_value = get_conf_value
 
     stats = plugin.update()

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -354,7 +354,7 @@ def test_temperature_core_mean_option_groups_core_temperatures(sensors_plugin, c
 
     stats = plugin.update()
 
-    assert len(stats) == 1
-    assert stats[0]['label'] == 'Core (mean)'
-    assert stats[0]['value'] == expected_mean
-    assert stats[0]['type'] == 'temperature_core'
+    assert len(stats) == 1  # nosec B101
+    assert stats[0]['label'] == 'Core (mean)'  # nosec B101
+    assert stats[0]['value'] == expected_mean  # nosec B101
+    assert stats[0]['type'] == 'temperature_core'  # nosec B101

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -10,7 +10,6 @@
 """Tests for the Sensors plugin."""
 
 import json
-from unittest.mock import Mock
 
 import pytest
 
@@ -80,43 +79,6 @@ class TestSensorsPluginUpdate:
         stats = sensors_plugin.get_raw()
         for sensor in stats:
             assert 'unit' in sensor
-
-    @pytest.mark.parametrize(
-        "core_values, expected_mean",
-        [
-            ([43, 42, 41], 42),
-            ([40, 41], 41),
-            ([44, 45, 46, 47], 46),
-        ],
-    )
-    def test_temperature_core_mean_option_groups_core_temperatures(self, sensors_plugin, core_values, expected_mean):
-        """Test that temperature_core_mean groups core temperatures."""
-
-        def get_conf_value(value, header="", **_kwargs):
-            """Return test configuration values."""
-            if value == 'mean' and header == 'temperature_core':
-                return ['true']
-            return []
-
-        plugin = SensorsPlugin(args=sensors_plugin.args)
-        plugin.sensors_grab_map = {
-            'temperature_core': Mock(
-                update=Mock(
-                    return_value=[
-                        {'label': f'Core {index}', 'unit': 'C', 'value': value, 'warning': 80, 'critical': 100}
-                        for index, value in enumerate(core_values)
-                    ]
-                )
-            )
-        }
-        plugin.get_conf_value = Mock(side_effect=get_conf_value)
-
-        stats = plugin.update()
-
-        assert len(stats) == 1
-        assert stats[0]['label'] == 'Core (mean)'
-        assert stats[0]['value'] == expected_mean
-        assert stats[0]['type'] == 'temperature_core'
 
 
 class TestSensorsPluginTypes:
@@ -359,3 +321,40 @@ class TestSensorsPluginAlerts:
             if label in views and 'value' in views[label]:
                 if sensor['value']:  # Only check if value is not empty
                     assert 'decoration' in views[label]['value']
+
+
+@pytest.mark.parametrize(
+    "core_values, expected_mean",
+    [
+        ([43, 42, 41], 42),
+        ([40, 41], 41),
+        ([44, 45, 46, 47], 46),
+    ],
+)
+def test_temperature_core_mean_option_groups_core_temperatures(sensors_plugin, core_values, expected_mean):
+    """Test that temperature_core_mean groups core temperatures."""
+    def get_conf_value(value, header="", **_kwargs):
+        """Return test configuration values."""
+        if value == 'mean' and header == 'temperature_core':
+            return ['true']
+        return []
+
+    def update_sensors():
+        """Return test core temperature values."""
+        return [
+            {'label': f'Core {index}', 'unit': 'C', 'value': value, 'warning': 80, 'critical': 100}
+            for index, value in enumerate(core_values)
+        ]
+
+    plugin = SensorsPlugin(args=sensors_plugin.args)
+    plugin.sensors_grab_map = {
+        'temperature_core': type('TemperatureGrabber', (), {'update': staticmethod(update_sensors)})()
+    }
+    plugin.get_conf_value = get_conf_value
+
+    stats = plugin.update()
+
+    assert len(stats) == 1
+    assert stats[0]['label'] == 'Core (mean)'
+    assert stats[0]['value'] == expected_mean
+    assert stats[0]['type'] == 'temperature_core'

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -340,24 +340,24 @@ def test_temperature_core_mean_option_groups_core_temperatures(sensors_plugin, c
             return ['true']
         return []
 
-    class TemperatureGrabber:
-        def __init__(self, values):
-            self.values = values
-
-        def update(self):
-            """Return test core temperature values."""
-            return [
-                {'label': f'Core {index}', 'unit': 'C', 'value': value, 'warning': 80, 'critical': 100}
-                for index, value in enumerate(self.values)
-            ]
-
     plugin_args = copy(sensors_plugin.args)
     plugin_args.disable_sensors = False
     plugin = SensorsPlugin(args=plugin_args)
-    plugin.sensors_grab_map = {'temperature_core': TemperatureGrabber(core_values)}
     plugin.get_conf_value = get_conf_value
 
-    stats = plugin.update()
+    stats = plugin._SensorsPlugin__transform_sensors(  # noqa: SLF001
+        [
+            {
+                'label': f'Core {index}',
+                'unit': 'C',
+                'value': value,
+                'warning': 80,
+                'critical': 100,
+                'type': 'temperature_core',
+            }
+            for index, value in enumerate(core_values)
+        ]
+    )
 
     assert len(stats) == 1  # nosec B101
     assert stats[0]['label'] == 'Core (mean)'  # nosec B101

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -348,9 +348,6 @@ def test_temperature_core_mean_option_groups_core_temperatures(sensors_plugin, c
         ]
 
     class TemperatureGrabber:
-
-        """Test temperature grabber."""
-
         def update(self):
             """Return test core temperature values."""
             return update_sensors()

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -14,7 +14,7 @@ import json
 import pytest
 
 from glances.globals import LINUX
-from glances.plugins.sensors import GlancesGrabSensors
+from glances.plugins.sensors import GlancesGrabSensors, SensorsPlugin
 
 
 @pytest.fixture
@@ -79,6 +79,28 @@ class TestSensorsPluginUpdate:
         stats = sensors_plugin.get_raw()
         for sensor in stats:
             assert 'unit' in sensor
+
+    def test_temperature_core_mean_option_groups_core_temperatures(self, sensors_plugin):
+        """Test that temperature_core_mean groups core temperatures."""
+
+        class FakeTemperatureGrabber:
+            def update(self):
+                return [
+                    {'label': 'Core 0', 'unit': 'C', 'value': 43, 'warning': 80, 'critical': 100},
+                    {'label': 'Core 1', 'unit': 'C', 'value': 42, 'warning': 80, 'critical': 100},
+                    {'label': 'Core 2', 'unit': 'C', 'value': 41, 'warning': 80, 'critical': 100},
+                ]
+
+        plugin = SensorsPlugin(args=sensors_plugin.args)
+        plugin.sensors_grab_map = {'temperature_core': FakeTemperatureGrabber()}
+        plugin._limits['sensors_temperature_core_mean'] = ['true']
+
+        stats = plugin.update()
+
+        assert len(stats) == 1
+        assert stats[0]['label'] == 'Core (mean)'
+        assert stats[0]['value'] == 42
+        assert stats[0]['type'] == 'temperature_core'
 
 
 class TestSensorsPluginTypes:

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -10,6 +10,7 @@
 """Tests for the Sensors plugin."""
 
 import json
+from copy import copy
 
 import pytest
 
@@ -346,10 +347,17 @@ def test_temperature_core_mean_option_groups_core_temperatures(sensors_plugin, c
             for index, value in enumerate(core_values)
         ]
 
-    plugin = SensorsPlugin(args=sensors_plugin.args)
-    plugin.sensors_grab_map = {
-        'temperature_core': type('TemperatureGrabber', (), {'update': staticmethod(update_sensors)})()
-    }
+    class TemperatureGrabber:
+        """Test temperature grabber."""
+
+        def update(self):
+            """Return test core temperature values."""
+            return update_sensors()
+
+    plugin_args = copy(sensors_plugin.args)
+    plugin_args.disable_sensors = False
+    plugin = SensorsPlugin(args=plugin_args)
+    plugin.sensors_grab_map = {'temperature_core': TemperatureGrabber()}
     plugin.get_conf_value = get_conf_value
 
     stats = plugin.update()

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -10,6 +10,7 @@
 """Tests for the Sensors plugin."""
 
 import json
+from unittest.mock import Mock
 
 import pytest
 
@@ -80,26 +81,41 @@ class TestSensorsPluginUpdate:
         for sensor in stats:
             assert 'unit' in sensor
 
-    def test_temperature_core_mean_option_groups_core_temperatures(self, sensors_plugin):
+    @pytest.mark.parametrize(
+        "core_values, expected_mean",
+        [
+            ([43, 42, 41], 42),
+            ([40, 41], 41),
+            ([44, 45, 46, 47], 46),
+        ],
+    )
+    def test_temperature_core_mean_option_groups_core_temperatures(self, sensors_plugin, core_values, expected_mean):
         """Test that temperature_core_mean groups core temperatures."""
 
-        class FakeTemperatureGrabber:
-            def update(self):
-                return [
-                    {'label': 'Core 0', 'unit': 'C', 'value': 43, 'warning': 80, 'critical': 100},
-                    {'label': 'Core 1', 'unit': 'C', 'value': 42, 'warning': 80, 'critical': 100},
-                    {'label': 'Core 2', 'unit': 'C', 'value': 41, 'warning': 80, 'critical': 100},
-                ]
+        def get_conf_value(value, header="", **_kwargs):
+            """Return test configuration values."""
+            if value == 'mean' and header == 'temperature_core':
+                return ['true']
+            return []
 
         plugin = SensorsPlugin(args=sensors_plugin.args)
-        plugin.sensors_grab_map = {'temperature_core': FakeTemperatureGrabber()}
-        plugin._limits['sensors_temperature_core_mean'] = ['true']
+        plugin.sensors_grab_map = {
+            'temperature_core': Mock(
+                update=Mock(
+                    return_value=[
+                        {'label': f'Core {index}', 'unit': 'C', 'value': value, 'warning': 80, 'critical': 100}
+                        for index, value in enumerate(core_values)
+                    ]
+                )
+            )
+        }
+        plugin.get_conf_value = Mock(side_effect=get_conf_value)
 
         stats = plugin.update()
 
         assert len(stats) == 1
         assert stats[0]['label'] == 'Core (mean)'
-        assert stats[0]['value'] == 42
+        assert stats[0]['value'] == expected_mean
         assert stats[0]['type'] == 'temperature_core'
 
 

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -348,6 +348,7 @@ def test_temperature_core_mean_option_groups_core_temperatures(sensors_plugin, c
         ]
 
     class TemperatureGrabber:
+
         """Test temperature grabber."""
 
         def update(self):


### PR DESCRIPTION
﻿## Summary
- add a `temperature_core_mean` option for the sensors plugin
- aggregate `Core N` CPU temperature sensors into a single `Core (mean)` entry when enabled
- document the new option in the sample configuration files and sensors documentation

## Verification
- `.\.venv\Scripts\python -m pytest tests\test_plugin_sensors.py`
- `.\.venv\Scripts\python -m ruff check glances\plugins\sensors\__init__.py tests\test_plugin_sensors.py`
- manually verified fake Core 0/1/2 readings aggregate to `Core (mean)` with value `42`

Closes #3604
