### PR TITLE
fix(plugins): init containers, vms and smart stats as a list

### DIFF
--- a/glances/plugins/containers/__init__.py
+++ b/glances/plugins/containers/__init__.py
@@ -147,7 +147,11 @@ class ContainersPlugin(GlancesPluginModel):
     def __init__(self, args=None, config=None):
         """Init the plugin."""
         super().__init__(
-            args=args, config=config, items_history_list=items_history_list, fields_description=fields_description
+            args=args,
+            config=config,
+            items_history_list=items_history_list,
+            stats_init_value=[],
+            fields_description=fields_description,
         )
 
         # The plugin can be disabled using: args.disable_docker

--- a/glances/plugins/smart/__init__.py
+++ b/glances/plugins/smart/__init__.py
@@ -187,13 +187,13 @@ def get_smart_data(hide_attributes):
 class SmartPlugin(GlancesPluginModel):
     """Glances' HDD SMART plugin."""
 
-    def __init__(self, args=None, config=None, stats_init_value=[]):
+    def __init__(self, args=None, config=None):
         """Init the plugin."""
         if not is_admin() and args:
             disable(args, "smart")
             logger.debug("Current user is not admin, HDD SMART plugin disabled.")
 
-        super().__init__(args=args, config=config)
+        super().__init__(args=args, config=config, stats_init_value=[])
 
         self.display_curse = True
         self.hide_attributes = self._parse_hide_attributes(config)

--- a/glances/plugins/vms/__init__.py
+++ b/glances/plugins/vms/__init__.py
@@ -100,7 +100,11 @@ class VmsPlugin(GlancesPluginModel):
     def __init__(self, args=None, config=None):
         """Init the plugin."""
         super().__init__(
-            args=args, config=config, items_history_list=items_history_list, fields_description=fields_description
+            args=args,
+            config=config,
+            items_history_list=items_history_list,
+            stats_init_value=[],
+            fields_description=fields_description,
         )
 
         # The plugin can be disabled using: args.disable_vm

--- a/tests/test_plugin_init_value.py
+++ b/tests/test_plugin_init_value.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests that plugins exposing a list of stats initialise them as a list."""
+
+import pytest
+
+LIST_PLUGINS = (
+    'alert',
+    'amps',
+    'containers',
+    'diskio',
+    'folders',
+    'fs',
+    'gpu',
+    'irq',
+    'mpp',
+    'network',
+    'npu',
+    'percpu',
+    'ports',
+    'processlist',
+    'programlist',
+    'sensors',
+    'smart',
+    'vms',
+    'wifi',
+)
+
+
+@pytest.mark.parametrize('plugin_name', LIST_PLUGINS)
+def test_init_value_is_a_list(glances_stats, plugin_name):
+    """get_init_value is what update() returns when it has nothing to report."""
+    plugin = glances_stats.get_plugin(plugin_name)
+
+    assert isinstance(plugin.get_init_value(), list)
+
+
+@pytest.mark.parametrize('plugin_name', LIST_PLUGINS)
+def test_reset_leaves_the_stats_a_list(glances_stats, plugin_name):
+    """reset() must not swap the stats to a dict behind the API's back."""
+    plugin = glances_stats.get_plugin(plugin_name)
+    plugin.reset()
+
+    assert isinstance(plugin.stats, list)


### PR DESCRIPTION
#### Description

`/api/4/containers` returns `{}` instead of `[]` when no container engine library is importable, which is what #3582 reports.

`ContainersPlugin` exposes a list of stats but never passed `stats_init_value` to `super().__init__()`, so it inherited the base default of `{}` (`glances/plugins/plugin/model.py:59`). `get_init_value()` is what `update()` returns when it has nothing to report:

```python
if not self.watchers:
    return self.get_init_value()
if self.input_method != 'local':
    return self.get_init_value()
```

...and it is also what the base `reset()` installs. So on a machine where `import docker` fails, the plugin answers with an empty dict where the API contract says list.

**Three plugins have this, not one.** `vms` has the identical omission. `smart` is the interesting one: it declares `stats_init_value=[]` as its *own parameter default* and then drops it on the way to the parent:

```python
def __init__(self, args=None, config=None, stats_init_value=[]):
    ...
    super().__init__(args=args, config=config)   # never forwarded
```

That reads as correct and greps as correct. Only running it shows the plugin still gets `{}`. Every other list plugin — alert, amps, diskio, folders, fs, gpu, irq, mpp, network, npu, percpu, ports, processlist, sensors, wifi — already passes `stats_init_value=[]`.

**This has been seen before and read as flakiness.** `tests/test_restful.py:149` carries a workaround for exactly this symptom:

```python
if isinstance(req.json(), dict) and not req.json():
    # Specific case for plugins that can be empty on VM (like sensors, containers...)
    # They return an empty dict instead of an empty list
    continue
```

added in 4c92e1b, *"test: Fix flaky tests (allow empty dicts for list plugins)"*. After this change that `continue` can no longer fire for any plugin in the list. I have deliberately left it alone to keep the diff on the bug — happy to remove it in a follow-up if you'd like the assertion tightened.

**On the "silently" in the issue title** — worth noting for the reporter, but not something I propose to change here. `glances/logger.py:60` pins the console handler to `CRITICAL` and nothing re-raises it under `--debug`, so the `logger.warning("Error loading Docker deps Lib. Docker plugin is disabled (...)")` at `containers/engines/docker.py:27` only ever reaches the rotating log file. That line in `glances.log` is what names their actual root cause. (Their check `from glances.plugins.containers.engines.docker import DockerExtension` proves nothing either way — that import succeeds even when the plugin is disabled, because the `try/except` only sets a flag.)

**Verification**, on macOS / Python 3.12 against `develop` @ 3bda428:

```
before:  glances --stdout-json containers  ->  {"containers": {}}
after:   glances --stdout-json containers  ->  {"containers": []}
```

and the reporter's exact code path, `watchers = {}`, now returns `[]`.

`tests/test_plugin_init_value.py` is added as a regression guard across all 19 list plugins rather than just the three, so a future plugin that forgets the argument fails immediately. Against the unpatched tree it fails 6 / passes 32 — exactly the three plugins × two assertions; with the fix, 38 pass.

Full suite is unchanged either side: **715 passed → 753 passed** (+38 new), same 8 pre-existing unrelated failures both runs (2 × `test_actions_sanitize`, 6 × `test_xmlrpc` host-header). `ruff check` and `ruff format --check` clean.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: 3582
