### PR TITLE
fix(folders): honour folder_N_refresh instead of walking every cycle

### DIFF
--- a/glances/folder_list.py
+++ b/glances/folder_list.py
@@ -119,7 +119,7 @@ class FolderList:
         # Iter upon the folder list
         for i in range(len(self.get())):
             # Update folder size
-            if not self.first_grab and i in self.timer_folders and not self.timer_folders[i].finished():
+            if not self.first_grab and i < len(self.timer_folders) and not self.timer_folders[i].finished():
                 continue
             # Set the key (see issue #2327)
             self.__folder_list[i]['key'] = key
@@ -132,7 +132,7 @@ class FolderList:
                     )
                 )
             # Reset the timer
-            if i in self.timer_folders:
+            if i < len(self.timer_folders):
                 self.timer_folders[i].reset()
 
         # It is no more the first time...

--- a/tests/test_folder_list_refresh.py
+++ b/tests/test_folder_list_refresh.py
@@ -1,0 +1,81 @@
+"""Tests for the per-folder refresh timer of the folder list."""
+
+from time import time
+
+import pytest
+
+import glances.folder_list as folder_list_mod
+from glances.folder_list import FolderList
+
+
+def expire(timer):
+    """Push a timer past its deadline without touching its duration."""
+    timer.target = time() - 1
+
+
+class FakeConfig:
+    """Minimal stand-in for the Glances config, with a single monitored folder."""
+
+    def __init__(self, refresh):
+        self.refresh = refresh
+
+    def has_section(self, section):
+        return section == 'folders'
+
+    def get_value(self, section, key, default=None):
+        return {'folder_1_path': '/a/folder', 'folder_1_refresh': self.refresh}.get(key, default)
+
+
+@pytest.fixture
+def walks(monkeypatch):
+    """Count the folder_size() walks and keep the real filesystem out of it."""
+    calls = []
+
+    def fake_folder_size(path, refresh=False):
+        calls.append(path)
+        return 1234, 0
+
+    monkeypatch.setattr(folder_list_mod, 'folder_size', fake_folder_size)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _empty_list():
+    # The folder list is held on the class, so it survives between instances.
+    FolderList._FolderList__folder_list = []
+    yield
+    FolderList._FolderList__folder_list = []
+
+
+def test_folder_is_not_walked_again_before_its_refresh_delay(walks):
+    folders = FolderList(FakeConfig('600'))
+    for _ in range(4):
+        folders.update()
+    assert len(walks) == 1
+
+
+def test_folder_is_walked_again_once_the_timer_is_over(walks):
+    folders = FolderList(FakeConfig('600'))
+    folders.update()
+    expire(folders.timer_folders[0])
+    folders.update()
+    assert len(walks) == 2
+
+
+def test_the_timer_is_restarted_after_a_walk(walks):
+    folders = FolderList(FakeConfig('600'))
+    folders.update()
+    expire(folders.timer_folders[0])
+    folders.update()
+    # Restarted for another 600s, so the next cycles must not walk the folder again.
+    assert not folders.timer_folders[0].finished()
+    folders.update()
+    assert len(walks) == 2
+
+
+def test_a_folder_without_a_timer_is_still_updated(walks):
+    folders = FolderList(FakeConfig('600'))
+    folders.update()
+    folders.timer_folders = []
+    folders.update()
+    assert len(walks) == 2


### PR DESCRIPTION
## The bug

`FolderList.update()` guards the per-folder timer like this:

```python
if not self.first_grab and i in self.timer_folders and not self.timer_folders[i].finished():
    continue
```

`i` is a list index; `self.timer_folders` is a list of `Timer` objects. `i in self.timer_folders` is a **membership** test, not a bounds check — it asks whether the integer `i` equals one of the timers. `Timer` doesn't implement `__eq__`, so it is always `False`:

```python
>>> from glances.timer import Timer
>>> 0 in [Timer(600), Timer(600)]
False
```

So the skip branch is unreachable, and the `self.timer_folders[i].reset()` below it never runs either.

## What it costs

`folder_N_refresh` has no effect. Every monitored folder is re-walked on **every** refresh cycle (2s by default) instead of on its own schedule — and `folder_size()` is a full recursive walk, which is the whole reason the setting exists.

Measured with `folder_1_refresh=600` and `folder_size` counted:

| | walks after 4 update cycles |
|---|---|
| before | 4 |
| after | 1 |

## The fix

Use the bound the code meant: `i < len(self.timer_folders)`.

The guard is worth keeping rather than dropping — `__folder_list` is a **class** attribute while `timer_folders` is per-instance, so the folder list can outgrow the timer list and the index has to be checked.

## Tests

`tests/test_folder_list_refresh.py`, 4 cases: refresh delay honoured, folder walked again once the timer is over, timer restarted after a walk, and a folder with no timer still updated.

Mutation-checked — putting `i in self.timer_folders` back turns 2 of the 4 red:

```
FAILED test_folder_is_not_walked_again_before_its_refresh_delay
FAILED test_the_timer_is_restarted_after_a_walk
2 failed, 2 passed
```

`ruff check` and `ruff format --check` clean on both files.
