### PR TITLE
perf: make remove_non_running_procs O(n) instead of O(n^2)

### DIFF
--- a/glances/processes.py
+++ b/glances/processes.py
@@ -681,11 +681,9 @@ class GlancesProcesses:
                 self.set_max_values(k, max(values_list))
 
     def remove_non_running_procs(self, processlist):
-        pids_running = [p['pid'] for p in processlist]
-        pids_cached = list(self.processlist_cache.keys()).copy()
-        for pid in pids_cached:
-            if pid not in pids_running:
-                self.processlist_cache.pop(pid, None)
+        pids_running = {p['pid'] for p in processlist}
+        for pid in [pid for pid in self.processlist_cache if pid not in pids_running]:
+            self.processlist_cache.pop(pid, None)
 
     def update_list(self, processlist):
         """Return the process list after filtering and transformation (namedtuple to dict)."""

--- a/tests/test_processes_cache.py
+++ b/tests/test_processes_cache.py
@@ -1,0 +1,35 @@
+"""Tests for the GlancesProcesses internal cache eviction."""
+
+import pytest
+
+from glances.processes import GlancesProcesses
+
+
+@pytest.fixture
+def processes():
+    return GlancesProcesses()
+
+
+def test_remove_non_running_procs_keeps_running_pids(processes):
+    processes.processlist_cache = {1: {'cmdline': 'a'}, 2: {'cmdline': 'b'}, 3: {'cmdline': 'c'}}
+    processes.remove_non_running_procs([{'pid': 1}, {'pid': 3}])
+    assert set(processes.processlist_cache) == {1, 3}
+
+
+def test_remove_non_running_procs_evicts_everything_when_no_proc_runs(processes):
+    processes.processlist_cache = {1: {'cmdline': 'a'}, 2: {'cmdline': 'b'}}
+    processes.remove_non_running_procs([])
+    assert processes.processlist_cache == {}
+
+
+def test_remove_non_running_procs_is_noop_when_all_running(processes):
+    cache = {1: {'cmdline': 'a'}, 2: {'cmdline': 'b'}}
+    processes.processlist_cache = dict(cache)
+    processes.remove_non_running_procs([{'pid': 1}, {'pid': 2}])
+    assert processes.processlist_cache == cache
+
+
+def test_remove_non_running_procs_ignores_running_pids_absent_from_cache(processes):
+    processes.processlist_cache = {1: {'cmdline': 'a'}}
+    processes.remove_non_running_procs([{'pid': 1}, {'pid': 42}])
+    assert set(processes.processlist_cache) == {1}


### PR DESCRIPTION
#### Description

`GlancesProcesses.remove_non_running_procs()` tests membership against a **list** of running PIDs, so each of the n cached PIDs triggers a linear scan — O(n²) overall. On a host with ~15 000 processes that is ~114 M comparisons.

Building a set costs O(n) once and makes the whole function linear. Measured on the same live process list:

| `remove_non_running_procs()` | min |
|---|---|
| develop | 807.04 ms |
| this PR | 1.84 ms |

The resulting cache is identical — both implementations were run against the same input and the remaining keys compared.

Effect on the full refresh, 6 interleaved before/after pairs in a single process (interleaved to cancel load drift on a shared machine), 15 383 processes, Linux, Python 3.12:

| `GlancesProcesses.update()` | median |
|---|---|
| develop | 4.483 s |
| this PR | 3.637 s |

~0.85 s per refresh, 1.23×. The cost is quadratic in process count, so it is invisible on a laptop and large on a busy server — likely why it went unnoticed.

Adds `tests/test_processes_cache.py` covering eviction, full eviction, the no-op case, and running PIDs absent from the cache.

#### Resume

* Bug fix: no (performance)
* New feature: no
* Fixed tickets:
