### PR TITLE
fix: compare stats to the init value, not to the bound method

### DIFF
--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -1275,7 +1275,7 @@ class GlancesPluginModel:
         """
 
         def wrapper(self, *args, **kw):
-            if self.is_enabled() and (self.refresh_timer.finished() or self.stats == self.get_init_value):
+            if self.is_enabled() and (self.refresh_timer.finished() or self.stats == self.get_init_value()):
                 # Run the method
                 ret = fct(self, *args, **kw)
                 # Reset the timer

--- a/tests/test_plugin_fs.py
+++ b/tests/test_plugin_fs.py
@@ -257,18 +257,21 @@ class TestFsPluginMsgCurse:
     def test_msg_curse_returns_list(self, fs_plugin):
         """Test that msg_curse returns a list."""
         fs_plugin.update()
+        fs_plugin.update_views()
         msg = fs_plugin.msg_curse(max_width=80)
         assert isinstance(msg, list)
 
     def test_msg_curse_empty_without_max_width(self, fs_plugin):
         """Test that msg_curse returns empty without max_width."""
         fs_plugin.update()
+        fs_plugin.update_views()
         msg = fs_plugin.msg_curse()
         assert isinstance(msg, list)
 
     def test_msg_curse_with_max_width(self, fs_plugin):
         """Test that msg_curse works with max_width."""
         fs_plugin.update()
+        fs_plugin.update_views()
         msg = fs_plugin.msg_curse(max_width=80)
         assert isinstance(msg, list)
 

--- a/tests/test_plugin_model.py
+++ b/tests/test_plugin_model.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2024 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the GlancesPluginModel._check_decorator method."""
+
+from glances.plugins.plugin.model import GlancesPluginModel
+
+# _check_decorator is a plain function on the class body (not a bound method
+# when accessed through the class), so it can be applied directly to a fake
+# update function to test it in isolation.
+_check_decorator = GlancesPluginModel._check_decorator
+
+
+class FakeTimer:
+    """Minimal stand-in for glances.timer.Timer."""
+
+    def __init__(self, finished):
+        self._finished = finished
+
+    def finished(self):
+        return self._finished
+
+    def set(self, duration):
+        pass
+
+    def reset(self, duration=None):
+        pass
+
+
+class FakePlugin:
+    """Minimal stand-in for a GlancesPluginModel instance."""
+
+    init_value = {}
+
+    def __init__(self, stats, timer_finished):
+        self.stats = stats
+        self.refresh_timer = FakeTimer(timer_finished)
+        self.called = False
+
+    def is_enabled(self, plugin_name=None):
+        return True
+
+    def get_init_value(self):
+        return self.init_value
+
+    def get_refresh(self):
+        return 2
+
+    @_check_decorator
+    def update(self):
+        self.called = True
+        self.stats = {'foo': 'bar'}
+        return self.stats
+
+
+class TestCheckDecorator:
+    """Test the update() gating logic in GlancesPluginModel._check_decorator."""
+
+    def test_update_called_when_stats_equal_init_value_and_timer_not_finished(self):
+        """Stats still at init value and timer not finished: update MUST run.
+
+        This is the retry-immediately path used after a fetch error (see
+        reset() in cpu/mem plugins), so a stale/empty init value should not
+        wait out the whole refresh interval.
+        """
+        plugin = FakePlugin(stats=FakePlugin.init_value, timer_finished=False)
+
+        plugin.update()
+
+        assert plugin.called is True
+
+    def test_update_not_called_when_stats_differ_and_timer_not_finished(self):
+        """Stats already populated and timer not finished: update must NOT run."""
+        plugin = FakePlugin(stats={'foo': 'previous'}, timer_finished=False)
+
+        plugin.update()
+
+        assert plugin.called is False


### PR DESCRIPTION
## What's broken

In `_check_decorator`, `glances/plugins/plugin/model.py:1278`:

```python
if self.is_enabled() and (self.refresh_timer.finished() or self.stats == self.get_init_value):
```

`self.get_init_value` is the bound method, not its result, so `self.stats` never equals it and that half of the condition is dead.

## Why it matters

The branch exists for the fetch-error path. On an SNMP error, `cpu/__init__.py:249` and `:271`, and `mem/__init__.py:227` and `:245`, call `self.reset()`, which sets `self.stats = self.get_init_value()`. The intent is that the next poll retries straight away instead of serving empty stats until the refresh interval expires. With the missing parentheses that retry never happens.

## The fix

Call it. One character.

I grepped for the same mistake elsewhere. The only other `== self.<attr>` comparisons are `glances_curses_browser.py:77` and `glances_restful_api.py:99`, both against plain attributes, so neither is affected.

## Verification

`tests/test_plugin_model.py` applies the decorator to a fake plugin and asserts update runs when stats are at the init value with the timer unfinished, and does not run when stats are populated. The first fails without the fix.

One thing to flag, because it is the only part of this that is not mechanical. Three tests in `tests/test_plugin_fs.py` started failing with `KeyError('/')` once the fix landed. They were passing vacuously: they call `update()` and then `msg_curse()`, and with the dead branch `update()` was a no-op after a preceding test's `reset()`, so `msg_curse` iterated an empty stats list and asserted nothing. With the fix, `update()` refetches real filesystems while `self.views` is still empty.

They now call `update_views()` after `update()`, which is the order production uses in `stats.py:319-320`. That felt like the right call since the tests were out of step with the real call sequence, but if you would rather `msg_curse` defend itself against empty views, say so and I will do that instead.

`pytest tests/` is otherwise unchanged: the two `test_actions_sanitize` failures are the same before and after on my machine.
