### PR TITLE
fix(containers): aggregate network stats over all container interfaces (#3669)

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,6 +8,7 @@ Version 4.5.6
 
 Bugs corrected:
 
+* Container network stats now aggregate all the container interfaces instead of eth0 only #3669
 * Alert level decided by dict ordering: a failing+slow URL is downgraded to WARNING, an unscanned URL reports CRITICAL #3632
 * GPU plugin duplicates card name and omits N/A for unavailable metrics in multi-GPU #3631
 * GPU plugin duplicates the utilisation value and paints it with the memory colour in multi-GPU #3630

--- a/glances/plugins/containers/engines/docker.py
+++ b/glances/plugins/containers/engines/docker.py
@@ -169,15 +169,25 @@ class DockerStatsFetcher:
             rx: Number of bytes received
             tx: Number of bytes transmitted
         """
-        eth0_stats = self._streamer.stats.get('networks', {}).get('eth0')
+        interfaces_stats = self._streamer.stats.get('networks') or {}
 
         # Checks for net_stats & mandatory fields
-        if not eth0_stats or any(field not in eth0_stats for field in ['rx_bytes', 'tx_bytes']):
+        # Note: a container can be attached to several networks (eth0, eth1...)
+        # so all the interfaces should be aggregated (issue #3669)
+        valid_interfaces = [
+            interface_stats
+            for interface_name, interface_stats in interfaces_stats.items()
+            if interface_name != 'lo' and all(field in interface_stats for field in ['rx_bytes', 'tx_bytes'])
+        ]
+        if not valid_interfaces:
             self._log_debug("Missing Network usage fields")
             return None
 
-        # Read the rx/tx stats (in bytes)
-        stats = {'cumulative_rx': eth0_stats["rx_bytes"], 'cumulative_tx': eth0_stats["tx_bytes"]}
+        # Read the rx/tx stats (in bytes), summed over all the container interfaces
+        stats = {
+            'cumulative_rx': sum(interface_stats['rx_bytes'] for interface_stats in valid_interfaces),
+            'cumulative_tx': sum(interface_stats['tx_bytes'] for interface_stats in valid_interfaces),
+        }
 
         # Using previous stats to calculate rates
         old_network_stats = self._old_computed_stats.get("network")

--- a/tests/test_plugin_containers.py
+++ b/tests/test_plugin_containers.py
@@ -28,6 +28,8 @@ def build_fetcher(networks, old_stats=None):
 
 
 class TestDockerNetworkStatsAggregation:
+    """Test the Docker network stats aggregation across container interfaces."""
+
     def test_single_interface(self):
         """A single interface keeps the values it had before the aggregation change."""
         fetcher = build_fetcher({'eth0': {'rx_bytes': 100, 'tx_bytes': 200}})
@@ -61,14 +63,18 @@ class TestDockerNetworkStatsAggregation:
 
 
 class TestDockerNetworkStatsNoData:
+    """Test the Docker network stats when no usable interface is reported."""
+
     def test_host_network_returns_none(self):
         """--network host containers have no networks key at all."""
         assert build_fetcher(None)._get_network_stats() is None
 
     def test_empty_networks_returns_none(self):
+        """An empty networks dict yields no stats."""
         assert build_fetcher({})._get_network_stats() is None
 
     def test_all_interfaces_malformed_returns_none(self):
+        """Every interface missing a counter yields no stats."""
         assert build_fetcher({'eth0': {'rx_bytes': 100}})._get_network_stats() is None
 
     def test_one_malformed_among_two_keeps_the_valid_one(self):
@@ -85,7 +91,10 @@ class TestDockerNetworkStatsNoData:
 
 
 class TestDockerNetworkStatsRates:
+    """Test the Docker network stats rate computation."""
+
     def test_rates_use_the_summed_counters(self):
+        """Rates are computed from the summed counters, not from a single interface."""
         fetcher = build_fetcher(
             {
                 'eth0': {'rx_bytes': 100, 'tx_bytes': 200},
@@ -99,6 +108,7 @@ class TestDockerNetworkStatsRates:
         assert 'time_since_update' in stats
 
     def test_first_sample_has_no_rate_keys(self):
+        """Without previous stats there is nothing to compute a rate from."""
         fetcher = build_fetcher({'eth0': {'rx_bytes': 100, 'tx_bytes': 200}})
         stats = fetcher._get_network_stats()
         assert 'rx' not in stats

--- a/tests/test_plugin_containers.py
+++ b/tests/test_plugin_containers.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the Containers plugin engines (issue #3669 network aggregation)."""
+
+from types import SimpleNamespace
+
+from glances.plugins.containers.engines.docker import DockerStatsFetcher
+
+
+def build_fetcher(networks, old_stats=None):
+    """Build a DockerStatsFetcher without opening a live stats stream."""
+    fetcher = DockerStatsFetcher.__new__(DockerStatsFetcher)
+    fetcher._container = SimpleNamespace(id='deadbeef')
+    fetcher._streamer = SimpleNamespace(
+        stats={'networks': networks} if networks is not None else {},
+        last_update_time=100.0,
+    )
+    fetcher._old_computed_stats = old_stats or {}
+    fetcher._last_stats_computed_time = 97.0
+    return fetcher
+
+
+class TestDockerNetworkStatsAggregation:
+    def test_single_interface(self):
+        """A single interface keeps the values it had before the aggregation change."""
+        fetcher = build_fetcher({'eth0': {'rx_bytes': 100, 'tx_bytes': 200}})
+        stats = fetcher._get_network_stats()
+        assert stats['cumulative_rx'] == 100
+        assert stats['cumulative_tx'] == 200
+
+    def test_two_interfaces_are_summed(self):
+        """A container attached to two networks reports the sum of both."""
+        fetcher = build_fetcher(
+            {
+                'eth0': {'rx_bytes': 100, 'tx_bytes': 200},
+                'eth1': {'rx_bytes': 50, 'tx_bytes': 25},
+            }
+        )
+        stats = fetcher._get_network_stats()
+        assert stats['cumulative_rx'] == 150
+        assert stats['cumulative_tx'] == 225
+
+    def test_loopback_is_excluded(self):
+        """Loopback traffic is not counted, even when the runtime reports it."""
+        fetcher = build_fetcher(
+            {
+                'eth0': {'rx_bytes': 100, 'tx_bytes': 200},
+                'lo': {'rx_bytes': 999, 'tx_bytes': 999},
+            }
+        )
+        stats = fetcher._get_network_stats()
+        assert stats['cumulative_rx'] == 100
+        assert stats['cumulative_tx'] == 200
+
+
+class TestDockerNetworkStatsNoData:
+    def test_host_network_returns_none(self):
+        """--network host containers have no networks key at all."""
+        assert build_fetcher(None)._get_network_stats() is None
+
+    def test_empty_networks_returns_none(self):
+        assert build_fetcher({})._get_network_stats() is None
+
+    def test_all_interfaces_malformed_returns_none(self):
+        assert build_fetcher({'eth0': {'rx_bytes': 100}})._get_network_stats() is None
+
+    def test_one_malformed_among_two_keeps_the_valid_one(self):
+        """A malformed interface no longer discards the valid ones."""
+        fetcher = build_fetcher(
+            {
+                'eth0': {'rx_bytes': 100, 'tx_bytes': 200},
+                'eth1': {'rx_bytes': 50},
+            }
+        )
+        stats = fetcher._get_network_stats()
+        assert stats['cumulative_rx'] == 100
+        assert stats['cumulative_tx'] == 200
+
+
+class TestDockerNetworkStatsRates:
+    def test_rates_use_the_summed_counters(self):
+        fetcher = build_fetcher(
+            {
+                'eth0': {'rx_bytes': 100, 'tx_bytes': 200},
+                'eth1': {'rx_bytes': 50, 'tx_bytes': 25},
+            },
+            old_stats={'network': {'cumulative_rx': 40, 'cumulative_tx': 25}},
+        )
+        stats = fetcher._get_network_stats()
+        assert stats['rx'] == 110
+        assert stats['tx'] == 200
+        assert 'time_since_update' in stats
+
+    def test_first_sample_has_no_rate_keys(self):
+        fetcher = build_fetcher({'eth0': {'rx_bytes': 100, 'tx_bytes': 200}})
+        stats = fetcher._get_network_stats()
+        assert 'rx' not in stats
+        assert 'tx' not in stats
+        assert 'time_since_update' not in stats


### PR DESCRIPTION
#### Description

Fixes #3669.

`DockerStatsFetcher._get_network_stats()` read the container network counters from a
single hardcoded interface:

```python
eth0_stats = self._streamer.stats.get('networks', {}).get('eth0')
```

The Docker stats endpoint returns one entry per container interface, so a container
attached to several networks (`docker network connect`, or several networks in a Compose
file) gets `eth0`, `eth1`, … and everything past `eth0` was silently dropped. Reported
RX/TX for those containers was too low.

The method now sums `rx_bytes`/`tx_bytes` across all interfaces. Its output contract is
unchanged: same keys, same types, same units.

Two deliberate choices, as discussed in the issue:

* **`lo` is excluded.** The Docker daemon does not normally report loopback in `networks`,
  but Docker-API-compatible runtimes have been observed to, and loopback traffic would
  massively inflate the totals.
* **Interfaces with missing counters are skipped, not fatal.** Previously a malformed
  `eth0` aborted the whole method; now one malformed interface among several no longer
  discards the valid ones. `None` is still returned when nothing usable remains, so
  `--network host` containers (no `networks` key) behave exactly as before.

#### On the decision point raised in the issue

The issue asked not to decide alone between **(a) leave as is** and **(b) clamp the delta
to zero**, given that attaching/detaching a network between two samples changes the
interface set and can produce one negative `rx`/`tx` delta.

**This PR implements (a)**, for two reasons:

1. Negative deltas are already reachable today on container restart, when the counters
   reset. (b) would silently swallow that pre-existing signal too, which changes behaviour
   for a case that is not in the scope of this issue.
2. (b) hides a real counter discontinuity rather than reporting it. If the glitch turns
   out to matter in practice, clamping is better addressed once for all cumulative
   counters than locally here.

Happy to switch to (b) if you prefer.

#### Tests

New file `tests/test_plugin_containers.py`, 9 cases, pytest style to match the sibling
`test_plugin_*.py` files. `DockerStatsFetcher.__init__` opens a live stats stream, so the
instance is built via `__new__` with the two attributes the method reads injected.

| Case | Expected |
|---|---|
| Single interface | identical values to the previous implementation (regression guard) |
| Two interfaces | counters summed |
| Loopback present | `lo` excluded |
| Host network (no `networks` key) | `None` |
| Empty `networks` dict | `None` |
| All interfaces malformed | `None` |
| One malformed among two | malformed skipped, valid one still counted |
| Rate computation | `rx`/`tx` are the summed deltas, `time_since_update` present |
| First sample | no `rx`/`tx`/`time_since_update` keys |

Verified the tests actually pin the bug — against the unpatched `docker.py`, exactly the
two cases that target it fail and the seven regression guards pass:

```
FAILED tests/test_plugin_containers.py::TestDockerNetworkStatsAggregation::test_two_interfaces_are_summed
        assert 100 == 150
FAILED tests/test_plugin_containers.py::TestDockerNetworkStatsRates::test_rates_use_the_summed_counters
        assert 60 == 110
2 failed, 7 passed
```

With the patch: `9 passed`.

#### Regression run

Full suite before and after, same machine (Windows 11, Python 3.14, 1 running container):

```
before: 57 failed, 571 passed, 106 skipped, 15 errors
after:  58 failed, 579 passed, 106 skipped, 15 errors
```

The 72 pre-existing failures/errors — `test_restful.py`, `test_xmlrpc.py`, `test_mcp.py`,
`test_browser_restful.py`, `test_amp_secure_popen.py`, `test_webui.py`, `test_perf.py`, all
server/WebUI tests that need a chromedriver and a POSIX socket — are **identical line for
line** before and after. The 9 new tests account for the passed count.

The single delta is `test_memoryleak.py::test_memoryleak_no_history`
(`assert memory_leak < 15000`, got 15524). It is not caused by this change:

* The file passes on its own with the patch applied.
* Its measurement is unstable on this machine, and **it exceeds its own threshold on
  unpatched `develop`**. Three runs each, reading the value the test itself logs:

  | run | unpatched `develop` | this branch |
  |---|---:|---:|
  | 1 | 12 391 B | 16 734 B |
  | 2 | 7 948 B | 20 268 B |
  | 3 | **32 480 B** ❌ | 6 718 B |
  | mean | 17 606 B | **14 573 B** |

  The unpatched spread is 7 948 – 32 480 B, a 4× range against a hard-coded 15 000 B
  threshold, and the unpatched maximum is the largest of all six runs.

* Isolating the changed method removes the ambiguity. Driving both implementations
  200 000 times under `tracemalloc` with the same single-interface payload:

  ```
     old (eth0 only): retained after 200,000 calls =  688 bytes  (0.0034 B/call)
    new (aggregated): retained after 200,000 calls =  656 bytes  (0.0033 B/call)
  ```

  Neither retains anything — that residue is tracemalloc's own bookkeeping — and the new
  form retains marginally less. The memory-leak test performs ~13 calls per run, so the
  per-call difference is well under a byte.

Flagging the threshold separately since it is unrelated to this PR: on a machine with any
background load, `test_memoryleak_no_history` looks like it can fail on a clean checkout.
Happy to open a separate issue if that is useful.

`ruff format` and `ruff check` are clean on both touched files. `rstcheck NEWS.rst` reports
the same 8 pre-existing issues before and after, shifted by the one added line.

#### Branches

Applied to `develop`. I re-verified the branch parity the issue asked about rather than
assuming it: `glances/plugins/containers/engines/docker.py` has blob SHA
`c818def749329c9b2d00171c43cb2f2739fac5f4` on both `develop` and `develop-v5`, so the
cherry-pick to `develop-v5` is clean. Say the word and I'll open the companion PR.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: #3669
