### PR TITLE
Sensors: grab temperatures on Windows from LibreHardwareMonitor

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -488,6 +488,15 @@ disable=False
 host=127.0.0.1
 port=7634
 
+[librehardwaremonitor]
+# Windows only: grab temperatures from the LibreHardwareMonitor web server
+# The "Remote Web Server" option should be enabled in LibreHardwareMonitor
+# https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
+disable=False
+# Define LibreHardwareMonitor web server IP and port (default is 127.0.0.1 and 8085 (TCP))
+host=127.0.0.1
+port=8085
+
 [sensors]
 # Documentation: https://glances.readthedocs.io/en/latest/aoa/sensors.html
 disable=False

--- a/docs/aoa/sensors.rst
+++ b/docs/aoa/sensors.rst
@@ -3,7 +3,7 @@
 Sensors
 =======
 
-*Availability: Linux*
+*Availability: Linux, Windows (temperatures, through LibreHardwareMonitor)*
 
 .. image:: ../_static/sensors.png
 
@@ -12,6 +12,21 @@ Glances can display the sensors information using ``psutil``,
 - motherboard and CPU temperatures
 - hard disk temperature
 - battery capacity
+
+On Windows, ``psutil`` does not provide temperatures. Glances can grab
+them from the `LibreHardwareMonitor
+<https://github.com/LibreHardwareMonitor/LibreHardwareMonitor>`_ web
+server instead. Run LibreHardwareMonitor, enable the *Remote Web Server*
+option (default port 8085) and (re)start Glances. The web server address
+can be changed in the configuration file under the
+``[librehardwaremonitor]`` section:
+
+.. code-block:: ini
+
+    [librehardwaremonitor]
+    # Define LibreHardwareMonitor web server IP and port (default is 127.0.0.1 and 8085 (TCP))
+    host=127.0.0.1
+    port=8085
 
 Limit values and sensors alias names can be defined in the configuration
 file under the ``[sensors]`` section.

--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -96,20 +96,29 @@ class SensorsPlugin(GlancesPluginModel):
 
         self.sensors_grab_map = {}
 
+        librehardwaremonitor_hdd_plugin = None
         if glances_grab_sensors_cpu_temp.init:
             self.sensors_grab_map[sensors_definition.get('cpu_temp').get('type')] = glances_grab_sensors_cpu_temp
         elif WINDOWS:
             # On Windows, psutil does not provide temperatures (see issue #3265)
-            # Grab them from the LibreHardwareMonitor web server (if available)
+            # Grab them from the LibreHardwareMonitor web server (if available):
+            # one instance for the CPU/motherboard/GPU temperatures and one for
+            # the disks ones (displayed as temperature_hdd, see below)
             start_duration.reset()
             librehardwaremonitor_plugin = LibrehardwaremonitorPlugin(args=args, config=config)
+            librehardwaremonitor_hdd_plugin = LibrehardwaremonitorPlugin(args=args, config=config, storage=True)
             logger.debug(f"LibreHardwareMonitor sensor plugin init duration: {start_duration.get()} seconds")
             self.sensors_grab_map[sensors_definition.get('cpu_temp').get('type')] = librehardwaremonitor_plugin
 
         if glances_grab_sensors_fan_speed.init:
             self.sensors_grab_map[sensors_definition.get('fan_speed').get('type')] = glances_grab_sensors_fan_speed
 
-        self.sensors_grab_map[sensors_definition.get('hdd_temp').get('type')] = hddtemp_plugin
+        if librehardwaremonitor_hdd_plugin is not None:
+            # On Windows, the hddtemp daemon is not available: grab the disks
+            # temperatures from the LibreHardwareMonitor web server too
+            self.sensors_grab_map[sensors_definition.get('hdd_temp').get('type')] = librehardwaremonitor_hdd_plugin
+        else:
+            self.sensors_grab_map[sensors_definition.get('hdd_temp').get('type')] = hddtemp_plugin
         self.sensors_grab_map[sensors_definition.get('battery').get('type')] = batpercent_plugin
 
         # We want to display the stat in the curse interface

--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -245,6 +245,17 @@ class SensorsPlugin(GlancesPluginModel):
             elif i['type'] == sensors_definition.get('battery').get('type'):
                 # Battery is in %
                 alert = self.get_alert(current=100 - i['value'], header=i['type'])
+            elif (
+                i['type'] == sensors_definition.get('hdd_temp').get('type')
+                and i.get('critical') is not None
+                and not self.is_limit('critical', stat_name=i['type'] + '_' + i['label'])
+            ):
+                # Disks sensors may carry their own thresholds (e.g. NVMe drives
+                # through LibreHardwareMonitor, see #3265): prefer them over the
+                # generic temperature_hdd limits (which are always set, see the
+                # set_default_cwc call in config.py), but not over a limit set
+                # for this specific sensor in the glances.conf file
+                alert = self.__get_system_thresholds(i)
             else:
                 alert = self.get_alert(current=i['value'], header=i['type'])
             # Set the alert in the view

--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -14,12 +14,13 @@ from typing import Any
 
 import psutil
 
-from glances.globals import natural_keys, to_fahrenheit
+from glances.globals import WINDOWS, natural_keys, to_fahrenheit
 from glances.logger import logger
 from glances.outputs.glances_unicode import unicode_message
 from glances.plugins.plugin.model import GlancesPluginModel
 from glances.plugins.sensors.sensor.glances_batpercent import BatpercentPlugin
 from glances.plugins.sensors.sensor.glances_hddtemp import HddtempPlugin
+from glances.plugins.sensors.sensor.glances_librehardwaremonitor import LibrehardwaremonitorPlugin
 from glances.timer import Counter
 
 # Define all kind of sensors available in Glances
@@ -97,6 +98,13 @@ class SensorsPlugin(GlancesPluginModel):
 
         if glances_grab_sensors_cpu_temp.init:
             self.sensors_grab_map[sensors_definition.get('cpu_temp').get('type')] = glances_grab_sensors_cpu_temp
+        elif WINDOWS:
+            # On Windows, psutil does not provide temperatures (see issue #3265)
+            # Grab them from the LibreHardwareMonitor web server (if available)
+            start_duration.reset()
+            librehardwaremonitor_plugin = LibrehardwaremonitorPlugin(args=args, config=config)
+            logger.debug(f"LibreHardwareMonitor sensor plugin init duration: {start_duration.get()} seconds")
+            self.sensors_grab_map[sensors_definition.get('cpu_temp').get('type')] = librehardwaremonitor_plugin
 
         if glances_grab_sensors_fan_speed.init:
             self.sensors_grab_map[sensors_definition.get('fan_speed').get('type')] = glances_grab_sensors_fan_speed

--- a/glances/plugins/sensors/sensor/glances_librehardwaremonitor.py
+++ b/glances/plugins/sensors/sensor/glances_librehardwaremonitor.py
@@ -12,7 +12,7 @@ Grab temperatures from the LibreHardwareMonitor embedded web server:
 https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
 
 The "Remote Web Server" option should be enabled in LibreHardwareMonitor
-(File > Web Server > Run). Default URL: http://localhost:8085
+(Options > Remote Web Server > Run). Default URL: http://localhost:8085
 """
 
 import json
@@ -21,14 +21,27 @@ from urllib.request import urlopen
 from glances.logger import logger
 from glances.plugins.plugin.model import GlancesPluginModel
 
+# NVMe drives expose their thresholds constants as pseudo temperature sensors:
+# do not report them as readings but as the warning/critical values of the
+# real temperature sensors of the same hardware
+GROUP_THRESHOLDS = {'Warning Temperature': 'warning', 'Critical Temperature': 'critical'}
+
+# Pseudo temperature sensors which are not actual readings
+# ('Distance to TjMax' is an inverted thermal margin: higher means cooler)
+EXCLUDED_SENSORS = ('Distance to TjMax',)
+
 
 class LibrehardwaremonitorPlugin(GlancesPluginModel):
     """Glances LibreHardwareMonitor temperatures plugin.
 
+    If storage is True, only the disks temperatures are grabbed (to be
+    displayed as temperature_hdd), else only the non disks ones (CPU,
+    motherboard, GPU... to be displayed as temperature_core).
+
     stats is a list
     """
 
-    def __init__(self, args=None, config=None):
+    def __init__(self, args=None, config=None, storage=False):
         """Init the plugin."""
         super().__init__(args=args, config=config, stats_init_value=[])
 
@@ -40,7 +53,7 @@ class LibrehardwaremonitorPlugin(GlancesPluginModel):
         if config is not None and config.has_section('librehardwaremonitor'):
             lhm_host = config.get_value('librehardwaremonitor', 'host', default=lhm_host)
             lhm_port = int(config.get_value('librehardwaremonitor', 'port', default=lhm_port))
-        self.lhm = GlancesGrabLHM(host=lhm_host, port=lhm_port)
+        self.lhm = GlancesGrabLHM(host=lhm_host, port=lhm_port, storage=storage)
 
         # We do not want to display the stat in a dedicated area
         # The LibreHardwareMonitor temperatures are displayed within the sensors plugin
@@ -70,9 +83,10 @@ class LibrehardwaremonitorPlugin(GlancesPluginModel):
 class GlancesGrabLHM:
     """Get temperatures from the LibreHardwareMonitor web server (data.json)."""
 
-    def __init__(self, host='127.0.0.1', port=8085):
+    def __init__(self, host='127.0.0.1', port=8085, storage=False):
         """Init the LibreHardwareMonitor stats."""
         self.url = f'http://{host}:{port}/data.json'
+        self.storage = storage
         self.last_fetch_ok = True
 
     def fetch(self):
@@ -109,30 +123,54 @@ class GlancesGrabLHM:
         except (AttributeError, IndexError, ValueError):
             return None
 
-    def _walk(self, node, chain, ret):
+    def _group_thresholds(self, children):
+        """Return the warning/critical thresholds exposed as pseudo sensors (NVMe)."""
+        thresholds = {}
+        for child in children:
+            if child.get('Text') in GROUP_THRESHOLDS and self._is_temperature(child):
+                value = self._parse_value(child.get('Value'))
+                if value is not None:
+                    thresholds[GROUP_THRESHOLDS[child.get('Text')]] = int(value)
+        return thresholds
+
+    def _walk(self, node, ancestors, ret):
         """Walk the data.json tree and add the temperature sensors to the ret list.
 
-        chain is the list of the parent nodes names (used to build the sensor label).
+        ancestors is the list of the parent nodes (used to get the hardware name).
         """
         children = node.get('Children') or []
-        if children:
-            for child in children:
-                self._walk(child, chain + [node.get('Text', '')], ret)
-        elif self._is_temperature(node):
-            value = self._parse_value(node.get('Value'))
+        if not children:
+            return
+
+        thresholds = self._group_thresholds(children)
+
+        for child in children:
+            if child.get('Children'):
+                self._walk(child, ancestors + [node], ret)
+                continue
+            if not self._is_temperature(child):
+                continue
+            text = child.get('Text', '')
+            if text in GROUP_THRESHOLDS or any(e in text for e in EXCLUDED_SENSORS):
+                continue
+            value = self._parse_value(child.get('Value'))
             if value is None:
-                return
-            # chain example: ['Sensor', 'MY-PC', 'Nuvoton NCT6793D', 'Temperatures']
-            # The hardware name is the parent of the 'Temperatures' category node
-            hardware = chain[-2] if len(chain) >= 2 else ''
-            label = f"{hardware} {node.get('Text', '')}".strip()
+                continue
+            # The parent of the sensors category node ("Temperatures") is the hardware node
+            hardware = ancestors[-1] if ancestors else {}
+            # Grab either the disks temperatures or the other ones (see storage flag)
+            if ('hdd' in hardware.get('ImageURL', '')) != self.storage:
+                continue
+            # Sensor name first so that the labels stay distinguishable when
+            # truncated in the TUI (hardware names can be very long)
+            hardware_text = hardware.get('Text', '')
             ret.append(
                 {
-                    'label': label,
+                    'label': f"{text} ({hardware_text})" if hardware_text else text,
                     'unit': 'C',
                     'value': value,
-                    'warning': None,
-                    'critical': None,
+                    'warning': thresholds.get('warning'),
+                    'critical': thresholds.get('critical'),
                 }
             )
 

--- a/glances/plugins/sensors/sensor/glances_librehardwaremonitor.py
+++ b/glances/plugins/sensors/sensor/glances_librehardwaremonitor.py
@@ -1,0 +1,146 @@
+#
+# This file is part of Glances.
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""LibreHardwareMonitor temperatures plugin (Windows only).
+
+Grab temperatures from the LibreHardwareMonitor embedded web server:
+https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
+
+The "Remote Web Server" option should be enabled in LibreHardwareMonitor
+(File > Web Server > Run). Default URL: http://localhost:8085
+"""
+
+import json
+from urllib.request import urlopen
+
+from glances.logger import logger
+from glances.plugins.plugin.model import GlancesPluginModel
+
+
+class LibrehardwaremonitorPlugin(GlancesPluginModel):
+    """Glances LibreHardwareMonitor temperatures plugin.
+
+    stats is a list
+    """
+
+    def __init__(self, args=None, config=None):
+        """Init the plugin."""
+        super().__init__(args=args, config=config, stats_init_value=[])
+
+        # Init the sensor class
+        # Note: the [librehardwaremonitor] section is read from the config object
+        # because plugin_name is 'sensors' for all the sensors sub-plugins
+        lhm_host = '127.0.0.1'
+        lhm_port = 8085
+        if config is not None and config.has_section('librehardwaremonitor'):
+            lhm_host = config.get_value('librehardwaremonitor', 'host', default=lhm_host)
+            lhm_port = int(config.get_value('librehardwaremonitor', 'port', default=lhm_port))
+        self.lhm = GlancesGrabLHM(host=lhm_host, port=lhm_port)
+
+        # We do not want to display the stat in a dedicated area
+        # The LibreHardwareMonitor temperatures are displayed within the sensors plugin
+        self.display_curse = False
+
+    @GlancesPluginModel._log_result_decorator
+    def update(self):
+        """Update LibreHardwareMonitor stats using the input method."""
+        # Init new stats
+        stats = self.get_init_value()
+
+        if self.input_method == 'local':
+            # Update stats using the LibreHardwareMonitor web server
+            stats = self.lhm.get()
+
+        else:
+            # Update stats using SNMP
+            # Not available for the moment
+            pass
+
+        # Update the stats
+        self.stats = stats
+
+        return self.stats
+
+
+class GlancesGrabLHM:
+    """Get temperatures from the LibreHardwareMonitor web server (data.json)."""
+
+    def __init__(self, host='127.0.0.1', port=8085):
+        """Init the LibreHardwareMonitor stats."""
+        self.url = f'http://{host}:{port}/data.json'
+        self.last_fetch_ok = True
+
+    def fetch(self):
+        """Fetch the sensors tree from the LibreHardwareMonitor web server."""
+        try:
+            with urlopen(self.url, timeout=3) as response:
+                data = json.load(response)
+        except Exception as e:
+            # Log only on state change to avoid flooding the logs at each refresh
+            if self.last_fetch_ok:
+                logger.debug(f"Cannot connect to the LibreHardwareMonitor web server ({self.url} => {e})")
+            self.last_fetch_ok = False
+            return None
+        self.last_fetch_ok = True
+        return data
+
+    @staticmethod
+    def _is_temperature(node):
+        """Return True if the given leaf node is a temperature sensor."""
+        # Recent LibreHardwareMonitor releases expose the sensor type in data.json
+        # Fall back to the value unit for older releases
+        if 'Type' in node:
+            return node['Type'] == 'Temperature'
+        return '°C' in node.get('Value', '')
+
+    @staticmethod
+    def _parse_value(raw_value):
+        """Parse a LibreHardwareMonitor value like '44,5 °C' and return a float (or None).
+
+        The decimal separator depends on the system locale (',' or '.').
+        """
+        try:
+            return float(raw_value.split(' ')[0].replace(',', '.'))
+        except (AttributeError, IndexError, ValueError):
+            return None
+
+    def _walk(self, node, chain, ret):
+        """Walk the data.json tree and add the temperature sensors to the ret list.
+
+        chain is the list of the parent nodes names (used to build the sensor label).
+        """
+        children = node.get('Children') or []
+        if children:
+            for child in children:
+                self._walk(child, chain + [node.get('Text', '')], ret)
+        elif self._is_temperature(node):
+            value = self._parse_value(node.get('Value'))
+            if value is None:
+                return
+            # chain example: ['Sensor', 'MY-PC', 'Nuvoton NCT6793D', 'Temperatures']
+            # The hardware name is the parent of the 'Temperatures' category node
+            hardware = chain[-2] if len(chain) >= 2 else ''
+            label = f"{hardware} {node.get('Text', '')}".strip()
+            ret.append(
+                {
+                    'label': label,
+                    'unit': 'C',
+                    'value': value,
+                    'warning': None,
+                    'critical': None,
+                }
+            )
+
+    def get(self):
+        """Get the temperatures list."""
+        data = self.fetch()
+        if data is None:
+            return []
+        ret = []
+        self._walk(data, [], ret)
+        return ret

--- a/tests/test_plugin_sensors_librehardwaremonitor.py
+++ b/tests/test_plugin_sensors_librehardwaremonitor.py
@@ -291,6 +291,43 @@ class TestGlancesGrabLHMValueParsing:
         assert GlancesGrabLHM._parse_value(None) is None
 
 
+class TestHddSystemThresholds:
+    """Test that the disks own thresholds are used by the alert logic.
+
+    NVMe drives declare their thresholds (e.g. warning 83 / critical 87):
+    a healthy internal sensor at 59.9C must not be flagged against the
+    generic temperature_hdd limits (see #3265).
+    """
+
+    @staticmethod
+    def _views_decoration(sensors_plugin, value):
+        sensors_plugin.stats = [
+            {
+                'label': 'Temperature #1 (WD_BLACK SN770 500GB)',
+                'unit': 'C',
+                'value': value,
+                'warning': 83,
+                'critical': 87,
+                'type': 'temperature_hdd',
+                'key': 'label',
+            }
+        ]
+        sensors_plugin.update_views()
+        return sensors_plugin.get_views()['Temperature #1 (WD_BLACK SN770 500GB)']['value']['decoration']
+
+    def test_healthy_value_is_ok(self, glances_stats):
+        sensors_plugin = glances_stats.get_plugin('sensors')
+        assert self._views_decoration(sensors_plugin, 59.9) == 'OK'
+
+    def test_value_over_drive_warning_is_warning(self, glances_stats):
+        sensors_plugin = glances_stats.get_plugin('sensors')
+        assert self._views_decoration(sensors_plugin, 84.0) == 'WARNING'
+
+    def test_value_over_drive_critical_is_critical(self, glances_stats):
+        sensors_plugin = glances_stats.get_plugin('sensors')
+        assert self._views_decoration(sensors_plugin, 90.0) == 'CRITICAL'
+
+
 class TestGlancesGrabLHMSensorDetection:
     """Test the temperature sensor detection."""
 

