### PR TITLE
feat(export): publish a numeric AMP result as result_float too (#3423)

### DIFF
--- a/glances/exports/export.py
+++ b/glances/exports/export.py
@@ -12,6 +12,7 @@ I am your father...
 """
 
 import re
+from math import isfinite
 
 from glances.globals import NoOptionError, NoSectionError, json_dumps
 from glances.logger import logger
@@ -172,9 +173,10 @@ class GlancesExport:
         FIELD_TO_TAG = ["name", "cmdline", "type"]
         # Some fields should be converted to string in order to avoid type mismatch in InfluxDB
         # Example: the 'result' field of the AMP plugin can be a string or a number depending on the AMP implementation.
-        # In this case, we convert it to a string and create another field with the same name but with a suffix (_float)
-        # to keep the original value.
-        # See #3419 for more details.
+        # In this case, we convert it to a string and, when the value is numeric,
+        # publish it a second time under a '<name>_float' field so it stays
+        # queryable as a number.
+        # See #3419 and #3423 for more details.
         FIELD_TO_STRING = ["result"]
 
         # Build initial dict by crossing columns and point
@@ -196,6 +198,9 @@ class GlancesExport:
                 fields = data_dict
             # Transform to InfluxDB data model
             # https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_reference/
+            # Companion fields are collected here and merged after the walk: a
+            # dict cannot grow while it is being iterated.
+            float_fields = {}
             for k in fields:
                 #  Do not export empty (None) value
                 if fields[k] is None:
@@ -211,7 +216,15 @@ class GlancesExport:
                         pass
                 # Convert some fields to string to avoid type mismatch in InfluxDB
                 if k in FIELD_TO_STRING:
+                    # Keep the numeric value under a name that is always a float,
+                    # so an AMP that reports a number stays graphable. Only when
+                    # the value really parsed as one - a string result has no
+                    # number to publish. NaN and inf are left out: InfluxDB
+                    # rejects them, and one would fail the whole write.
+                    if isinstance(fields[k], float) and isfinite(fields[k]):
+                        float_fields[f'{k}_float'] = fields[k]
                     fields[k] = str(fields[k])
+            fields.update(float_fields)
             # Manage tags
             tags = self.parse_tags(self.tags)
             # Add the hostname as a tag

--- a/tests/test_export_influxdb_normalize.py
+++ b/tests/test_export_influxdb_normalize.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the InfluxDB normalization of exported stats (issues #3419, #3423)."""
+
+import pytest
+
+from glances.exports.export import GlancesExport
+
+
+@pytest.fixture
+def exporter():
+    """An exporter with just enough state for normalize_for_influxdb()."""
+    export = GlancesExport.__new__(GlancesExport)
+    export.tags = None
+    export.hostname = 'testhost'
+    return export
+
+
+def fields_of(exporter, columns, points, measurement='amps'):
+    result = exporter.normalize_for_influxdb(measurement, columns, points)
+    assert len(result) == 1
+    return result[0]['fields']
+
+
+class TestAmpResultTyping:
+    """`result` carries whatever the AMP command printed.
+
+    Forcing it to a string keeps InfluxDB from rejecting the second AMP that
+    writes a different type into the same column (#3419) — but it also left a
+    numeric AMP with no numeric field at all. `result_float` is that field.
+    """
+
+    def test_a_numeric_result_is_also_published_as_a_float(self, exporter):
+        fields = fields_of(exporter, ['key', 'name', 'result'], ['name', 'throttle', '42'])
+        assert fields['result_float'] == 42.0
+        assert isinstance(fields['result_float'], float)
+
+    def test_result_itself_stays_a_string(self, exporter):
+        fields = fields_of(exporter, ['key', 'name', 'result'], ['name', 'throttle', 3.5])
+        assert isinstance(fields['result'], str)
+
+    def test_a_textual_result_publishes_no_float(self, exporter):
+        fields = fields_of(exporter, ['key', 'name', 'result'], ['name', 'conntrack', 'nf_conntrack_count = 123'])
+        assert 'result_float' not in fields
+        assert fields['result'] == 'nf_conntrack_count = 123'
+
+    def test_the_two_amps_from_the_report_can_coexist(self, exporter):
+        """A string AMP and a numeric AMP must not disagree about a column type."""
+        text = fields_of(exporter, ['key', 'name', 'result'], ['name', 'conntrack', 'count = 1'])
+        number = fields_of(exporter, ['key', 'name', 'result'], ['name', 'throttle', '7'])
+        assert type(text['result']) is type(number['result'])
+        assert number['result_float'] == 7.0
+
+    @pytest.mark.parametrize('value', [float('nan'), float('inf'), float('-inf')])
+    def test_non_finite_results_are_not_published_as_floats(self, exporter, value):
+        """InfluxDB rejects NaN/inf; one of them would fail the whole write."""
+        fields = fields_of(exporter, ['key', 'name', 'result'], ['name', 'weird', value])
+        assert 'result_float' not in fields
+
+    def test_an_empty_result_publishes_neither_field(self, exporter):
+        fields = fields_of(exporter, ['key', 'name', 'result'], ['name', 'quiet', None])
+        assert 'result_float' not in fields
+
+    def test_a_zero_result_is_still_published(self, exporter):
+        fields = fields_of(exporter, ['key', 'name', 'result'], ['name', 'throttle', '0'])
+        assert fields['result_float'] == 0.0
+
+
+class TestNormalizeUnchanged:
+    """The companion field must not disturb the rest of the normalization."""
+
+    def test_ordinary_numeric_fields_stay_floats_without_a_companion(self, exporter):
+        fields = fields_of(exporter, ['key', 'name', 'cpu_percent'], ['name', 'a', 12], measurement='p')
+        assert fields['cpu_percent'] == 12.0
+        assert 'cpu_percent_float' not in fields
+
+    def test_a_measurement_without_a_result_is_untouched(self, exporter):
+        fields = fields_of(exporter, ['key', 'name', 'count'], ['name', 'a', 3], measurement='p')
+        assert fields == {'key': 'name', 'count': 3.0}


### PR DESCRIPTION
Closes #3423.

## The comment describes a field that does not exist

`normalize_for_influxdb` says:

```python
# Some fields should be converted to string in order to avoid type mismatch in InfluxDB
# Example: the 'result' field of the AMP plugin can be a string or a number depending on the AMP implementation.
# In this case, we convert it to a string and create another field with the same name but with a suffix (_float)
# to keep the original value.
# See #3419 for more details.
FIELD_TO_STRING = ["result"]
```

Only the first half is implemented:

```python
if k in FIELD_TO_STRING:
    fields[k] = str(fields[k])
```

`grep -rn "_float" glances/` finds the comment and nothing else — the companion field was never created.

## Why it matters

Forcing `result` to a string is what stopped InfluxDB rejecting the second AMP that wrote a different type into the same column (#3419). But it also left every **numeric** AMP with no numeric field at all: a `package_throttle_count` that used to be graphable is now a string, and there is no way to chart it.

Measured against the real `normalize_for_influxdb`:

| AMP result | before | after |
|---|---|---|
| `'42'` | `result: str '42.0'` | `result: str '42.0'`, **`result_float: float 42.0`** |
| `3.5` | `result: str '3.5'` | `result: str '3.5'`, **`result_float: float 3.5`** |
| `'nf_conntrack_count = 123'` | `result: str …` | `result: str …` *(no companion)* |

A textual result publishes no companion — there is no number to publish — so the two AMPs from the original report still agree on the type of every column they share. `result` itself is untouched, so existing dashboards keep working.

## Two details

- The companion is collected during the walk and merged afterwards. A dict cannot grow while it is being iterated, and writing it inline would raise `RuntimeError: dictionary changed size during iteration` the first time a numeric AMP reported.
- `NaN` and `inf` are excluded. InfluxDB rejects them, and one would fail the **whole** write — a worse outcome than the missing field this change is fixing.

## Tests

`tests/test_export_influxdb_normalize.py` — 11 cases:

- a numeric result is published as a float, and `result` stays a string
- a textual result publishes no companion
- the string AMP and the numeric AMP from #3419 agree on `result`'s type, and the numeric one still gets its float
- `nan`, `inf`, `-inf` publish no companion
- `None` publishes neither field; `0` still publishes `0.0` (not swallowed as falsy)
- ordinary numeric fields keep their float type and get **no** companion — only `FIELD_TO_STRING` names do
- a measurement without a `result` is byte-for-byte unchanged

Mutation-checked, twice:

```
# drop the companion field
× a_numeric_result_is_also_published_as_a_float
× the_two_amps_from_the_report_can_coexist
× a_zero_result_is_still_published                     3 failed, 8 passed

# drop the isfinite guard
× non_finite_results_are_not_published_as_floats[nan]
× ...[inf]
× ...[-inf]                                            3 failed, 8 passed
```

`ruff check` and `ruff format --check` clean on both files.
