### PR TITLE
fix: make the TTL cache actually cache

### DIFF
--- a/glances/api.py
+++ b/glances/api.py
@@ -35,7 +35,9 @@ class GlancesAPI:
         # Init the stats of all plugins in order to ensure that rate are computed
         self._stats.update()
 
-    @weak_lru_cache(maxsize=1, ttl=ttl)
+    # maxsize has to exceed the number of plugins: callers walk several of them in a row,
+    # so a smaller cache would evict every entry before it could ever be reused.
+    @weak_lru_cache(maxsize=128, ttl=ttl)
     def __getattr__(self, item):
         """Fallback to the stats object for any missing attributes."""
         if item in self._stats.getPluginsList():

--- a/glances/globals.py
+++ b/glances/globals.py
@@ -25,6 +25,7 @@ import re
 import socket
 import subprocess
 import sys
+import time
 import weakref
 from collections import OrderedDict
 from configparser import ConfigParser, NoOptionError, NoSectionError
@@ -554,13 +555,16 @@ def folder_size(path, errno=0):
 
 
 def _get_ttl_hash(ttl):
-    """A simple (dummy) function to return a hash based on the current second.
-    TODO: Implement a real TTL mechanism.
+    """Return a value that stays constant for ttl seconds, then changes.
+
+    Used as part of an lru_cache key, so that an entry stops being reused once it is older
+    than ttl. Buckets are aligned to a monotonic clock: an entry created just before a
+    boundary lives less than the full ttl, which is the price of expiring through the cache
+    key instead of storing a timestamp per entry.
     """
     if ttl is None:
         return 0
-    now = datetime.now()
-    return now.second
+    return int(time.monotonic() / ttl)
 
 
 def weak_lru_cache(maxsize=1, typed=False, ttl=None):

--- a/glances/stats.py
+++ b/glances/stats.py
@@ -311,9 +311,11 @@ please rename it to "{plugin_path.capitalize()}Plugin"'
         for p in self.getPluginsList(enable=False):
             self._plugins[p].load_limits(config)
 
-    # It's a weak cache to avoid updating the same plugin too often
+    # It's a weak cache to avoid updating the same plugin too often.
+    # maxsize has to exceed the number of plugins: this is called once per plugin in a row,
+    # so a smaller cache would evict every entry before it could ever be reused.
     # Note: the function always return None
-    @weak_lru_cache(ttl=1)
+    @weak_lru_cache(maxsize=128, ttl=1)
     def update_plugin(self, p):
         """Update stats, history and views for the given plugin name p"""
         self._plugins[p].update()

--- a/tests/test_ttl_cache.py
+++ b/tests/test_ttl_cache.py
@@ -1,0 +1,48 @@
+"""Tests for the TTL-based lru cache helpers in glances.globals."""
+
+from unittest import mock
+
+import pytest
+
+from glances.globals import _get_ttl_hash
+
+
+@pytest.fixture
+def clock():
+    with mock.patch('glances.globals.time.monotonic') as m:
+        yield m
+
+
+def test_hash_is_stable_within_the_ttl(clock):
+    clock.return_value = 1000.0
+    first = _get_ttl_hash(5)
+    clock.return_value = 1004.0
+    assert _get_ttl_hash(5) == first
+
+
+def test_hash_changes_once_the_ttl_has_passed(clock):
+    clock.return_value = 1000.0
+    first = _get_ttl_hash(5)
+    clock.return_value = 1006.0
+    assert _get_ttl_hash(5) != first
+
+
+def test_hash_honours_the_requested_ttl(clock):
+    """A longer ttl must hold its value where a shorter one has already moved on."""
+    clock.return_value = 1000.0
+    short, long = _get_ttl_hash(1), _get_ttl_hash(30)
+    clock.return_value = 1002.0
+    assert _get_ttl_hash(1) != short
+    assert _get_ttl_hash(30) == long
+
+
+def test_hash_does_not_repeat_after_a_minute(clock):
+    """The value must not cycle, or an entry could be served long after it expired."""
+    clock.return_value = 1000.0
+    first = _get_ttl_hash(1)
+    clock.return_value = 1060.0
+    assert _get_ttl_hash(1) != first
+
+
+def test_hash_is_disabled_without_a_ttl():
+    assert _get_ttl_hash(None) == 0


### PR DESCRIPTION
#### Description

Two defects in the `weak_lru_cache` / `_get_ttl_hash` pair. They have to be fixed together, because the second one currently hides the first.

**1. The TTL is ignored.** `_get_ttl_hash()` returns `datetime.now().second` and never looks at the `ttl` argument beyond the `None` check. So `ttl=30` behaves exactly like `ttl=1`, and because the value cycles every minute, an entry created at second 17 collides with second 17 of the *next* minute — a cache hit on data that is 60 seconds old. The docstring already says `TODO: Implement a real TTL mechanism`.

Now bucketed on a monotonic clock: the key stays constant for `ttl` seconds and never repeats.

**2. The cache holds one entry while the working set is dozens.** Both call sites left `maxsize` at its default of 1, and both are called once per plugin in a row. Every call evicts the previous entry, so nothing is ever reused:

```
processlist    0.0ms     (cached)
cpu            0.4ms     <- evicts processlist
processlist  207.2ms     <- recomputed, same second, ttl=1
```

With 35 plugins the cache never hits at all. After the fix, a full sweep of every plugin inside one TTL window costs 0.0 ms instead of 573 ms, and still recomputes once the window closes:

```
sweep 1 (same second):      0.0ms
sweep 2 (same second):      0.0ms
sweep 3 (same second):      0.0ms
sweep after 1.2s:        3173.4ms
```

#### On memory

`update_plugin()` returns `None`, so the cache stores keys only — a weak ref, a plugin name and an int, roughly 25 KB at `maxsize=128`. `GlancesApi.__getattr__` stores a reference to an already-live plugin object, not a copy.

`maxsize` cannot be dropped to `None`: with bucketed keys the entries of expired buckets stay until evicted, so an unbounded cache would grow forever. The bound is deliberate.

#### Behaviour change worth flagging

`GlancesApi.__getattr__` is decorated with `ttl=ttl`, where `ttl` is the refresh interval. Until now that value was ignored and the effective window was always under a second; it is now honoured. If a shorter window is wanted there, say so and I will pin it.

#### Tests

Adds `tests/test_ttl_cache.py` covering: the value is stable inside the window, changes after it, honours the requested `ttl`, and does not repeat after a minute. Four of its five tests cannot pass on current `develop`.

Full suite on Linux (web tests skipped, no FastAPI/selenium in this environment): **642 passed, 4 failed**. All four — `test_perf_update`, `test_memoryleak_no_history` and two in `test_actions_sanitize` — fail identically on unmodified `develop` on this machine. `test_perf_update` asserts more than one update per second, which this host (15 000 processes) cannot do either way.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:
