### PR TITLE
processcount pid_max always 0, and status comparison uses `is` instead of `==` #3637

### DIFF
--- a/glances/processes.py
+++ b/glances/processes.py
@@ -174,10 +174,12 @@ class GlancesProcesses:
         """Update the global process count from the current processes list"""
         # Update the maximum process ID (pid) number
         self.processcount['pid_max'] = self.pid_max
-        # For each key in the processcount dict
+        # For each status key in the processcount dict
         # count the number of processes with the same status
-        for k in list(self.processcount.keys()):
-            self.processcount[k] = len(list(filter(lambda v: v.get('status', '?') is k, plist)))
+        # Note: only the status keys should be counted, the other ones
+        # ('pid_max', 'thread' and 'total') are computed separately (see issue #3637)
+        for k in ('running', 'sleeping'):
+            self.processcount[k] = len(list(filter(lambda v: v.get('status', '?') == k, plist)))
         # Compute thread
         try:
             self.processcount['thread'] = sum(i['num_threads'] for i in plist if i['num_threads'] is not None)

--- a/tests/test_plugin_processcount.py
+++ b/tests/test_plugin_processcount.py
@@ -10,8 +10,11 @@
 """Tests for the ProcessCount plugin."""
 
 import json
+from unittest.mock import PropertyMock, patch
 
 import pytest
+
+from glances.processes import GlancesProcesses
 
 
 @pytest.fixture
@@ -272,3 +275,33 @@ class TestProcesscountPluginPidMax:
     def test_pid_max_description(self, processcount_plugin):
         """Test that pid_max has a description."""
         assert 'description' in processcount_plugin.fields_description['pid_max']
+
+
+class TestProcessesUpdateProcesscount:
+    """Test GlancesProcesses.update_processcount (see issue #3637)."""
+
+    @pytest.fixture
+    def processes(self):
+        """Return a standalone GlancesProcesses instance."""
+        return GlancesProcesses()
+
+    def test_pid_max_is_not_overwritten_by_the_status_count(self, processes):
+        """Test that pid_max keeps the system value and is not reset to 0."""
+        with patch.object(GlancesProcesses, 'pid_max', new_callable=PropertyMock) as pid_max:
+            pid_max.return_value = 4194304
+            processes.update_processcount([{'status': 'sleeping', 'num_threads': 1}])
+        assert processes.processcount['pid_max'] == 4194304
+
+    def test_status_count_uses_equality(self, processes):
+        """Test that the status count does not rely on the string interning."""
+        plist = [
+            # Build a non interned 'running' string
+            {'status': ''.join(['run', 'ning']), 'num_threads': 1},
+            {'status': 'sleeping', 'num_threads': 2},
+            {'status': 'disk-sleep', 'num_threads': 3},
+        ]
+        processes.update_processcount(plist)
+        assert processes.processcount['running'] == 1
+        assert processes.processcount['sleeping'] == 1
+        assert processes.processcount['total'] == 3
+        assert processes.processcount['thread'] == 6


### PR DESCRIPTION
Fixes #3637.

`update_processcount()` looped over every key of the processcount dict, so `pid_max` was overwritten with the number of processes whose status is `'pid_max'`, ie 0. `total` and `thread` are recomputed after the loop, so `pid_max` was the only casualty: `/api/4/processcount` returned 0 while `/proc/sys/kernel/pid_max` was 4194304.

The status was also matched with `is`, which only worked because CPython interns literals like `'running'`. A non-interned or non-identifier status such as `'disk-sleep'` would never match.

Now the loop counts the two status keys only, with `==`. `pid_max` keeps the system value, and stays `None` when unreadable (non-Linux), as the property documents and `reset_processcount()` initialises.

Two regression tests added in `tests/test_plugin_processcount.py`, driving `update_processcount()` with a synthetic process list so they run on any OS. Both fail on `develop` and pass with the fix; full file is 35 passed, `ruff check`/`format` clean.

The `pid_max: 0` examples in `docs/api/*.rst` are generated by `make docs`, so I left them for the next regeneration.
