### PR TITLE
fix: count terminated connection states instead of counting initiated twice

### DIFF
--- a/glances/plugins/connections/__init__.py
+++ b/glances/plugins/connections/__init__.py
@@ -120,7 +120,7 @@ class ConnectionsPlugin(GlancesPluginModel):
             initiated += stats[s]
         stats['initiated'] = initiated
         terminated = 0
-        for s in self.initiated_states:
+        for s in self.terminated_states:
             stats[s] = len([c for c in net_connections if c.status == s])
             terminated += stats[s]
         stats['terminated'] = terminated

--- a/tests/test_connections_states.py
+++ b/tests/test_connections_states.py
@@ -1,0 +1,53 @@
+"""Tests for the connections plugin state counters."""
+
+from unittest import mock
+
+import psutil
+import pytest
+
+from glances.plugins.connections import ConnectionsPlugin
+
+
+def make_connection(status):
+    return mock.Mock(status=status)
+
+
+@pytest.fixture
+def plugin():
+    return ConnectionsPlugin(args=mock.Mock(time=2), config=None)
+
+
+@pytest.fixture
+def stats(plugin):
+    connections = [
+        make_connection(psutil.CONN_LISTEN),
+        make_connection(psutil.CONN_ESTABLISHED),
+        make_connection(psutil.CONN_ESTABLISHED),
+        make_connection(psutil.CONN_SYN_SENT),
+        make_connection(psutil.CONN_TIME_WAIT),
+        make_connection(psutil.CONN_TIME_WAIT),
+        make_connection(psutil.CONN_CLOSE_WAIT),
+    ]
+    with mock.patch('psutil.net_connections', return_value=connections):
+        return plugin.update_for_net_connections_method({})
+
+
+def test_terminated_states_are_counted(stats):
+    assert stats['terminated'] == 3  # 2 TIME_WAIT + 1 CLOSE_WAIT
+    assert stats[psutil.CONN_TIME_WAIT] == 2
+    assert stats[psutil.CONN_CLOSE_WAIT] == 1
+
+
+def test_initiated_states_are_counted(stats):
+    assert stats['initiated'] == 1
+    assert stats[psutil.CONN_SYN_SENT] == 1
+
+
+def test_every_terminated_state_is_reported(plugin, stats):
+    for state in plugin.terminated_states:
+        assert state in stats
+
+
+def test_listen_and_established_are_counted(stats):
+    assert stats[psutil.CONN_LISTEN] == 1
+    assert stats[psutil.CONN_ESTABLISHED] == 2


### PR DESCRIPTION
#### Description

`update_for_net_connections_method()` loops over `self.initiated_states` twice. The second loop is meant to fill the terminated counters, so `self.terminated_states` is defined but never used: `stats['terminated']` always equals `stats['initiated']`, and `FIN_WAIT1`, `FIN_WAIT2`, `TIME_WAIT`, `CLOSE`, `CLOSE_WAIT` and `LAST_ACK` are never reported at all.

On a live host:

```
terminated_states: [FIN_WAIT1, FIN_WAIT2, TIME_WAIT, CLOSE, CLOSE_WAIT, LAST_ACK]   <- defined
keys produced    : [ESTABLISHED, LISTEN, SYN_RECV, SYN_SENT, 'initiated', 'terminated']
terminated states never set: all six
initiated=2  terminated=2  equal=True
```

The same machine had 556 connections in `TIME_WAIT` and 157 in `CLOSE_WAIT` at that moment, none of which reached the UI.

One word changed. Adds `tests/test_connections_states.py`, which feeds the plugin a fixed set of connections and checks the counters; two of its four tests fail on current `develop` and pass with the fix.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:
