### PR TITLE
fix(network): use the TX alert for bytes_sent_rate_per_sec decoration

### DIFF
--- a/glances/plugins/network/__init__.py
+++ b/glances/plugins/network/__init__.py
@@ -233,7 +233,7 @@ class NetworkPlugin(GlancesPluginModel):
             self.views[i[self.get_key()]]['bytes_recv']['decoration'] = alert_rx
             self.views[i[self.get_key()]]['bytes_recv_rate_per_sec']['decoration'] = alert_rx
             self.views[i[self.get_key()]]['bytes_sent']['decoration'] = alert_tx
-            self.views[i[self.get_key()]]['bytes_sent_rate_per_sec']['decoration'] = alert_rx
+            self.views[i[self.get_key()]]['bytes_sent_rate_per_sec']['decoration'] = alert_tx
 
     def _msg_curse_header(self, args, name_max_width):
         """Return the header curse lines."""


### PR DESCRIPTION
Fixes #3660.

`bytes_sent_rate_per_sec` was being decorated with `alert_rx` instead of `alert_tx`. The line directly above it already does the right thing for `bytes_sent`:

```python
self.views[...]['bytes_sent']['decoration'] = alert_tx
self.views[...]['bytes_sent_rate_per_sec']['decoration'] = alert_rx   # <-- this one
```

It's user-visible because the two front ends read different keys — the curses UI reads `bytes_sent`, the Web UI reads `bytes_sent_rate_per_sec` ([plugin-network.vue#L30](https://github.com/nicolargo/glances/blob/develop/glances/outputs/static/js/components/plugin-network.vue#L30)). On an interface with asymmetric traffic they can therefore disagree in the same poll: a 1 Gbps link at ~950 Mbps RX / ~10 Mbps TX shows `Tx/s` undecorated in the terminal and in the **critical** colour in the browser.

One-line change, against `develop` per CONTRIBUTING. I found this by reading the source rather than from a live reproduction, so a second pair of eyes on the expected behaviour is welcome — but the asymmetry with line 235 looks unambiguous.