### PR TITLE
Run the unit tests on FreeBSD

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,37 +135,38 @@ jobs:
         run: |
           python -m pytest ./tests/test_core.py
 
-  # test-freebsd:
+  test-freebsd:
 
-  #   needs: source-code-checks
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       # Only test the latest stable version
-  #       python-version: ["3.14"]
-  #   steps:
+    needs: source-code-checks
+    # FreeBSD is not offered by the GitHub-hosted runners, so the tests run in
+    # a FreeBSD VM booted under QEMU/KVM on a Linux runner. The whole job has
+    # to live in a single vmactions step: each step starts its own VM, so
+    # installing dependencies in one step and running pytest in another would
+    # run pytest in a VM that never saw the dependencies.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
 
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    permissions:
+      contents: read
 
-  #     - name: Set up Python ${{ matrix.python-version }}
-  #       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-  #       with:
-  #         python-version: ${{ matrix.python-version }}
-  #         cache: 'pip'
+    steps:
 
-  #     - name: Install dependencies
-  #       uses: vmactions/freebsd-vm@v1
-  #       with:
-  #         usesh: true
-  #         run: |
-  #           pkg install -y python3 gcc devel/py-pip
-  #           python3 --version
-  #           if [ -f dev-requirements.txt ]; then python3 -m pip install -r dev-requirements.txt; fi
-  #           if [ -f requirements.txt ]; then python3 -m pip install -r requirements.txt; fi
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-  #     - name: Unitary tests
-  #       uses: vmactions/freebsd-vm@v1
-  #       with:
-  #         usesh: true
-  #         run: |
-  #           python3 -m pytest ./tests/test_core.py
+      - name: Unitary tests
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
+        with:
+          usesh: true
+          cache-after-prepare: true
+          prepare: |
+            pkg install -y python3 gcc devel/py-pip devel/py-pytest sysutils/py-psutil
+          run: |
+            set -e
+            python3 --version
+            # Only the runtime requirements are installed here.
+            # dev-requirements.txt pulls in matplotlib's build chain (contourpy,
+            # cffi, ...), and FreeBSD has no wheels for those, so pip builds them
+            # from source and the job times out. tests/test_core.py does not need
+            # them.
+            python3 -m pip install --break-system-packages -r requirements.txt
+            python3 -m pytest ./tests/test_core.py


### PR DESCRIPTION
#### Description

The `test-freebsd` job has been commented out since it was written, and as
written it could not have worked:

- It used two separate `vmactions` steps, one to install dependencies and one
  to run pytest. Each step boots its own VM, so pytest ran in a VM where the
  dependencies had never been installed.
- It carried an `actions/setup-python` step and a `python-version` matrix,
  which configure the Linux host and have no effect inside the guest.

This folds it into a single step with `prepare`/`run`, drops the host-side
Python setup, and caches the prepared VM image.

It also installs only the runtime requirements. `dev-requirements.txt` pulls
in matplotlib's build chain (contourpy, cffi) and FreeBSD ships no wheels for
those, so pip builds them from source -- that alone ran past the job timeout.
pytest and psutil come from packages instead.

**Verification**

https://github.com/neilpang/glances/actions/runs/30731827218

```
Python 3.12.13 on FreeBSD 15.1
py312-pytest 8.4.2, py312-psutil 7.2.2
======================== 48 passed, 4 skipped in 7.93s =========================
```

Job time 2m50s. With `cache-after-prepare` the package install is skipped on
subsequent runs.

#### Resume

* Bug fix: no
* New feature: yes -- restores FreeBSD test coverage
* Fixed tickets: #2749
