### PR TITLE
fix(connections): alert on the tracked percentage, not on 0

### DIFF
--- a/glances/plugins/connections/__init__.py
+++ b/glances/plugins/connections/__init__.py
@@ -182,7 +182,9 @@ class ConnectionsPlugin(GlancesPluginModel):
         try:
             # Alert and log
             if self.stats['nf_conntrack_enabled']:
-                self.views['nf_conntrack_percent']['decoration'] = self.get_alert(header='nf_conntrack_percent')
+                self.views['nf_conntrack_percent']['decoration'] = self.get_alert(
+                    self.stats['nf_conntrack_percent'], header='nf_conntrack_percent'
+                )
         except KeyError:
             # try/except mandatory for Windows compatibility (no conntrack stats)
             pass

--- a/tests/test_connections_states.py
+++ b/tests/test_connections_states.py
@@ -51,3 +51,41 @@ def test_every_terminated_state_is_reported(plugin, stats):
 def test_listen_and_established_are_counted(stats):
     assert stats[psutil.CONN_LISTEN] == 1
     assert stats[psutil.CONN_ESTABLISHED] == 2
+
+
+@pytest.fixture
+def conntrack_plugin(plugin):
+    """A plugin whose nf_conntrack limits match the ones conf/glances.conf ships."""
+    plugin._limits.update(
+        {
+            'connections_nf_conntrack_percent_careful': 70,
+            'connections_nf_conntrack_percent_warning': 80,
+            'connections_nf_conntrack_percent_critical': 90,
+        }
+    )
+    return plugin
+
+
+def conntrack_decoration(plugin, percent):
+    """Run update_views over a conntrack table filled to *percent* and read the decoration."""
+    count = int(65536 * percent / 100)
+    plugin.stats = {
+        'net_connections_enabled': False,
+        'nf_conntrack_enabled': True,
+        'nf_conntrack_count': count,
+        'nf_conntrack_max': 65536,
+        'nf_conntrack_percent': percent,
+    }
+    plugin.update_views()
+    return plugin.views['nf_conntrack_percent']['decoration']
+
+
+def test_conntrack_alert_reads_the_tracked_percentage(conntrack_plugin):
+    """A conntrack table this full drops connections; the thresholds exist to say so."""
+    assert conntrack_decoration(conntrack_plugin, 95) == 'CRITICAL'
+    assert conntrack_decoration(conntrack_plugin, 85) == 'WARNING'
+    assert conntrack_decoration(conntrack_plugin, 75) == 'CAREFUL'
+
+
+def test_conntrack_alert_stays_ok_below_the_first_threshold(conntrack_plugin):
+    assert conntrack_decoration(conntrack_plugin, 10) == 'OK'


### PR DESCRIPTION
`connections/__init__.py` builds the conntrack decoration like this:

```python
self.views['nf_conntrack_percent']['decoration'] = self.get_alert(header='nf_conntrack_percent')
```

No value is passed, so `get_alert` uses its own default — `current=0` — and computes `value = 0 * 100 / 100`. Zero is below every threshold, so the result is `OK` on every refresh regardless of how full the table is.

The thresholds are real and documented. `conf/glances.conf` ships them:

```ini
# nf_conntrack thresholds in %
nf_conntrack_percent_careful=70
nf_conntrack_percent_warning=80
nf_conntrack_percent_critical=90
```

and `docs/aoa/connections.rst` documents the same three. None of them could ever fire.

That matters more than a missing colour: once `nf_conntrack_count` reaches `nf_conntrack_max` the kernel starts dropping new connections, which is precisely the condition a `critical=90` threshold is there to warn about before it happens. `nf_conntrack_percent` is already computed correctly in `update_for_nf_conntrack_method`, so the number on screen was right the whole time — only its colour was decided from 0.

Both interfaces read this one decoration — the WebUI through `getDecoration('nf_conntrack_percent')` in `plugin-connections.vue` — so both were silent, and both are fixed by the one change.

## Tests

Added to `tests/test_connections_states.py`, reusing that file's plugin fixture. `update_views` runs over injected stats and the decoration is read back:

- 95% → `CRITICAL`, 85% → `WARNING`, 75% → `CAREFUL`
- 10% → `OK`

The limits are set on the fixture to the values `conf/glances.conf` ships, since the fixture builds the plugin with `config=None`.

**Mutation-checked** — restoring `get_alert(header='nf_conntrack_percent')` fails exactly one test, on the first assertion:

```
- CRITICAL
+ OK
1 failed, 5 passed
```

The `10% → OK` case deliberately does not catch that mutation: it pins the low end, which reads `OK` either way. It is there so a future change cannot fix the high end by colouring everything.

```
python -m pytest tests/test_connections_states.py -q
6 passed
```

No WebUI rebuild is needed — the change is Python only, and the bundle already reads the decoration the plugin publishes.
