### PR TITLE
fix(ports): resolve alert level by severity instead of dict ordering

### DIFF
--- a/glances/plugins/ports/__init__.py
+++ b/glances/plugins/ports/__init__.py
@@ -138,7 +138,7 @@ class PortsPlugin(GlancesPluginModel):
     def get_conds_if_url(self, web):
         return {
             'CAREFUL': web['status'] is None,
-            'CRITICAL': web['status'] not in [200, 301, 302],
+            'CRITICAL': web['status'] is not None and web['status'] not in [200, 301, 302],
             'WARNING': web['rtt_warning'] is not None and web['elapsed'] > web['rtt_warning'],
         }
 
@@ -162,9 +162,13 @@ class PortsPlugin(GlancesPluginModel):
         return ret
 
     def get_default_ret_value(self, conds):
-        ret_as_dict_val = {'ret': key for key, cond in conds.items() if cond}
+        # Resolve by severity, not by dict insertion order: several conditions
+        # can match at once and the most severe one has to win.
+        for level in ('CRITICAL', 'WARNING', 'CAREFUL'):
+            if conds.get(level):
+                return level
 
-        return ret_as_dict_val.get('ret', 'OK')
+        return 'OK'
 
     def set_status_if_host(self, p):
         if p['host'] is None:

--- a/tests/test_plugin_ports.py
+++ b/tests/test_plugin_ports.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the Ports plugin."""
+
+import pytest
+
+from glances.plugins.ports import PortsPlugin
+
+
+@pytest.fixture
+def ports_plugin():
+    """Return a Ports plugin instance without running its full init."""
+    return PortsPlugin.__new__(PortsPlugin)
+
+
+def web_scan(status, elapsed=0, rtt_warning=1):
+    """Return a web scan result as stored by the ports plugin."""
+    return {'status': status, 'elapsed': elapsed, 'rtt_warning': rtt_warning}
+
+
+class TestPortsPluginAlertLevel:
+    """Test that the alert level is resolved by severity, not by dict ordering."""
+
+    @pytest.mark.parametrize(
+        ('conds', 'expected'),
+        [
+            ({'CAREFUL': True, 'CRITICAL': True, 'WARNING': True}, 'CRITICAL'),
+            ({'CAREFUL': True, 'CRITICAL': False, 'WARNING': True}, 'WARNING'),
+            ({'CAREFUL': True, 'CRITICAL': False, 'WARNING': False}, 'CAREFUL'),
+            ({'CAREFUL': False, 'CRITICAL': False, 'WARNING': False}, 'OK'),
+        ],
+    )
+    def test_most_severe_condition_wins(self, ports_plugin, conds, expected):
+        """Test that the most severe matching condition is returned."""
+        assert ports_plugin.get_default_ret_value(conds) == expected
+
+    def test_web_not_scanned_yet_is_careful(self, ports_plugin):
+        """Test that a URL whose first scan did not complete is not CRITICAL."""
+        conds = ports_plugin.get_conds_if_url(web_scan(None))
+        assert ports_plugin.get_default_ret_value(conds) == 'CAREFUL'
+
+    def test_web_failing_and_slow_is_critical(self, ports_plugin):
+        """Test that a failing URL stays CRITICAL even when it is also slow."""
+        conds = ports_plugin.get_conds_if_url(web_scan(404, elapsed=5))
+        assert ports_plugin.get_default_ret_value(conds) == 'CRITICAL'
+
+    def test_web_failing_and_fast_is_critical(self, ports_plugin):
+        """Test that a failing URL is CRITICAL."""
+        conds = ports_plugin.get_conds_if_url(web_scan(404))
+        assert ports_plugin.get_default_ret_value(conds) == 'CRITICAL'
+
+    def test_web_ok_but_slow_is_warning(self, ports_plugin):
+        """Test that a reachable but slow URL is WARNING."""
+        conds = ports_plugin.get_conds_if_url(web_scan(200, elapsed=5))
+        assert ports_plugin.get_default_ret_value(conds) == 'WARNING'
+
+    def test_web_ok_and_fast_is_ok(self, ports_plugin):
+        """Test that a reachable and fast URL is OK."""
+        conds = ports_plugin.get_conds_if_url(web_scan(200))
+        assert ports_plugin.get_default_ret_value(conds) == 'OK'


### PR DESCRIPTION
Closes #3632

#### Description

`PortsPlugin.get_default_ret_value()` built `{'ret': key for key, cond in conds.items() if cond}`, so every matching condition overwrote the same key and the level that won was whichever was evaluated last, not the most severe. Two consequences for the web/URL checks: a URL that is both failing and slow was reported WARNING instead of CRITICAL, and a URL whose first scan had not completed matched both CAREFUL and CRITICAL (because `None not in [200, 301, 302]`) and showed as CRITICAL, which can also fire `ports_critical_action`.

The fix resolves by severity (CRITICAL > WARNING > CAREFUL > OK) and stops a `None` status from matching the CRITICAL condition, as suggested in the issue. `get_conds_if_port()` is unchanged and its behaviour is unaffected.

Added `tests/test_plugin_ports.py` covering the severity ordering and the four web scan outcomes; it fails on the current code (3 failures) and passes with the fix. This change was prepared with AI assistance; the regression test was run locally and fails without the fix.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: 3632
