### PR TITLE
fix: keep zero-valued fields when aggregating processes into programs

### DIFF
--- a/glances/programs.py
+++ b/glances/programs.py
@@ -6,8 +6,6 @@
 # SPDX-License-Identifier: LGPL-3.0-only
 #
 
-from collections import Counter
-
 # from glances.logger import logger
 
 # This constant defines the list of available processes sort key
@@ -37,14 +35,27 @@ def create_program_dict(p):
     }
 
 
+def sum_field_dict(total, addition):
+    """Add addition into total field by field.
+
+    Counter() is not usable here: adding two Counters drops every key whose sum is not
+    positive, so a program whose iowait or children_user happens to total 0.0 would lose
+    that key and end up with a different set of fields than the processes it aggregates.
+    """
+    merged = dict(total or {})
+    for field, value in (addition or {}).items():
+        merged[field] = merged.get(field, 0) + value
+    return merged
+
+
 def update_program_dict(program, p):
     """Update an existing entry in the dict (existing program)"""
     # some values can be None, e.g. macOS system processes
     program['num_threads'] += p['num_threads'] or 0
     program['cpu_percent'] += p['cpu_percent'] or 0
     program['memory_percent'] += p['memory_percent'] or 0
-    program['cpu_times'] = dict(Counter(program['cpu_times'] or {}) + Counter(p['cpu_times'] or {}))
-    program['memory_info'] = dict(Counter(program['memory_info'] or {}) + Counter(p['memory_info'] or {}))
+    program['cpu_times'] = sum_field_dict(program['cpu_times'], p['cpu_times'])
+    program['memory_info'] = sum_field_dict(program['memory_info'], p['memory_info'])
 
     program['io_counters'] += p['io_counters']
     program['childrens'].append(p['pid'])

--- a/tests/test_programs_aggregation.py
+++ b/tests/test_programs_aggregation.py
@@ -1,0 +1,67 @@
+"""Tests for aggregating processes into programs."""
+
+from glances.programs import processes_to_programs, sum_field_dict
+
+CPU_TIMES_FIELDS = ('user', 'system', 'children_user', 'children_system', 'iowait')
+
+
+def make_process(pid, name, user, system, iowait):
+    return {
+        'pid': pid,
+        'time_since_update': 1.0,
+        'name': name,
+        'cmdline': [name],
+        'username': 'someone',
+        'nice': 0,
+        'status': 'S',
+        'num_threads': 1,
+        'cpu_percent': 1.0,
+        'memory_percent': 1.0,
+        'cpu_times': {
+            'user': user,
+            'system': system,
+            'children_user': 0.0,
+            'children_system': 0.0,
+            'iowait': iowait,
+        },
+        'memory_info': {'rss': 1024, 'vms': 2048, 'shared': 0, 'text': 0, 'data': 0},
+        'io_counters': [0, 0, 0, 0, 0],
+    }
+
+
+def test_zero_totals_keep_their_field():
+    """A field summing to zero must survive, or programs end up with a different schema."""
+    merged = sum_field_dict({'user': 1.0, 'iowait': 0.0}, {'user': 2.0, 'iowait': 0.0})
+    assert merged == {'user': 3.0, 'iowait': 0.0}
+
+
+def test_missing_field_is_added():
+    assert sum_field_dict({'user': 1.0}, {'system': 2.0}) == {'user': 1.0, 'system': 2.0}
+
+
+def test_none_operands_are_tolerated():
+    assert sum_field_dict(None, {'user': 1.0}) == {'user': 1.0}
+    assert sum_field_dict({'user': 1.0}, None) == {'user': 1.0}
+
+
+def test_aggregated_program_keeps_every_cpu_times_field():
+    processes = [
+        make_process(1, 'worker', user=1.5, system=0.5, iowait=0.0),
+        make_process(2, 'worker', user=2.5, system=0.5, iowait=0.0),
+    ]
+    program = processes_to_programs(processes)[0]
+    assert set(program['cpu_times']) == set(CPU_TIMES_FIELDS)
+    assert program['cpu_times']['iowait'] == 0.0
+    assert program['cpu_times']['user'] == 4.0
+    assert program['nprocs'] == 2
+
+
+def test_aggregated_program_keeps_every_memory_info_field():
+    processes = [
+        make_process(1, 'worker', user=1.0, system=1.0, iowait=1.0),
+        make_process(2, 'worker', user=1.0, system=1.0, iowait=1.0),
+    ]
+    program = processes_to_programs(processes)[0]
+    assert set(program['memory_info']) == {'rss', 'vms', 'shared', 'text', 'data'}
+    assert program['memory_info']['shared'] == 0
+    assert program['memory_info']['rss'] == 2048


### PR DESCRIPTION
#### Description

`update_program_dict()` merges the per-process `cpu_times` and `memory_info` dicts with `Counter` arithmetic:

```python
program['cpu_times'] = dict(Counter(program['cpu_times'] or {}) + Counter(p['cpu_times'] or {}))
```

`Counter.__add__` drops every key whose sum is not positive. `iowait`, `children_user` and `shared` are legitimately `0.0` for most processes, so those keys silently disappear from the aggregated program:

```python
>>> dict(Counter({'user': 1.0, 'system': 0.0, 'iowait': 0.0}) + Counter({'user': 2.0, 'system': 0.0, 'iowait': 0.0}))
{'user': 3.0}
```

On a live host every process has the same five `cpu_times` keys, while the programs built from them end up with **six different key sets**, down to a single `{'system'}`. **78 of 1453 programs** carried an incomplete `cpu_times` dict, among them `node`, `python` and `MainThread`. Anything reading `program['cpu_times']['iowait']` raises `KeyError`, and the REST API and exporters emit a schema that varies from program to program.

Replaced with plain dict addition, which keeps zeros. It is also considerably cheaper: the old form built three `Counter` objects per field per process, 87 000 allocations for 15 900 processes.

Measured on 15 921 processes, the two implementations run back to back in one process:

| `processes_to_programs()` | median |
|---|---|
| develop | 144.3 ms |
| this PR | 53.0 ms |

**2.72x**, and programs with an incomplete `cpu_times` go from 78 to 0.

#### Tests

Adds `tests/test_programs_aggregation.py`: zero totals keep their field, missing fields are added, `None` operands are tolerated, and an aggregated program keeps the full `cpu_times` and `memory_info` key sets.

Full suite on Linux (web tests skipped, no FastAPI/selenium in this environment): **638 passed, 4 failed**. The four — `test_perf_update`, `test_memoryleak_no_history` and two in `test_actions_sanitize` — fail identically on unmodified `develop` on this machine. `test_perf_update` asserts more than one full update per second, which this host (15 900 processes) cannot manage either way.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets:
