### PR TITLE
Remove `pyinstrument` from runtime dependencies

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -377,7 +377,7 @@ Enhancements:
 
 Bugs corrected:
 
-* [MACOS] Glances not showing Processes on MacOS #3100
+* [MACOS] Glances not showing Processes on macOS #3100
 * Last dev build broke Homepage API calls ? only 1 widget still working #3322
 * Cloud plugin always generate communication with 169.254.169.254, even if the plugin is disabled #3316
 * API response delay (3+ minutes) when VMs are running #3317
@@ -1029,7 +1029,7 @@ Bugs corrected:
 
 * Correct issue (error message) concerning the Cloud plugin - Related to #2392
 * InfluxDB2 export doesn't process folders correctly - missing key #2327
-* Index error when displaying programs on MacOS #2360
+* Index error when displaying programs on macOS #2360
 * Dissociate 2 sensors with exactly the same names #2280
 * All times displayed in UTC - Container not using TZ/localtime (Docker) #2278
 * It is not possible to return API data for a particular mount point (FS plugin) #1162
@@ -2587,7 +2587,7 @@ Version 1.7.2
 Version 1.7.1
 =============
 
-* Fix IoWait error on FreeBSD / Mac OS
+* Fix IoWait error on FreeBSD / Mac OS X
 * HDDTemp module is now Python v3 compatible
 * Don't warn a process is not running if countmin=0
 * Add PyPI badge on the README.rst

--- a/README.rst
+++ b/README.rst
@@ -413,7 +413,7 @@ It is also possible to use a simple Docker compose file (see in ./docker-compose
 .. code-block:: console
 
     cd ./docker-compose
-    docker-compose up
+    docker compose up
 
 It will start a Glances server with WebUI.
 

--- a/README.rst
+++ b/README.rst
@@ -420,7 +420,7 @@ It will start a Glances server with WebUI.
 Brew: The missing package manager
 ---------------------------------
 
-For Linux and Mac OS, it is also possible to install Glances with `Brew`_:
+For Linux and macOS, it is also possible to install Glances with `Brew`_:
 
 .. code-block:: console
 
@@ -477,7 +477,7 @@ To install Glances from Ports:
 macOS
 -----
 
-MacOS users can install Glances using ``Homebrew`` or ``MacPorts``.
+macOS users can install Glances using ``Homebrew`` or ``MacPorts``.
 
 Homebrew
 ````````

--- a/all-requirements.txt
+++ b/all-requirements.txt
@@ -167,8 +167,6 @@ pydantic-settings==2.14.2
     # via mcp
 pygal==3.1.3
     # via glances
-pyinstrument==5.1.3
-    # via glances
 pyjwt==2.13.0
     # via
     #   ibm-cloud-sdk-core

--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -88,8 +88,6 @@ pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.14.2
     # via mcp
-pyinstrument==5.1.3
-    # via glances
 pyjwt==2.13.0
     # via mcp
 pylxd==2.4.1

--- a/docs/aoa/smart.rst
+++ b/docs/aoa/smart.rst
@@ -3,7 +3,7 @@
 SMART
 =====
 
-*Availability: all but Mac OS*
+*Availability: all but macOS*
 
 *Dependency: this plugin uses the optional pySMART Python lib*
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -236,7 +236,7 @@ Include the `--gpus` flag with the `docker run` command.
 ..
 
 
-With `docker-compose`
+With `docker compose`
 ^^^^^^^^^^^^^^^^^^^^^
 Include the `deploy` section in compose file as specified below in the example service definition.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
   "windows-curses; platform_system == 'Windows'",
   "shtab; platform_system != 'Windows'",
   "jinja2",
-  "pyinstrument>=5.1.2",
 ]
 description = "A cross-platform curses-based monitoring tool"
 dynamic = ["version"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,6 @@ packaging==26.2
     # via glances
 psutil==7.2.2
     # via glances
-pyinstrument==5.1.3
-    # via glances
 shtab==1.9.2 ; sys_platform != 'win32'
     # via glances
 windows-curses==2.4.2 ; sys_platform == 'win32'


### PR DESCRIPTION
#### Description

Has some superficial corrections and also a non-superficial removal of `pyinstrument` from all package groups except for `dev`.

This was causing a `pip check` fail with the Arch Linux package - it seems that `pyinstrument` is part of profilers, so I assumed anywhere where `memray` isn't, `pyinstrument` shouldn't be either.

By the way, what's the point of duplicating the package groups?

You already use `pyproject.toml`, using runtime dependencies, optional dependencies and the internal dependency groups - what's the reason to also define `all-requirements.txt`, `dev-requirements.txt`, `docker-requirements.txt` (notably missing from `pyproject.toml`) and `requirements.txt`?

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: N/A