### PR TITLE
Fix duplicated and suppressed metrics in the multi-GPU curses view

### DIFF
--- a/glances/plugins/gpu/__init__.py
+++ b/glances/plugins/gpu/__init__.py
@@ -332,7 +332,7 @@ class GpuPlugin(GlancesPluginModel):
                 )
             if gpu_stats.get('mem') is not None:
                 mem_msg = self._format_value(gpu_stats.get('mem'))
-                msg += f' mem {mem_msg}'
+                msg = f' mem {mem_msg}'
                 ret.append(
                     self.curse_add_line(
                         msg,

--- a/glances/plugins/gpu/__init__.py
+++ b/glances/plugins/gpu/__init__.py
@@ -319,26 +319,21 @@ class GpuPlugin(GlancesPluginModel):
             ret.append(self.curse_new_line())
             # id_msg = '{:7}'.format(gpu_stats['gpu_id'])
             id_msg = '{:7}'.format(gpu_stats['name'][0:9])
-            msg = f'{id_msg}'
-            ret.append(self.curse_add_line(msg))
-            if gpu_stats.get('proc') is not None:
-                proc_msg = self._format_value(gpu_stats.get('proc'))
-                msg = f' {proc_msg}'
-                ret.append(
-                    self.curse_add_line(
-                        msg,
-                        self.get_views(item=gpu_stats[self.get_key()], key='proc', option='decoration'),
-                    )
+            ret.append(self.curse_add_line(f'{id_msg}'))
+            # Each metric is a standalone segment: it carries its own decoration and must not
+            # re-emit the previous one. An unavailable sensor is displayed as N/A, not hidden.
+            ret.append(
+                self.curse_add_line(
+                    f" {self._format_value(gpu_stats.get('proc'))}",
+                    self.get_views(item=gpu_stats[self.get_key()], key='proc', option='decoration'),
                 )
-            if gpu_stats.get('mem') is not None:
-                mem_msg = self._format_value(gpu_stats.get('mem'))
-                msg = f' mem {mem_msg}'
-                ret.append(
-                    self.curse_add_line(
-                        msg,
-                        self.get_views(item=gpu_stats[self.get_key()], key='mem', option='decoration'),
-                    )
+            )
+            ret.append(
+                self.curse_add_line(
+                    f" mem {self._format_value(gpu_stats.get('mem'))}",
+                    self.get_views(item=gpu_stats[self.get_key()], key='mem', option='decoration'),
                 )
+            )
 
     def msg_curse(self, args=None, max_width=None):
         """Return the dict to display in the curse interface."""


### PR DESCRIPTION

#### Description

Relevant issue: [#3630](https://github.com/nicolargo/glances/issues/3630) and [#3631](https://github.com/nicolargo/glances/issues/3631).

The multi-GPU curses view renders each GPU row as several `curse_add_line()` segments so that the processor and memory values can carry their own alert decoration. Two defects were introduced when that split was made in d8b1648b, and they interact.

First, the local `msg` is accumulated with `+=` rather than reassigned between the two segments. `curse_add_line()` emits each segment independently, so the memory segment re-emits whatever the processor segment already printed, and repaints it with the memory alert colour. A row showing an idle GPU with high VRAM pressure renders as `AMD GPU   0%   0% mem  97%`. The utilisation value appears twice, and the second copy is red because memory is critical.

Second, each segment is guarded by `if gpu_stats.get(...) is not None:`, which suppresses the column entirely when a sensor cannot be read. `_format_value()` already maps `None` to `'N/A'`, and the summary view (`_msg_curse_summary()`) relies on exactly that. Suppressing the column instead is a loss of information in the one situation where it matters most, and it also leaves `msg` holding the card name, so the `+=` above duplicates the name: `AMD GPUAMD GPU mem   0%`.

Unreadable sensors are not an edge case: amdgpu returns `EBUSY` for `gpu_busy_percent` while a card is runtime-suspended (#3590) or fenced by a fatal RAS event, NVIDIA returns `None` on `NVMLError`, and ARM's `proc` is `None` on its first sample by design. `_msg_curse_multi()` is shared by every backend, so neither defect is vendor-specific; this surfaced on an 8x AMD Instinct MI355X host whose GPUs were all RAS-disabled, but a multi-NVIDIA host shows the duplication identically.

The fix drops the `is not None` guards and always emits both segments through `_format_value()`, building each segment string independently. Behaviour on healthy hardware is unchanged apart from the removal of the duplicated value; unavailable sensors now read `N/A`, consistent with the summary view.

Regression range: introduced in d8b1648b; present verbatim in released v4.5.1 and v4.5.5.

Before:

```
AMD GPU   0%   0% mem  97%      # healthy card, utilisation printed twice
AMD GPUAMD GPU mem   0%         # sensor unreadable, name printed twice, no utilisation column
```

After:

```
AMD GPU   0% mem  97%
AMD GPU  N/A mem   0%
```

The "after" form matches the per-GPU view in the documentation ([`_images/pergpu.png`](https://glances.readthedocs.io/en/latest/_images/pergpu.png)), which shows
one utilisation value per row.

#### Resume

* Bug fix: yes
* New feature: no
