### PR TITLE
fix(containers): stop repeating a title fragment when several engines run

### DIFF
--- a/glances/plugins/containers/__init__.py
+++ b/glances/plugins/containers/__init__.py
@@ -344,8 +344,12 @@ class ContainersPlugin(GlancesPluginModel):
             msg = f' sorted by {sort_for_human[self.sort_key]}'
             ret.append(self.curse_add_line(msg))
         if not self.views['show_engine_name']:
+            # With several engines the name is a per-row column instead, so
+            # there is nothing to add here. The append has to stay inside the
+            # branch: `msg` still holds the previous fragment, and appending it
+            # again repeats it in the title.
             msg = f' (served by {self.stats[0].get("engine", "")})'
-        ret.append(self.curse_add_line(msg))
+            ret.append(self.curse_add_line(msg))
         ret.append(self.curse_new_line())
         return ret
 

--- a/tests/test_plugin_containers.py
+++ b/tests/test_plugin_containers.py
@@ -11,6 +11,7 @@
 
 from types import SimpleNamespace
 
+from glances.plugins.containers import ContainersPlugin
 from glances.plugins.containers.engines.docker import DockerStatsFetcher
 
 
@@ -114,3 +115,55 @@ class TestDockerNetworkStatsRates:
         assert 'rx' not in stats
         assert 'tx' not in stats
         assert 'time_since_update' not in stats
+
+
+class TestContainersTitle:
+    """The title line is built by appending fragments to one list.
+
+    `build_title` ended with the "(served by X)" append sitting outside its
+    own `if`, so when several engines are present — the one case where that
+    branch is skipped — the previous fragment was appended a second time.
+    """
+
+    @staticmethod
+    def title(stats, show_engine_name, sort_key='cpu_percent'):
+        plugin = ContainersPlugin.__new__(ContainersPlugin)
+        plugin.curse_add_line = lambda msg, *args, **kwargs: {'msg': msg}
+        plugin.curse_new_line = lambda: {'msg': '\n'}
+        plugin.stats = stats
+        plugin.views = {'show_engine_name': show_engine_name}
+        plugin.sort_key = sort_key
+        return ''.join(line['msg'] for line in plugin.build_title([]) if line['msg'] != '\n')
+
+    def test_several_engines_do_not_repeat_the_sort_fragment(self):
+        stats = [{'engine': 'docker'}, {'engine': 'podman'}]
+        assert self.title(stats, show_engine_name=True) == 'CONTAINERS 2 sorted by CPU consumption'
+
+    def test_several_engines_with_one_container_do_not_repeat_the_title(self):
+        assert self.title([{'engine': 'podman'}], show_engine_name=True) == 'CONTAINERS'
+
+    def test_one_engine_still_names_it(self):
+        stats = [{'engine': 'docker'}, {'engine': 'docker'}]
+        assert self.title(stats, show_engine_name=False) == (
+            'CONTAINERS 2 sorted by CPU consumption (served by docker)'
+        )
+
+    def test_one_engine_one_container(self):
+        assert self.title([{'engine': 'docker'}], show_engine_name=False) == ('CONTAINERS (served by docker)')
+
+    def test_the_sort_key_is_named_in_the_title(self):
+        stats = [{'engine': 'docker'}, {'engine': 'docker'}]
+        assert 'memory consumption' in self.title(stats, show_engine_name=False, sort_key='memory_usage')
+        assert 'container name' in self.title(stats, show_engine_name=False, sort_key='name')
+
+    def test_no_fragment_appears_twice(self):
+        for stats, show in (
+            ([{'engine': 'docker'}, {'engine': 'podman'}], True),
+            ([{'engine': 'podman'}], True),
+            ([{'engine': 'docker'}, {'engine': 'docker'}], False),
+            ([{'engine': 'docker'}], False),
+        ):
+            title = self.title(stats, show_engine_name=show)
+            assert title.count('CONTAINERS') == 1, title
+            assert title.count('sorted by') <= 1, title
+            assert title.count('served by') <= 1, title


### PR DESCRIPTION
## One append in the wrong block

`build_title` assembles the containers header by appending fragments to a single list. The final append sits **outside** the branch that produces its message:

```python
if len(self.stats) > 1:
    msg = f' {len(self.stats)}'
    ret.append(self.curse_add_line(msg))
    msg = f' sorted by {sort_for_human[self.sort_key]}'
    ret.append(self.curse_add_line(msg))
if not self.views['show_engine_name']:
    msg = f' (served by {self.stats[0].get("engine", "")})'
ret.append(self.curse_add_line(msg))      # ← outside the `if`
```

With one engine the branch runs and the append is right. With several engines the branch is skipped, `msg` still holds the fragment appended just above it, and appending it again repeats it in the header.

`show_engine_name` is set when the containers come from more than one engine:

```python
if len({ct["engine"] for ct in self.stats}) > 1:
    show_engine_name = True
```

so this is exactly the Docker + Podman case.

## Measured

Driving the real `build_title`:

| containers | engines | title |
|---|---|---|
| 2 | 2 | `CONTAINERS 2 sorted by CPU consumption `**`sorted by CPU consumption`** |
| 1 | 2 | `CONTAINERS`**`CONTAINERS`** |
| 2 | 1 | `CONTAINERS 2 sorted by CPU consumption (served by docker)` ✓ |
| 1 | 1 | `CONTAINERS (served by docker)` ✓ |

After the fix the first two read `CONTAINERS 2 sorted by CPU consumption` and `CONTAINERS`, and the two correct rows are unchanged.

## The fix

Move the append inside its branch. Nothing is lost in the multi-engine case: `maybe_add_engine_name_or_pod_line` already adds a per-row **Engine** column there, which is why the header deliberately omits "(served by …)".

## Tests

Six cases in `tests/test_plugin_containers.py`, driving `build_title` with the curses helpers stubbed:

- several engines → the sort fragment appears once
- several engines with a single container → the title appears once
- one engine → `(served by docker)` still shown, with and without the count
- the sort key is named in the title (`memory consumption`, `container name`)
- a sweep asserting no fragment appears twice in any of the four combinations

Mutation-checked — putting the append back outside the branch turns 3 of the 6 red:

```
FAILED test_several_engines_do_not_repeat_the_sort_fragment
FAILED test_several_engines_with_one_container_do_not_repeat_the_title
FAILED test_no_fragment_appears_twice
3 failed, 12 passed
```

`ruff check` and `ruff format --check` clean on both files.
