### PR TITLE
Sensors thresholds set in the configuration file are ignored when no critical level is defined #3627

### DIFF
--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -189,6 +189,14 @@ class SensorsPlugin(GlancesPluginModel):
 
         return stats
 
+    def __has_user_thresholds(self, stat_name):
+        """Return True if the user defined at least one threshold for the given stat_name.
+
+        All the criticality levels are checked because the user is free to define only
+        some of them (for example a warning without a critical). See #3627.
+        """
+        return any(self.is_limit(level, stat_name=stat_name) for level in ('careful', 'warning', 'critical'))
+
     def __get_system_thresholds(self, sensor):
         """Return the alert level thanks to the system thresholds.
         Note: Only Warning (aka High) and Critical thresholds are used. Careful is not available.
@@ -216,10 +224,10 @@ class SensorsPlugin(GlancesPluginModel):
                 continue
             # Alert processing
             if i['type'] == sensors_definition.get('cpu_temp').get('type'):
-                if self.is_limit('critical', stat_name=i['type'] + '_' + i['label']):
+                if self.__has_user_thresholds(i['type'] + '_' + i['label']):
                     # Get thresholds for the specific sensor in the glances.conf file (see #2058)
                     alert = self.get_alert(current=i['value'], header=i['label'], action_key=i['type'])
-                elif self.is_limit('critical', stat_name=i['type']):
+                elif self.__has_user_thresholds(i['type']):
                     # Get thresholds for the sensor type in the glances.conf file (see #3049)
                     alert = self.get_alert(current=i['value'], header=i['type'])
                 else:

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -13,8 +13,9 @@ import json
 
 import pytest
 
+from glances.config import Config
 from glances.globals import LINUX
-from glances.plugins.sensors import GlancesGrabSensors
+from glances.plugins.sensors import GlancesGrabSensors, SensorsPlugin
 
 
 @pytest.fixture
@@ -321,3 +322,66 @@ class TestSensorsPluginAlerts:
             if label in views and 'value' in views[label]:
                 if sensor['value']:  # Only check if value is not empty
                     assert 'decoration' in views[label]['value']
+
+
+class TestSensorsPluginConfigThresholds:
+    """Test that core temperature thresholds set in the config file are used (see #3627)."""
+
+    @staticmethod
+    def build_plugin(tmp_path, sensors_section):
+        """Return a sensors plugin configured with the given [sensors] section."""
+        config_file = tmp_path / 'glances.conf'
+        config_file.write_text('[sensors]\ndisable=False\n' + sensors_section, encoding='utf-8')
+        return SensorsPlugin(args=None, config=Config(config_dir=str(config_file)))
+
+    @staticmethod
+    def decoration(plugin, value, label='Tctl', system_high=None, system_critical=None):
+        """Return the view decoration for a single fake core temperature reading."""
+        plugin.stats = [
+            {
+                'label': label,
+                'unit': 'C',
+                'value': value,
+                'warning': system_high,
+                'critical': system_critical,
+                'type': 'temperature_core',
+                'key': 'label',
+            }
+        ]
+        plugin.update_views()
+        return plugin.get_views(item=label, key='value', option='decoration')
+
+    @pytest.mark.parametrize(
+        ('sensors_section', 'expected'),
+        [
+            ('temperature_core_careful=60\n', 'CAREFUL'),
+            ('temperature_core_warning=90\n', 'WARNING'),
+            ('temperature_core_critical=95\n', 'CRITICAL'),
+            ('temperature_core_careful=60\ntemperature_core_warning=90\n', 'WARNING'),
+        ],
+    )
+    def test_partial_type_thresholds_are_used(self, tmp_path, sensors_section, expected):
+        """A sensor type threshold is used even when the other levels are not defined."""
+        plugin = self.build_plugin(tmp_path, sensors_section)
+        assert self.decoration(plugin, 95).startswith(expected)
+
+    def test_partial_sensor_thresholds_are_used(self, tmp_path):
+        """A per sensor threshold is used even when no critical level is defined."""
+        plugin = self.build_plugin(tmp_path, 'temperature_core_tctl_warning=90\n')
+        assert self.decoration(plugin, 95).startswith('WARNING')
+
+    def test_config_thresholds_overwrite_system_ones(self, tmp_path):
+        """The config threshold, not the system one, gives the alert level."""
+        plugin = self.build_plugin(tmp_path, 'temperature_core_warning=90\n')
+        # The system would already warn at 70C, the configuration only at 90C
+        assert self.decoration(plugin, 80, system_high=70, system_critical=100).startswith('OK')
+
+    def test_system_thresholds_are_used_when_not_configured(self, tmp_path):
+        """Without any threshold in the config file, the system ones are used."""
+        plugin = self.build_plugin(tmp_path, '')
+        assert self.decoration(plugin, 95, system_high=70, system_critical=100).startswith('WARNING')
+
+    def test_no_threshold_at_all_is_not_decorated(self, tmp_path):
+        """Sensors without config and system thresholds are not decorated."""
+        plugin = self.build_plugin(tmp_path, '')
+        assert self.decoration(plugin, 95) == 'DEFAULT'


### PR DESCRIPTION
#### Description

While investigating #3627 I could not reproduce the reported case on `develop`: the
reporter's configuration works correctly today.

```ini
[sensors]
temperature_core_warning=90
temperature_core_critical=95
```

| Tctl  | decoration |
|-------|------------|
| 85C   | OK         |
| 92C   | WARNING    |
| 95C   | CRITICAL   |

The reporter is on 3.4.0.3, which predates the sensor *type* thresholds added in
4.3.0 (#3049), so their `temperature_core_warning` key was never read on that
version. That part of the issue is a version problem, not a bug.

However, the dispatch that decides *which* thresholds to use has an adjacent bug
that produces exactly the same symptom on current `develop`. It only probes the
`critical` level:

```python
if self.is_limit('critical', stat_name=i['type'] + '_' + i['label']):
```

So a configuration that defines `careful` and/or `warning` but **no** `critical` is
silently discarded, and the plugin falls back to the system thresholds. This affects
both the per sensor (#2058) and the per type (#3049) forms.

The user visible consequence is the one described in #3627. AMD `k10temp` reports no
`high`/`critical` for `Tctl` on many boards, so `__get_system_thresholds()` returns
`DEFAULT` and the temperature is never highlighted:

```
config: temperature_core_warning=90   system: high=None, critical=None
  80C -> DEFAULT
  92C -> DEFAULT
  95C -> DEFAULT
  99C -> DEFAULT
```

That the configuration is genuinely ignored (rather than coincidentally agreeing with
the system) is visible when the two disagree, with `warning=90` in the config and
`high=70` from the system:

```
  80C -> WARNING     config(90) says OK, system(70) says WARNING
```

This PR checks every criticality level instead of only `critical`, so the documented
precedence (specific sensor, then sensor type, then system) applies as soon as the
user defines any threshold. With the fix, the two cases above return `WARNING` at
92C/95C/99C and `OK` at 80C.

Notes:

* No behaviour change for the shipped default configuration, which defines all three
  levels, nor for the fan speed, hdd temperature and battery sensors.
* No new configuration key, and `docs/aoa/sensors.rst` already documents the
  precedence this restores, so no documentation change.
* `NEWS.rst` left untouched, following the usual release process.
* 8 regression tests added in `tests/test_plugin_sensors.py`; 5 of them fail without
  the fix and the other 3 pin the unchanged system threshold fallback. Full sensors
  suite: 40 passed, 3 skipped (Linux only). `make lint` and `make format` are clean.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #3627