--- a/tests/test_plugin_sensors_librehardwaremonitor.py
+++ b/tests/test_plugin_sensors_librehardwaremonitor.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the LibreHardwareMonitor sensor (Windows temperatures)."""
+
+from glances.plugins.sensors.sensor.glances_librehardwaremonitor import GlancesGrabLHM
+
+# Sample of the data.json tree returned by the LibreHardwareMonitor web server
+DATA_JSON_SAMPLE = {
+    "id": 0,
+    "Text": "Sensor",
+    "Min": "Min",
+    "Value": "Value",
+    "Max": "Max",
+    "ImageURL": "",
+    "Children": [
+        {
+            "id": 1,
+            "Text": "MY-PC",
+            "ImageURL": "images_icon/computer.png",
+            "Children": [
+                {
+                    "id": 2,
+                    "Text": "ASUS PRIME B250M-C",
+                    "ImageURL": "images_icon/mainboard.png",
+                    "Children": [
+                        {
+                            "id": 3,
+                            "Text": "Nuvoton NCT6793D",
+                            "ImageURL": "images_icon/chip.png",
+                            "Children": [
+                                {
+                                    "id": 4,
+                                    "Text": "Voltages",
+                                    "ImageURL": "images_icon/voltage.png",
+                                    "Children": [
+                                        {
+                                            "id": 5,
+                                            "Text": "Vcore",
+                                            "Children": [],
+                                            "Min": "0,960 V",
+                                            "Value": "1,032 V",
+                                            "Max": "1,144 V",
+                                            "ImageURL": "images/transparent.png",
+                                            "SensorId": "/lpc/nct6793d/0/voltage/0",
+                                            "Type": "Voltage",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "id": 6,
+                                    "Text": "Temperatures",
+                                    "ImageURL": "images_icon/temperature.png",
+                                    "Children": [
+                                        {
+                                            "id": 7,
+                                            "Text": "SYSTIN",
+                                            "Children": [],
+                                            "Min": "27,0 °C",
+                                            "Value": "29,5 °C",
+                                            "Max": "33,0 °C",
+                                            "ImageURL": "images/transparent.png",
+                                            "SensorId": "/lpc/nct6793d/0/temperature/3",
+                                            "Type": "Temperature",
+                                        },
+                                    ],
+                                },
+                                {
+                                    "id": 8,
+                                    "Text": "Fans",
+                                    "ImageURL": "images_icon/fan.png",
+                                    "Children": [
+                                        {
+                                            "id": 9,
+                                            "Text": "CPU Fan",
+                                            "Children": [],
+                                            "Min": "1100 RPM",
+                                            "Value": "1200 RPM",
+                                            "Max": "1300 RPM",
+                                            "ImageURL": "images/transparent.png",
+                                            "SensorId": "/lpc/nct6793d/0/fan/1",
+                                            "Type": "Fan",
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "id": 10,
+                    "Text": "Intel Core i7-7700",
+                    "ImageURL": "images_icon/cpu.png",
+                    "Children": [
+                        {
+                            "id": 11,
+                            "Text": "Temperatures",
+                            "ImageURL": "images_icon/temperature.png",
+                            "Children": [
+                                {
+                                    "id": 12,
+                                    "Text": "CPU Package",
+                                    "Children": [],
+                                    "Min": "29,0 °C",
+                                    "Value": "35,5 °C",
+                                    "Max": "45,0 °C",
+                                    "ImageURL": "images/transparent.png",
+                                    "SensorId": "/intelcpu/0/temperature/8",
+                                    "Type": "Temperature",
+                                },
+                                {
+                                    "id": 13,
+                                    "Text": "CPU Core #1",
+                                    "Children": [],
+                                    "Min": "28,0 °C",
+                                    "Value": "-",
+                                    "Max": "44,0 °C",
+                                    "ImageURL": "images/transparent.png",
+                                    "SensorId": "/intelcpu/0/temperature/0",
+                                    "Type": "Temperature",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+
+
+class TestGlancesGrabLHMParsing:
+    """Test the data.json parsing."""
+
+    def test_get_returns_temperatures_only(self):
+        """Test that only the temperature sensors are returned."""
+        lhm = GlancesGrabLHM()
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        stats = lhm.get()
+        labels = [i['label'] for i in stats]
+        assert 'Nuvoton NCT6793D SYSTIN' in labels
+        assert 'Intel Core i7-7700 CPU Package' in labels
+        # Voltages and fans are not temperatures
+        assert not any('Vcore' in label for label in labels)
+        assert not any('Fan' in label for label in labels)
+
+    def test_sensor_fields(self):
+        """Test that each sensor entry has the expected fields."""
+        lhm = GlancesGrabLHM()
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        for sensor in lhm.get():
+            assert isinstance(sensor['label'], str)
+            assert sensor['unit'] == 'C'
+            assert isinstance(sensor['value'], float)
+            assert sensor['warning'] is None
+            assert sensor['critical'] is None
+
+    def test_locale_decimal_separator(self):
+        """Test that values with a comma decimal separator are parsed."""
+        lhm = GlancesGrabLHM()
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        stats = lhm.get()
+        systin = next(i for i in stats if i['label'] == 'Nuvoton NCT6793D SYSTIN')
+        assert systin['value'] == 29.5
+
+    def test_sensor_without_value_is_skipped(self):
+        """Test that a sensor with a non numeric value ('-') is skipped."""
+        lhm = GlancesGrabLHM()
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        labels = [i['label'] for i in lhm.get()]
+        assert 'Intel Core i7-7700 CPU Core #1' not in labels
+
+    def test_fetch_failure_returns_empty_list(self):
+        """Test that a web server connection failure returns an empty list."""
+        lhm = GlancesGrabLHM()
+        lhm.fetch = lambda: None
+        assert lhm.get() == []
+
+
+class TestGlancesGrabLHMValueParsing:
+    """Test the sensor value parsing."""
+
+    def test_parse_value_comma(self):
+        assert GlancesGrabLHM._parse_value('44,5 °C') == 44.5
+
+    def test_parse_value_dot(self):
+        assert GlancesGrabLHM._parse_value('44.5 °C') == 44.5
+
+    def test_parse_value_invalid(self):
+        assert GlancesGrabLHM._parse_value('-') is None
+
+    def test_parse_value_none(self):
+        assert GlancesGrabLHM._parse_value(None) is None
+
+
+class TestGlancesGrabLHMSensorDetection:
+    """Test the temperature sensor detection."""
+
+    def test_type_field(self):
+        assert GlancesGrabLHM._is_temperature({'Type': 'Temperature', 'Value': '44,5 °C'})
+        assert not GlancesGrabLHM._is_temperature({'Type': 'Voltage', 'Value': '1,032 V'})
+
+    def test_fallback_on_value_unit(self):
+        # Older LibreHardwareMonitor releases do not expose the Type field
+        assert GlancesGrabLHM._is_temperature({'Value': '44,5 °C'})
+        assert not GlancesGrabLHM._is_temperature({'Value': '1200 RPM'})
+        assert not GlancesGrabLHM._is_temperature({})

--- a/tests/test_plugin_sensors_librehardwaremonitor.py
+++ b/tests/test_plugin_sensors_librehardwaremonitor.py
@@ -125,6 +125,64 @@ DATA_JSON_SAMPLE = {
                                     "SensorId": "/intelcpu/0/temperature/0",
                                     "Type": "Temperature",
                                 },
+                                {
+                                    "id": 14,
+                                    "Text": "CPU Core #1 Distance to TjMax",
+                                    "Children": [],
+                                    "Min": "55,0 °C",
+                                    "Value": "62,0 °C",
+                                    "Max": "71,0 °C",
+                                    "ImageURL": "images/transparent.png",
+                                    "SensorId": "/intelcpu/0/temperature/10",
+                                    "Type": "Temperature",
+                                },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    "id": 15,
+                    "Text": "Samsung SSD 980 1TB",
+                    "ImageURL": "images_icon/hdd.png",
+                    "Children": [
+                        {
+                            "id": 16,
+                            "Text": "Temperatures",
+                            "ImageURL": "images_icon/temperature.png",
+                            "Children": [
+                                {
+                                    "id": 17,
+                                    "Text": "Temperature",
+                                    "Children": [],
+                                    "Min": "38,0 °C",
+                                    "Value": "43,0 °C",
+                                    "Max": "51,0 °C",
+                                    "ImageURL": "images/transparent.png",
+                                    "SensorId": "/nvme/0/temperature/0",
+                                    "Type": "Temperature",
+                                },
+                                {
+                                    "id": 18,
+                                    "Text": "Warning Temperature",
+                                    "Children": [],
+                                    "Min": "83,0 °C",
+                                    "Value": "83,0 °C",
+                                    "Max": "83,0 °C",
+                                    "ImageURL": "images/transparent.png",
+                                    "SensorId": "/nvme/0/temperature/10",
+                                    "Type": "Temperature",
+                                },
+                                {
+                                    "id": 19,
+                                    "Text": "Critical Temperature",
+                                    "Children": [],
+                                    "Min": "87,0 °C",
+                                    "Value": "87,0 °C",
+                                    "Max": "87,0 °C",
+                                    "ImageURL": "images/transparent.png",
+                                    "SensorId": "/nvme/0/temperature/11",
+                                    "Type": "Temperature",
+                                },
                             ],
                         },
                     ],
@@ -144,11 +202,45 @@ class TestGlancesGrabLHMParsing:
         lhm.fetch = lambda: DATA_JSON_SAMPLE
         stats = lhm.get()
         labels = [i['label'] for i in stats]
-        assert 'Nuvoton NCT6793D SYSTIN' in labels
-        assert 'Intel Core i7-7700 CPU Package' in labels
+        assert 'SYSTIN (Nuvoton NCT6793D)' in labels
+        assert 'CPU Package (Intel Core i7-7700)' in labels
         # Voltages and fans are not temperatures
         assert not any('Vcore' in label for label in labels)
         assert not any('Fan' in label for label in labels)
+
+    def test_pseudo_sensors_are_excluded(self):
+        """Test that thresholds constants and thermal margins are not readings."""
+        lhm = GlancesGrabLHM()
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        labels = [i['label'] for i in lhm.get()]
+        # NVMe thresholds constants (would trigger a permanent CRITICAL alert)
+        assert not any('Warning Temperature' in label for label in labels)
+        assert not any('Critical Temperature' in label for label in labels)
+        # Inverted thermal margin (higher means cooler)
+        assert not any('Distance to TjMax' in label for label in labels)
+
+    def test_disks_are_excluded_by_default(self):
+        """Test that the disks temperatures are not in the default (core) instance."""
+        lhm = GlancesGrabLHM()
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        labels = [i['label'] for i in lhm.get()]
+        assert not any('Samsung' in label for label in labels)
+
+    def test_storage_instance_returns_disks_only(self):
+        """Test that the storage instance returns only the disks temperatures."""
+        lhm = GlancesGrabLHM(storage=True)
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        stats = lhm.get()
+        assert [i['label'] for i in stats] == ['Temperature (Samsung SSD 980 1TB)']
+        assert stats[0]['value'] == 43.0
+
+    def test_nvme_thresholds_are_used_as_warning_critical(self):
+        """Test that the NVMe thresholds constants fill the warning/critical fields."""
+        lhm = GlancesGrabLHM(storage=True)
+        lhm.fetch = lambda: DATA_JSON_SAMPLE
+        disk = lhm.get()[0]
+        assert disk['warning'] == 83
+        assert disk['critical'] == 87
 
     def test_sensor_fields(self):
         """Test that each sensor entry has the expected fields."""
@@ -166,7 +258,7 @@ class TestGlancesGrabLHMParsing:
         lhm = GlancesGrabLHM()
         lhm.fetch = lambda: DATA_JSON_SAMPLE
         stats = lhm.get()
-        systin = next(i for i in stats if i['label'] == 'Nuvoton NCT6793D SYSTIN')
+        systin = next(i for i in stats if i['label'] == 'SYSTIN (Nuvoton NCT6793D)')
         assert systin['value'] == 29.5
 
     def test_sensor_without_value_is_skipped(self):
@@ -174,7 +266,7 @@ class TestGlancesGrabLHMParsing:
         lhm = GlancesGrabLHM()
         lhm.fetch = lambda: DATA_JSON_SAMPLE
         labels = [i['label'] for i in lhm.get()]
-        assert 'Intel Core i7-7700 CPU Core #1' not in labels
+        assert 'CPU Core #1 (Intel Core i7-7700)' not in labels
 
     def test_fetch_failure_returns_empty_list(self):
         """Test that a web server connection failure returns an empty list."""


### PR DESCRIPTION
## Description

On Windows, `psutil` does not implement `sensors_temperatures()`, so the sensors plugin shows no temperatures at all. This PR grabs the temperatures from the [LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor) embedded web server (`data.json` endpoint) and feeds them into the existing sensors plugin, as discussed in #3265.

No WebUI change needed: the temperatures flow through the standard `temperature_core` model, so they show up in the TUI, the Web UI and `/api/4/sensors` automatically.

## How it works

- New `librehardwaremonitor` sub-sensor following the same pattern as the `hddtemp` one (`glances/plugins/sensors/sensor/glances_librehardwaremonitor.py`).
- Registered only on Windows, and only when the psutil temperature grabber is not available — zero impact on Linux/macOS/BSD.
- The user runs LibreHardwareMonitor with its *Remote Web Server* option enabled (default port 8085); host/port are configurable in a new `[librehardwaremonitor]` section.
- Handles both recent `data.json` payloads (`Type` field) and older releases (fallback on the `°C` unit in the value), plus locale decimal separators (`44,5 °C`).
- Sensor labels are `<hardware> <sensor>` (e.g. `Nuvoton NCT6793D SYSTIN`, `Intel Core i7-7700 CPU Package`), so the existing `[sensors]` hide/show/alias machinery applies to them.
- On connection failure it degrades to an empty list and logs once at debug level (no log flooding, and it recovers if LibreHardwareMonitor is started later).

## Design notes

- The [librehardwaremonitor-api](https://pypi.org/project/librehardwaremonitor-api/) lib suggested in #3265 is async (aiohttp) while the sensors grabbers are sync, and it requires Python >= 3.11 while Glances supports >= 3.10. So this PR uses a stdlib-only fetch (`urllib`) — the parsing needed is ~40 lines and there is no new dependency. Happy to switch to the lib if you prefer.
- Fan speeds are available from the same endpoint and would be a small follow-up (`fan_speed` type).
- While wiring the configuration I noticed that all the sensors sub-plugins get `plugin_name == 'sensors'` (`model.py` builds it from the first component of the module path relative to `glances.plugins`), so for instance the `[hddtemp]` host/port section seems to be silently ignored since the 4.x plugins layout. That is why the new section is read directly from the config object. I can open a separate issue for this if you confirm.

## Tests

- `tests/test_plugin_sensors_librehardwaremonitor.py`: 11 new unit tests (tree parsing, sensor type detection, locale decimals, failure modes) — all passing on Windows (Python 3.13).
- `tests/test_plugin_sensors.py`: 32 passed, 3 skipped (Linux-only), unchanged.
- `ruff check` and `ruff format --check` clean.
- End-to-end on a Windows 10 Pro machine, against a local stub replaying the LibreHardwareMonitor `data.json` format: the sub-sensor registers on Windows and the temperatures show up in the TUI, the Web UI and `/api/4/sensors`.
- **Not yet tested against a live LibreHardwareMonitor web server** — my production box still runs an older LibreHardwareMonitorLib-based bridge and I did not want to install the PawnIO driver on it yet. I will follow up with a real-instance validation (and screenshot) in a comment before this is merged.

Closes #3265

🤖 Generated with [Claude Code](https://claude.com/claude-code)
