### PR TITLE
Fix AMD GPU name resolution when the card is only listed in AMD's `amdgpu.ids`

### DIFF
--- a/glances/plugins/gpu/cards/amd.py
+++ b/glances/plugins/gpu/cards/amd.py
@@ -46,7 +46,10 @@ import re
 
 DRM_ROOT_FOLDER: str = '/sys/class/drm'
 DEVICE_FOLDER_PATTERN: str = 'card[0-9]*/device'
-AMDGPU_IDS_FILE: str = '/usr/share/libdrm/amdgpu.ids'
+# Looked up in order, first match wins. The distribution list comes first so that an already
+# resolved name never changes; the list shipped by AMD (amdgpu-install / ROCm) is only consulted
+# for the cards the distribution does not know, typically the Instinct data center ones.
+AMDGPU_IDS_FILES: tuple[str, ...] = ('/usr/share/libdrm/amdgpu.ids', '/opt/amdgpu/share/libdrm/amdgpu.ids')
 PCI_DEVICE_ID: str = 'device'
 PCI_REVISION_ID: str = 'revision'
 GPU_PROC_PERCENT: str = 'gpu_busy_percent'
@@ -125,16 +128,17 @@ def get_device_name(device_folder: str) -> str:
     # Table source: https://cgit.freedesktop.org/drm/libdrm/tree/data/amdgpu.ids
     device_id = read_file(device_folder, PCI_DEVICE_ID)
     revision_id = read_file(device_folder, PCI_REVISION_ID)
-    amdgpu_ids = read_file(AMDGPU_IDS_FILE)
-    if device_id and revision_id and amdgpu_ids:
+    if device_id and revision_id:
         # Strip leading "0x" and convert to uppercase hexadecimal
         device_id = device_id[2:].upper()
         revision_id = revision_id[2:].upper()
         # Syntax:
         # device_id,	revision_id,	product_name        <-- single tab after comma
         pattern = re.compile(f'^{device_id},\\s{revision_id},\\s(?P<product_name>.+)$', re.MULTILINE)
-        if match := pattern.search(amdgpu_ids):
-            return match.group('product_name').removeprefix('AMD ').removesuffix(' Graphics')
+        for amdgpu_ids_file in AMDGPU_IDS_FILES:
+            amdgpu_ids = read_file(amdgpu_ids_file)
+            if amdgpu_ids and (match := pattern.search(amdgpu_ids)):
+                return match.group('product_name').removeprefix('AMD ').removesuffix(' Graphics')
 
     return 'AMD GPU'
 


### PR DESCRIPTION

#### Description

Fixes https://github.com/nicolargo/glances/issues/3663, where `get_device_name()` in `glances/plugins/gpu/cards/amd.py` hard-codes its lookup table to `/usr/share/libdrm/amdgpu.ids`. That copy is frozen at distribution release, so any newer card misses the lookup and falls through to the literal `'AMD GPU'`. Hosts running ROCm or `amdgpu-install` also carry `libdrm-amdgpu-common`, which ships a current copy of the same table at `/opt/amdgpu/share/libdrm/amdgpu.ids`; Glances simply never looked there.

This PR makes the constant an ordered tuple and walks it until a card matches. Two details carry the safety of the change. **The loop stops on a match, not on a readable file:** 51 device IDs live in the distribution list and are absent from AMD's, 50 of them Raven Ridge and Picasso APUs, so returning at the first file that merely exists would have regressed all of them to `AMD GPU`. **The distribution list is searched first,** which makes the change strictly additive: a name that already resolved keeps resolving to the exact same string, and the patch can only ever turn `AMD GPU` into a real name.

I did try AMD's list first and measured it before dropping it. Of the 259 IDs present in both files, 90 render differently after the `AMD ` / ` Graphics` stripping the function applies: 63 are cosmetic `(TM)` insertions and 27 are substantive rewrites (`Radeon Vega 3` becomes `Ryzen Embedded R1305G with Radeon Vega Gfx`). That is user-visible churn on machines that were never broken, and `(TM)` costs five characters in a field the header truncates at 17.

Before:

```
8 AMD GPU
AMD GPU   0% mem  16%    # eight cards, none of them named
```

After:

```
8 Instinct MI355X
Instinct    0% mem  16%  # name from AMD's table
```

Verified on two hosts, 8 × MI250X and 8 × MI355X, and against both real databases comparing old behaviour with new: `740C:01`, `75A3:00` and `744C:C8` go from `AMD GPU` to their model names, while the APU IDs `15D8:CF` and `15DD:C1`, `6600:81`, an unknown `FFFF:FF`, and any host without `/opt` are all byte-identical to before. NVIDIA is untouched by construction, since those names come from NVML in `cards/nvidia.py` and never reach `amdgpu.ids`, and the AMD backend only admits DRM devices exposing `gpu_busy_percent`. Snap strict confinement needs no new handling: `read_file()` already wraps `open()` in `try/except`, so a blocked `/opt` returns `None` and the loop moves on, the same guard added for #3456. Cost is nil when the distribution list matches, since the loop returns before touching `/opt`; on a miss it is one extra read and one regex scan, once per card per process because `get_device_name()` is `@functools.cache`d.

`pytest tests/test_plugin_gpu.py` passes (41), `ruff check` and `ruff format --check` are clean. Note that `AMDGPU_IDS_FILE: str` is renamed and retyped to `AMDGPU_IDS_FILES: tuple[str, ...]`; the only two references in the tree are the definition and its use in the same function. Happy to add a unit test for the multi-path lookup and a `NEWS.rst` entry if you want them here, as there is currently no test covering AMD's `get_device_name()`.

#### Resume

- Bug fix: yes, fixes https://github.com/nicolargo/glances/issues/3663
- New feature: no


| :warning: WARNING           |
|:----------------------------|
| Warning: constant `AMDGPU_IDS_FILES` is changed from type `str` to `tuple`.     |
