### PR TITLE
fix(filter): keep the whole regex when it contains a colon

### DIFF
--- a/glances/filter.py
+++ b/glances/filter.py
@@ -110,7 +110,11 @@ class GlancesFilter:
             self._filter = None
             self._filter_key = None
         else:
-            new_filter = value.split(':')
+            # Split once: everything after the first colon is the regex. Splitting on
+            # every colon dropped the rest, and the truncation is silent because the
+            # leading fragment usually still compiles -- `cmdline:C:\Program Files\.*`
+            # became the pattern `C`, which matches nothing and raises nothing.
+            new_filter = value.split(':', 1)
             if len(new_filter) == 1:
                 self._filter = new_filter[0]
                 self._filter_key = None

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -568,6 +568,26 @@ class TestGlances(unittest.TestCase):
         self.assertTrue(gf.is_filtered({'username': 'nicolargo'}))
         self.assertFalse(gf.is_filtered({'username': 'notme'}))
         self.assertFalse(gf.is_filtered({'notuser': 'nicolargo'}))
+        # The regex may itself contain a colon: a Windows path is the common case,
+        # and every absolute one has a drive colon. Splitting on every colon kept only
+        # the fragment before the second one -- and silently, because that fragment
+        # usually still compiles, so the filter matched nothing and reported nothing.
+        gf.filter = 'cmdline:C:/Program Files/.*'
+        self.assertEqual(gf.filter, 'C:/Program Files/.*')
+        self.assertEqual(gf.filter_key, 'cmdline')
+        self.assertTrue(gf.is_filtered({'cmdline': 'C:/Program Files/app.exe'}))
+        self.assertFalse(gf.is_filtered({'cmdline': 'D:/Other/app.exe'}))
+        # Same shape without a path, so the case is not Windows-only.
+        gf.filter = 'name:foo:bar'
+        self.assertEqual(gf.filter, 'foo:bar')
+        self.assertEqual(gf.filter_key, 'name')
+        self.assertTrue(gf.is_filtered({'name': 'foo:bar'}))
+        # A backslash is a regex escape, not a separator escape: `split_esc` would
+        # strip it and mangle the pattern, which is why plain maxsplit is the right
+        # tool here.
+        gf.filter = r'cmdline:C:\\Windows\\.*'
+        self.assertEqual(gf.filter, r'C:\\Windows\\.*')
+        self.assertTrue(gf.is_filtered({'cmdline': r'C:\Windows\system32'}))
         gfl = GlancesFilterList()
         gfl.filter = '.*python.*,username:nicolargo'
         self.assertTrue(gfl.is_filtered({'name': 'python is in the place'}))


### PR DESCRIPTION
## The defect

`GlancesFilter.filter` splits the input on **every** colon and keeps only the second field (`glances/filter.py:113`):

```python
new_filter = value.split(':')
...
self._filter = new_filter[1]
self._filter_key = new_filter[0]
```

So everything after the second colon is discarded. Measured on `develop`:

| input | key | regex |
| --- | --- | --- |
| `cmdline:C:/Program Files/.*` | `cmdline` | **`C`** |
| `name:foo:bar` | `name` | **`foo`** |

And the truncated filter then rejects the process it was written for:

```python
>>> f.filter = 'cmdline:C:/Program Files/.*'
>>> f.is_filtered({'cmdline': 'C:/Program Files/app.exe'})
False
```

**The truncation is silent.** The leading fragment is usually still a valid regex — `C` compiles fine — so the `except` around `re.compile` at `:134` never fires. The user gets an empty process list, no error, and one `debug`-level log line.

On Windows this is *every absolute path*, because each one carries a drive colon. It is not Windows-only, though: it also truncates URLs, IPv6 literals, and any `foo:bar` process name.

## The fix

`value.split(':', 1)`.

I looked at the repo's own `split_esc` (`glances/globals.py:677`) first, since `plugins/plugin/model.py:1069` already uses it for a `key:value` pair. It is the wrong tool here: it escapes on backslash and **removes the escape characters from its result**, which would mangle a Windows path regex like `C:\Windows\.*`. The separator in this field needs no escaping — a filter key never contains a colon — so plain `maxsplit` is both smaller and correct. There is a test pinning that backslashes survive.

## Verification

Windows 11, Python 3.14.7.

```
tests/test_core.py     46 passed, 6 skipped     (identical to develop — no test moved)
ruff check             All checks passed
```

**Mutation-checked**, after confirming the edit applied: restoring `split(':')` fails `test_020_filter` with `AssertionError: 'C' != 'C:/Program Files/.*'`.

## Tests

Extends the existing `test_020_filter`, which already exercises `GlancesFilter` this way, with three cases: a path regex carrying a drive colon, the same shape without a path (`name:foo:bar`, so the case is not read as Windows-only), and a backslash-bearing regex asserting the escapes survive the split.

One thing I did **not** change: a filter written as a bare regex with a colon in it, such as `http://.*`, still has its scheme read as the key. This fix stops the regex being truncated but does not disambiguate that; validating the key against the known process fields would, and that is a larger decision than this one-token change.
