### PR TITLE
Fix cursor navigation in client/server mode (#3221)

### DIFF
--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -277,10 +277,10 @@ class _GlancesCurses:
             in {curses.KEY_LEFT if self.args.arrow_keys_sort else curses.KEY_SLEFT}: self._handle_sort_left,
             self.pressedkey
             in {curses.KEY_RIGHT if self.args.arrow_keys_sort else curses.KEY_SRIGHT}: self._handle_sort_right,
-            self.pressedkey
-            in {curses.KEY_SLEFT if self.args.arrow_keys_sort else curses.KEY_LEFT}: self._handle_process_name_left,
-            self.pressedkey
-            in {curses.KEY_SRIGHT if self.args.arrow_keys_sort else curses.KEY_RIGHT}: self._handle_process_name_right,
+            self.pressedkey in {curses.KEY_SLEFT if self.args.arrow_keys_sort else curses.KEY_LEFT}
+            and not self.args.disable_cursor: self._handle_process_name_left,
+            self.pressedkey in {curses.KEY_SRIGHT if self.args.arrow_keys_sort else curses.KEY_RIGHT}
+            and not self.args.disable_cursor: self._handle_process_name_right,
             self.pressedkey in {curses.KEY_UP, 65} and not self.args.disable_cursor: self._handle_cursor_up,
             self.pressedkey in {curses.KEY_DOWN, 66} and not self.args.disable_cursor: self._handle_cursor_down,
             self.pressedkey in {curses.KEY_F5, 18}: self._handle_refresh,

--- a/glances/processes.py
+++ b/glances/processes.py
@@ -242,6 +242,11 @@ class GlancesProcesses:
     @property
     def processes_count(self):
         """Get the current number of processes showed in the UI."""
+        # Defensive guard: when _max_processes is not set (e.g. client/server
+        # mode before the display class assigns it), return 0 instead of
+        # raising TypeError. See issue #3221.
+        if self._max_processes is None:
+            return 0
         return min(self._max_processes - 2, glances_processes.processcount['total'] - 1)
 
     @property

--- a/tests/test_glances_curses.py
+++ b/tests/test_glances_curses.py
@@ -1,3 +1,4 @@
+import curses
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
@@ -169,3 +170,46 @@ class TestDisplayTopHelpers:
 
         assert result_widths == plugin_widths  # nosec B101
         assert result_stats_width == 0  # nosec B101
+
+
+class TestCursorDisable:
+    """Test cursor disabling in client/server mode (see issue #3221)."""
+
+    @pytest.fixture
+    def screen(self, glancescreen):
+        """Extend the lightweight screen with cursor-related state."""
+        glancescreen.args.disable_cursor = True
+        glancescreen.args.cursor_process_name_position = 3
+        glancescreen.args.arrow_keys_sort = False
+        return glancescreen
+
+    def _dispatch(self, screen, key):
+        """Invoke the dispatch table with a given pressed key."""
+        screen.pressedkey = key
+        screen.catch_other_actions_maybe_return_to_browser(return_to_browser=False)
+
+    def test_process_name_left_is_noop_when_cursor_disabled(self, screen):
+        """Left arrow must not scroll the process name when cursor is disabled."""
+        self._dispatch(screen, curses.KEY_LEFT)
+        assert screen.args.cursor_process_name_position == 3  # nosec B101
+
+    def test_process_name_right_is_noop_when_cursor_disabled(self, screen):
+        """Right arrow must not scroll the process name when cursor is disabled."""
+        self._dispatch(screen, curses.KEY_RIGHT)
+        assert screen.args.cursor_process_name_position == 3  # nosec B101
+
+    def test_process_name_right_advances_when_cursor_enabled(self, glancescreen):
+        """When cursor is enabled, right arrow advances the name position."""
+        glancescreen.args.disable_cursor = False
+        glancescreen.args.cursor_process_name_position = 3
+        glancescreen.args.arrow_keys_sort = False
+        self._dispatch(glancescreen, curses.KEY_RIGHT)
+        assert glancescreen.args.cursor_process_name_position == 4  # nosec B101
+
+    def test_process_name_left_decrements_when_cursor_enabled(self, glancescreen):
+        """When cursor is enabled, left arrow decrements the name position."""
+        glancescreen.args.disable_cursor = False
+        glancescreen.args.cursor_process_name_position = 3
+        glancescreen.args.arrow_keys_sort = False
+        self._dispatch(glancescreen, curses.KEY_LEFT)
+        assert glancescreen.args.cursor_process_name_position == 2  # nosec B101

--- a/tests/test_plugin_processcount.py
+++ b/tests/test_plugin_processcount.py
@@ -305,3 +305,22 @@ class TestProcessesUpdateProcesscount:
         assert processes.processcount['sleeping'] == 1
         assert processes.processcount['total'] == 3
         assert processes.processcount['thread'] == 6
+
+
+class TestProcessesCount:
+    """Test GlancesProcesses.processes_count (see issue #3221)."""
+
+    @pytest.fixture
+    def processes(self):
+        """Return a standalone GlancesProcesses instance."""
+        return GlancesProcesses()
+
+    def test_processes_count_none_max_processes(self, processes):
+        """processes_count must not crash when max_processes is None (client/server mode)."""
+        processes.max_processes = None
+        assert processes.processes_count == 0  # nosec B101
+
+    def test_processes_count_does_not_raise_with_max_processes(self, processes):
+        """processes_count returns an int (no crash) when max_processes is set."""
+        processes.max_processes = 50
+        assert isinstance(processes.processes_count, int)  # nosec B101


### PR DESCRIPTION
## Description

Client/server mode disables process cursor navigation, but the left/right process-name scroll handlers were not subject to the same guard as the up/down and kill handlers. Pressing those keys could still mutate cursor state even though cursor navigation is unavailable in client mode.

This change also makes `processes_count` safe when no process display limit has been assigned, preventing the `NoneType - int` crash reported by the issue.

## Verification

- `python3 -m pytest tests/test_glances_curses.py tests/test_plugin_processcount.py` — 46 passed
- `python3 -m pytest ./tests/test_core.py` — 52 passed
- `ruff check` — passed
- `ruff format --check` on changed files — passed

The available full suite excluding the optional Selenium-dependent WebUI module ran 713 passed, with four unrelated environment/baseline failures.

## Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #3221

---