### PR TITLE
perf: reuse the program aggregation until the process list changes

### DIFF
--- a/glances/processes.py
+++ b/glances/processes.py
@@ -74,7 +74,7 @@ class GlancesProcesses:
         self.processlist = []
         self.reset_processcount()
 
-        # Programs aggregated from processlist, kept until the list itself is replaced
+        # Aggregation of processlist, valid while _programs_source is still the current list
         self._programs = []
         self._programs_source = None
 
@@ -721,12 +721,9 @@ class GlancesProcesses:
         return self.processlist
 
     def _get_programs(self):
-        """Aggregate the processes into programs, reusing the result until the list changes.
-
-        processes_to_programs() walks every process, while the list itself is only rebuilt by
-        update(). Callers ask for it far more often than that, so without this the aggregation
-        is redone from scratch on every refresh of the UI. Both update() and a re-sort replace
-        the list object, which is what invalidates the cache here.
+        """Callers ask for the programs far more often than update() rebuilds the process
+        list, and walking every process each time is the bulk of the programlist refresh.
+        Both update() and a re-sort replace the list object, which is the invalidation.
         """
         if self._programs_source is not self.processlist:
             self._programs = processes_to_programs(self.processlist)

--- a/glances/processes.py
+++ b/glances/processes.py
@@ -74,6 +74,10 @@ class GlancesProcesses:
         self.processlist = []
         self.reset_processcount()
 
+        # Programs aggregated from processlist, kept until the list itself is replaced
+        self._programs = []
+        self._programs_source = None
+
         # Cache is a dict with key=pid and value = dict of cached value
         self.processlist_cache = {}
 
@@ -713,8 +717,21 @@ class GlancesProcesses:
         if sorted:
             self.processlist = sort_stats(self.processlist, sorted_by=self.sort_key, reverse=self.sort_reverse)
         if as_programs:
-            return processes_to_programs(self.processlist)
+            return self._get_programs()
         return self.processlist
+
+    def _get_programs(self):
+        """Aggregate the processes into programs, reusing the result until the list changes.
+
+        processes_to_programs() walks every process, while the list itself is only rebuilt by
+        update(). Callers ask for it far more often than that, so without this the aggregation
+        is redone from scratch on every refresh of the UI. Both update() and a re-sort replace
+        the list object, which is what invalidates the cache here.
+        """
+        if self._programs_source is not self.processlist:
+            self._programs = processes_to_programs(self.processlist)
+            self._programs_source = self.processlist
+        return self._programs
 
     def get_export(self):
         """Return the processlist for export."""
@@ -828,9 +845,11 @@ def sort_stats(stats, sorted_by='cpu_percent', sorted_by_secondary='memory_perce
         try:
             stats = sorted(stats, key=sort_by_these_keys(sorted_by, sorted_by_secondary), reverse=reverse)
         except (KeyError, TypeError) as e:
-            # Fallback to name
+            # Fallback to name. sorted() rather than list.sort(): every other branch returns
+            # a new list, and sorting the caller's list in place makes the result impossible
+            # to tell apart from the input.
             logger.debug(f'Error while sorting by {sorted_by}, fallback to name ({e})')
-            stats.sort(key=lambda process: process['name'] if process['name'] is not None else '~', reverse=False)
+            stats = sorted(stats, key=lambda process: process['name'] if process['name'] is not None else '~')
 
     return stats
 

--- a/glances/processes.py
+++ b/glances/processes.py
@@ -716,6 +716,9 @@ class GlancesProcesses:
         If as_programs is True, return the list of programs."""
         if sorted:
             self.processlist = sort_stats(self.processlist, sorted_by=self.sort_key, reverse=self.sort_reverse)
+            # One branch of sort_stats() reorders the list in place, so a changed order does
+            # not always mean a different object.
+            self._programs_source = None
         if as_programs:
             return self._get_programs()
         return self.processlist
@@ -842,11 +845,9 @@ def sort_stats(stats, sorted_by='cpu_percent', sorted_by_secondary='memory_perce
         try:
             stats = sorted(stats, key=sort_by_these_keys(sorted_by, sorted_by_secondary), reverse=reverse)
         except (KeyError, TypeError) as e:
-            # Fallback to name. sorted() rather than list.sort(): every other branch returns
-            # a new list, and sorting the caller's list in place makes the result impossible
-            # to tell apart from the input.
+            # Fallback to name
             logger.debug(f'Error while sorting by {sorted_by}, fallback to name ({e})')
-            stats = sorted(stats, key=lambda process: process['name'] if process['name'] is not None else '~')
+            stats.sort(key=lambda process: process['name'] if process['name'] is not None else '~', reverse=False)
 
     return stats
 

--- a/tests/test_program_aggregation.py
+++ b/tests/test_program_aggregation.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from glances.processes import GlancesProcesses, sort_stats
+from glances.processes import GlancesProcesses
 
 
 def make_process(pid, name):
@@ -61,17 +61,17 @@ def test_aggregation_content(processes):
     assert programs['other']['nprocs'] == 1
 
 
-def test_sort_stats_does_not_mutate_the_input():
-    """Every branch must return a new list, or callers cannot tell the result from the input.
+def test_aggregation_follows_an_in_place_sort(processes):
+    """sort_stats() reorders the list in place when the primary sort raises, leaving the
+    object identical; the cache has to notice anyway."""
+    # Mixed types in the sort field make the primary sort raise, which is what reaches the
+    # in-place branch. nice is compared but never summed, so the aggregation still works.
+    processes.processlist[0]['nice'] = 'x'
+    assert [p['name'] for p in processes.get_list(as_programs=True)] == ['worker', 'other']
 
-    Mixing types in the sort field makes the primary sort raise TypeError, which is what
-    reaches the fallback branch; that branch used to sort the caller's list in place.
-    """
-    stats = [make_process(1, 'b'), make_process(2, 'a')]
-    stats[0]['cpu_percent'] = 'not-a-number'
+    processes.set_sort_key('nice', auto=False)
+    before = processes.processlist
+    resorted = processes.get_list(sorted=True, as_programs=True)
 
-    result = sort_stats(stats, sorted_by='cpu_percent')
-
-    assert result is not stats
-    assert [p['pid'] for p in stats] == [1, 2], "the caller's list was reordered"
-    assert [p['pid'] for p in result] == [2, 1], 'the fallback sorts by name'
+    assert processes.processlist is before, 'this test is pointless unless the sort was in place'
+    assert [p['name'] for p in resorted] == ['other', 'worker']

--- a/tests/test_program_aggregation.py
+++ b/tests/test_program_aggregation.py
@@ -1,0 +1,70 @@
+"""Tests for reusing the program aggregation between refreshes."""
+
+import pytest
+
+from glances.processes import GlancesProcesses, sort_stats
+
+
+def make_process(pid, name):
+    return {
+        'pid': pid,
+        'name': name,
+        'cmdline': [name],
+        'username': 'someone',
+        'nice': 0,
+        'status': 'S',
+        'num_threads': 1,
+        'cpu_percent': 1.0,
+        'memory_percent': 1.0,
+        'cpu_times': {'user': 1.0, 'system': 1.0, 'children_user': 0.0, 'children_system': 0.0, 'iowait': 0.0},
+        'memory_info': {'rss': 1024, 'vms': 2048, 'shared': 0, 'text': 0, 'data': 0},
+        'io_counters': [0, 0, 0, 0, 0],
+        'time_since_update': 1.0,
+    }
+
+
+@pytest.fixture
+def processes():
+    p = GlancesProcesses()
+    p.processlist = [make_process(1, 'worker'), make_process(2, 'worker'), make_process(3, 'other')]
+    return p
+
+
+def test_aggregation_is_reused_while_the_list_is_unchanged(processes):
+    first = processes.get_list(as_programs=True)
+    assert processes.get_list(as_programs=True) is first
+
+
+def test_aggregation_is_rebuilt_when_the_list_is_replaced(processes):
+    first = processes.get_list(as_programs=True)
+    processes.processlist = [make_process(1, 'worker'), make_process(4, 'newcomer')]
+    second = processes.get_list(as_programs=True)
+    assert second is not first
+    assert {p['name'] for p in second} == {'worker', 'newcomer'}
+
+
+def test_aggregation_is_rebuilt_after_a_sort(processes):
+    first = processes.get_list(as_programs=True)
+    assert processes.get_list(sorted=True, as_programs=True) is not first
+
+
+def test_aggregation_content(processes):
+    programs = {p['name']: p for p in processes.get_list(as_programs=True)}
+    assert programs['worker']['nprocs'] == 2
+    assert programs['other']['nprocs'] == 1
+
+
+def test_sort_stats_does_not_mutate_the_input():
+    """Every branch must return a new list, or callers cannot tell the result from the input.
+
+    Mixing types in the sort field makes the primary sort raise TypeError, which is what
+    reaches the fallback branch; that branch used to sort the caller's list in place.
+    """
+    stats = [make_process(1, 'b'), make_process(2, 'a')]
+    stats[0]['cpu_percent'] = 'not-a-number'
+
+    result = sort_stats(stats, sorted_by='cpu_percent')
+
+    assert result is not stats
+    assert [p['pid'] for p in stats] == [1, 2], "the caller's list was reordered"
+    assert [p['pid'] for p in result] == [2, 1], 'the fallback sorts by name'

--- a/tests/test_program_aggregation.py
+++ b/tests/test_program_aggregation.py
@@ -27,6 +27,7 @@ def make_process(pid, name):
 def processes():
     p = GlancesProcesses()
     p.processlist = [make_process(1, 'worker'), make_process(2, 'worker'), make_process(3, 'other')]
+    p.processlist[2]['cpu_percent'] = 99.0  # 'other' sorts ahead of 'worker' by CPU
     return p
 
 
@@ -43,9 +44,15 @@ def test_aggregation_is_rebuilt_when_the_list_is_replaced(processes):
     assert {p['name'] for p in second} == {'worker', 'newcomer'}
 
 
-def test_aggregation_is_rebuilt_after_a_sort(processes):
-    first = processes.get_list(as_programs=True)
-    assert processes.get_list(sorted=True, as_programs=True) is not first
+def test_aggregation_follows_a_re_sort(processes):
+    """Sorting replaces the process list, so the programs must be aggregated again in the
+    new order rather than served from the previous call."""
+    assert [p['name'] for p in processes.get_list(as_programs=True)] == ['worker', 'other']
+
+    processes.set_sort_key('cpu_percent', auto=False)
+    resorted = processes.get_list(sorted=True, as_programs=True)
+
+    assert [p['name'] for p in resorted] == ['other', 'worker']
 
 
 def test_aggregation_content(processes):


### PR DESCRIPTION
#### Description

`get_list(as_programs=True)` re-runs `processes_to_programs()` on every call, although the
process list it aggregates is only rebuilt by `update()`. The `programlist` plugin asks for it
on every refresh, so the whole list is walked again for a result that cannot have changed.

The aggregation is now kept until the list it was built from is replaced:

| `get_list(as_programs=True)` on ~16 000 processes | median |
|---|---|
| first call after a refresh | 207.8 ms |
| repeated call | 0.00 ms |

`programlist.update()` drops from 153 ms to nothing on the refreshes in between, which on this
machine is most of them.

Replacing the list is what normally invalidates the cache, so `update()` needs no change. A
re-sort is the exception: one branch of `sort_stats()` reorders in place when the primary sort
raises, leaving the same object with a different order, so `get_list(sorted=True)` clears the
cache explicitly.

#### Tests

`tests/test_program_aggregation.py`. `test_aggregation_is_reused_while_the_list_is_unchanged`
fails on `develop`; the others were checked by breaking the implementation on purpose —
removing the explicit invalidation fails the in-place sort test, and neutering the identity
check fails two more. Run together with `tests/test_core.py`: 53 passed.

#### Resume

* Bug fix: no (performance)
* New feature: no
* Fixed tickets:
