### PR TITLE
feat(fs): allow free-space display in config

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -403,6 +403,8 @@ tx_latency_critical=50
 
 [fs]
 disable=False
+# Display free space instead of used space (same as --fs-free-space)
+#free_space=False
 # Refresh rate for this plugin (in seconds). Default is the global refresh rate.
 # Filesystem usage (statvfs) changes slowly.
 refresh=60

--- a/glances/main.py
+++ b/glances/main.py
@@ -828,6 +828,9 @@ Examples of use:
             args.password = self.password
 
     def init_ui_mode(self, args):
+        # Display free filesystem space when requested from the configuration file
+        args.fs_free_space = args.fs_free_space or self.config.get_bool_value('fs', 'free_space', default=False)
+
         # Manage light mode
         if getattr(args, 'enable_light', False):
             logger.info("Light mode is on")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -20,7 +20,9 @@ class TestGlancesMain(TestCase):
             config_path = Path(tmpdir) / 'glances.conf'
             config_path.write_text('[fs]\nfree_space=true\n')
 
-            with patch('sys.argv', ['glances', '-C', str(config_path)]):
-                args = GlancesMain().get_args()
+            for mode_args in ([], ['-w']):
+                with self.subTest(mode_args=mode_args):
+                    with patch('sys.argv', ['glances', *mode_args, '-C', str(config_path)]):
+                        args = GlancesMain().get_args()
 
-        self.assertTrue(args.fs_free_space)
+                    self.assertTrue(args.fs_free_space)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,26 @@
+# This file is part of Glances.
+#
+# SPDX-FileCopyrightText: 2026 Jack Chen <nightcityblade@gmail.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+
+"""Tests for Glances command-line initialization."""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+from glances.main import GlancesMain
+
+
+class TestGlancesMain(TestCase):
+    def test_fs_free_space_from_config(self):
+        with TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / 'glances.conf'
+            config_path.write_text('[fs]\nfree_space=true\n')
+
+            with patch('sys.argv', ['glances', '-C', str(config_path)]):
+                args = GlancesMain().get_args()
+
+        self.assertTrue(args.fs_free_space)


### PR DESCRIPTION
#### Description

Allow the `[fs]` section to set `free_space=true`, enabling the same display mode as `--fs-free-space`. The command-line flag remains effective, and the sample configuration plus a focused regression test document the new setting.

Fixes #3659.

Tests:

- `uv run pytest -q tests/test_main.py` (1 passed)
- `uv run pytest -q tests/test_core.py` (48 passed, 4 skipped)
- `uv run ruff check glances/main.py tests/test_main.py`
- `uv run ruff format --check glances/main.py tests/test_main.py`

#### Resume

* Bug fix: no
* New feature: yes
* Fixed tickets: #3659
