### PR TITLE
fix(ports): send the ICMP timeout in the unit each ping expects

### DIFF
--- a/glances/plugins/ports/__init__.py
+++ b/glances/plugins/ports/__init__.py
@@ -347,13 +347,17 @@ class ThreadScanner(threading.Thread):
         if WINDOWS:
             timeout_opt = '-w'
             count_opt = '-n'
+            # Windows ping takes the reply timeout in milliseconds
+            timeout_value = str(int(float(port['timeout']) * 1000))
         elif MACOS or BSD:
             timeout_opt = '-t'
             count_opt = '-c'
+            timeout_value = str(port['timeout'])
         else:
             # Linux and co...
             timeout_opt = '-W'
             count_opt = '-c'
+            timeout_value = str(port['timeout'])
         # Build the command line
         # Note: Only string are allowed
         cmd = [
@@ -361,7 +365,7 @@ class ThreadScanner(threading.Thread):
             count_opt,
             '1',
             timeout_opt,
-            str(self._resolv_name(port['timeout'])),
+            timeout_value,
             self._resolv_name(port['host']),
         ]
         fnull = open(os.devnull, 'w')

--- a/tests/test_plugin_ports.py
+++ b/tests/test_plugin_ports.py
@@ -11,7 +11,8 @@
 
 import pytest
 
-from glances.plugins.ports import PortsPlugin
+import glances.plugins.ports as ports_mod
+from glances.plugins.ports import PortsPlugin, ThreadScanner
 
 
 @pytest.fixture
@@ -65,3 +66,56 @@ class TestPortsPluginAlertLevel:
         """Test that a reachable and fast URL is OK."""
         conds = ports_plugin.get_conds_if_url(web_scan(200))
         assert ports_plugin.get_default_ret_value(conds) == 'OK'
+
+
+@pytest.fixture
+def scanner():
+    """Return a ThreadScanner instance without running its full init."""
+    return ThreadScanner.__new__(ThreadScanner)
+
+
+class TestIcmpPingCommand:
+    """Test the ping command line built for an ICMP (port 0) check."""
+
+    @pytest.fixture
+    def ping_cmd(self, scanner, monkeypatch):
+        """Return the ping command line built on the given platform."""
+
+        def build(platform, timeout=3):
+            recorded = {}
+
+            def fake_check_call(cmd, **kwargs):
+                recorded['cmd'] = cmd
+                return 0
+
+            for name in ('WINDOWS', 'MACOS', 'BSD'):
+                monkeypatch.setattr(ports_mod, name, name == platform)
+            monkeypatch.setattr(ports_mod.subprocess, 'check_call', fake_check_call)
+            monkeypatch.setattr(ThreadScanner, '_resolv_name', lambda self, host: host)
+            scanner._port_scan_icmp({'host': 'example.net', 'port': 0, 'timeout': timeout})
+            return recorded['cmd']
+
+        return build
+
+    def test_windows_timeout_is_expressed_in_milliseconds(self, ping_cmd):
+        """Windows ping -w is a per-reply timeout in ms, so 3s must be sent as 3000."""
+        assert ping_cmd('WINDOWS') == ['ping', '-n', '1', '-w', '3000', 'example.net']
+
+    def test_linux_timeout_stays_in_seconds(self, ping_cmd):
+        """Linux ping -W is in seconds, so the value is passed through."""
+        assert ping_cmd('LINUX') == ['ping', '-c', '1', '-W', '3', 'example.net']
+
+    def test_macos_timeout_stays_in_seconds(self, ping_cmd):
+        """macOS and BSD ping -t is in seconds, so the value is passed through."""
+        assert ping_cmd('MACOS') == ['ping', '-c', '1', '-t', '3', 'example.net']
+
+    def test_timeout_is_not_sent_through_the_name_resolver(self, scanner, monkeypatch):
+        """The timeout is a number of seconds, not a hostname to look up."""
+        resolved = []
+
+        for name in ('WINDOWS', 'MACOS', 'BSD'):
+            monkeypatch.setattr(ports_mod, name, False)
+        monkeypatch.setattr(ports_mod.subprocess, 'check_call', lambda cmd, **kwargs: 0)
+        monkeypatch.setattr(ThreadScanner, '_resolv_name', lambda self, host: resolved.append(host) or host)
+        scanner._port_scan_icmp({'host': 'example.net', 'port': 0, 'timeout': 3})
+        assert resolved == ['example.net']


### PR DESCRIPTION
## Windows: the timeout is a thousand times too small

`_port_scan_icmp()` passes the configured timeout straight to `ping`:

```python
if WINDOWS:
    timeout_opt = '-w'
...
cmd = ['ping', count_opt, '1', timeout_opt, str(self._resolv_name(port['timeout'])), ...]
```

Windows `ping -w` is documented as *"Timeout in milliseconds to wait for each reply"*. `-W` (Linux) and `-t` (macOS/BSD) are in seconds. So `timeout = 3` — the default in `glances.conf` — becomes a **3 ms** deadline on Windows.

Measured on Windows 11, two hosts that answer comfortably inside 3 seconds:

| host | RTT | `ping -n 1 -w 3` | `ping -n 1 -w 3000` |
|---|---|---|---|
| 200.160.2.3 | 350 ms | exit **1** | exit 0 |
| 139.130.4.5 | 168 ms | exit **1** | exit 0 |

A non-zero exit lands in `port['status'] = False`, i.e. the host shows as **offline**.

Windows clamps the actual wait to roughly 50 ms, which is why this hides on a LAN:

```
-w 3     -> elapsed 50 ms      (against a black-holed IP)
-w 3000  -> elapsed 2985 ms
```

So `8.8.8.8` at 35 ms still answers in time, and anything further away is silently reported down. That matches the symptom of remote hosts flapping to offline on Windows while the same config is fine on Linux.

## The same argument also goes through the DNS resolver

```python
str(self._resolv_name(port['timeout']))
```

`_resolv_name()` runs `socket.gethostbyname()`. The timeout is a number of seconds, not a host — `ports_list.py` builds it with `int(...)`, so the call can only raise:

```python
>>> socket.gethostbyname(3)
TypeError: gethostbyname() argument 1 must be str, bytes or bytearray, not int
```

`_resolv_name` swallows that and returns the value unchanged, so nothing breaks today — but every ICMP check pays for a pointless call and writes a misleading `Cannot convert 3 to IP address` into the debug log.

## The fix

Build the timeout argument next to the option that consumes it, in that option's own unit, and stop routing it through the resolver. `-W` and `-t` keep passing seconds through unchanged.

## Tests

Four cases added to `tests/test_plugin_ports.py`, driving `ThreadScanner._port_scan_icmp` with `subprocess.check_call` captured:

- Windows → `['ping', '-n', '1', '-w', '3000', 'example.net']`
- Linux → `['ping', '-c', '1', '-W', '3', 'example.net']`
- macOS/BSD → `['ping', '-c', '1', '-t', '3', 'example.net']`
- only the host reaches `_resolv_name`

Mutation-checked — reverting the source turns exactly the two affected cases red and leaves the two passthrough cases green:

```
FAILED TestIcmpPingCommand::test_windows_timeout_is_expressed_in_milliseconds
FAILED TestIcmpPingCommand::test_timeout_is_not_sent_through_the_name_resolver
2 failed, 11 passed
```

`ruff check` and `ruff format --check` clean.
