### PR TITLE
fix(diskio): alert on the bitrate, and decorate the field the WebUI reads

### DIFF
--- a/glances/plugins/diskio/__init__.py
+++ b/glances/plugins/diskio/__init__.py
@@ -189,11 +189,22 @@ class DiskioPlugin(GlancesPluginModel):
             # if not i.get('read_bytes_rate_per_sec') or not i.get('write_bytes_rate_per_sec'):
             #     continue
 
-            # Decorate the bitrate with the configuration file
-            alert_rx = self.get_alert(i['read_bytes'], header='rx', action_key=disk_real_name)
-            alert_tx = self.get_alert(i['write_bytes'], header='tx', action_key=disk_real_name)
-            self.views[i[self.get_key()]]['read_bytes']['decoration'] = alert_rx
-            self.views[i[self.get_key()]]['write_bytes']['decoration'] = alert_tx
+            # Decorate the bitrate with the configuration file.
+            # The thresholds describe a bitrate, so they are measured against the rate and
+            # not against read_bytes/write_bytes, which are lifetime counters: those only
+            # grow, so any configured threshold latched on and stayed there. Same shape as
+            # the network plugin, which alerts on bytes_recv_rate_per_sec.
+            alert_rx = self.get_alert(i.get('read_bytes_rate_per_sec') or 0, header='rx', action_key=disk_real_name)
+            alert_tx = self.get_alert(i.get('write_bytes_rate_per_sec') or 0, header='tx', action_key=disk_real_name)
+            # Published on both keys because the two interfaces read different ones: the TUI
+            # asks for read_bytes while printing the rate, the WebUI asks for
+            # read_bytes_rate_per_sec, which nothing decorated. The rate view only exists
+            # once there is a timespan to divide by, so it is set when present.
+            disk_views = self.views[i[self.get_key()]]
+            for field, alert in (('read_bytes', alert_rx), ('write_bytes', alert_tx)):
+                disk_views[field]['decoration'] = alert
+                if f'{field}_rate_per_sec' in disk_views:
+                    disk_views[f'{field}_rate_per_sec']['decoration'] = alert
 
             # Decorate the latency with the configuration file
             # Try to get the read/write latency for the current disk

--- a/tests/test_plugin_diskio.py
+++ b/tests/test_plugin_diskio.py
@@ -348,3 +348,62 @@ class TestDiskioPluginAlias:
         for disk in stats:
             if 'alias' in disk:
                 assert disk['alias'] is None or isinstance(disk['alias'], str)
+
+
+class TestDiskioBitrateAlert:
+    """The rx/tx thresholds describe a bitrate, so they must be measured against one."""
+
+    # get_stat_name() builds plugin_name + action_key + header, so a per-disk threshold
+    # is named after the disk, exactly as the network plugin's docstring documents
+    # (network_wlan0_rx_careful).
+    LIMITS = {
+        'diskio_sda_rx_careful': 50,
+        'diskio_sda_rx_warning': 70,
+        'diskio_sda_rx_critical': 90,
+        'diskio_sda_tx_careful': 50,
+        'diskio_sda_tx_warning': 70,
+        'diskio_sda_tx_critical': 90,
+    }
+
+    def _views_for(self, plugin, read_rate, write_rate):
+        plugin._limits.update(self.LIMITS)
+        plugin.stats = [
+            {
+                'disk_name': 'sda',
+                # Lifetime counters, large as they are on any machine with uptime.
+                'read_bytes': 5_000_000_000,
+                'write_bytes': 5_000_000_000,
+                'read_bytes_rate_per_sec': read_rate,
+                'write_bytes_rate_per_sec': write_rate,
+                'read_latency': 0,
+                'write_latency': 0,
+            }
+        ]
+        plugin.update_views()
+        return plugin.views['sda']
+
+    def test_alert_follows_the_rate_not_the_lifetime_counter(self, diskio_plugin):
+        """A quiet disk with terabytes of history is quiet, whatever the counter reads."""
+        views = self._views_for(diskio_plugin, read_rate=10, write_rate=10)
+        assert views['read_bytes']['decoration'] == 'OK'
+        assert views['write_bytes']['decoration'] == 'OK'
+
+    def test_a_busy_disk_still_raises_the_alert(self, diskio_plugin):
+        views = self._views_for(diskio_plugin, read_rate=95, write_rate=95)
+        assert views['read_bytes']['decoration'] == 'CRITICAL'
+        assert views['write_bytes']['decoration'] == 'CRITICAL'
+
+    def test_the_rate_field_the_webui_reads_is_decorated_too(self, diskio_plugin):
+        """plugin-diskio.vue asks for *_rate_per_sec; nothing used to set it."""
+        views = self._views_for(diskio_plugin, read_rate=95, write_rate=10)
+        assert views['read_bytes_rate_per_sec']['decoration'] == 'CRITICAL'
+        assert views['write_bytes_rate_per_sec']['decoration'] == 'OK'
+
+    def test_a_missing_rate_on_the_first_sample_does_not_raise(self, diskio_plugin):
+        """Before the second sample there is no timespan, so no rate field exists yet."""
+        diskio_plugin._limits.update(self.LIMITS)
+        diskio_plugin.stats = [
+            {'disk_name': 'sda', 'read_bytes': 1, 'write_bytes': 1, 'read_latency': 0, 'write_latency': 0}
+        ]
+        diskio_plugin.update_views()
+        assert diskio_plugin.views['sda']['read_bytes']['decoration'] == 'OK'


### PR DESCRIPTION
Two things, one line apart, and the network plugin next door already does both correctly.

## The alert measured a lifetime counter against a bitrate threshold

```python
alert_rx = self.get_alert(i['read_bytes'], header='rx', action_key=disk_real_name)
```

`read_bytes` carries `rate: True` in `fields_description`, which is what produces `read_bytes_rate_per_sec` — `read_bytes` itself is psutil's counter since boot. It only ever grows, so on any machine with real uptime a configured `..._rx_critical` was crossed within seconds of the first read and stayed crossed for the life of the process, regardless of what the disk was doing. An operator who set thresholds got a permanently red column; one who set none saw nothing, which is why this could sit unnoticed.

The network plugin is the shape this should have had:

```python
bps_rx = int(i['bytes_recv_rate_per_sec'] * 8)
alert_rx = self.get_alert(bps_rx, header='rx', action_key=if_real_name)
```

## The decoration went to a key one interface reads and the other does not

`update_views` set it only on `read_bytes` / `write_bytes`:

- the **TUI** prints `read_bytes_rate_per_sec` (`auto_unit(i.get('read_bytes_rate_per_sec'))`) but reads `read_bytes`' decoration — a colour computed from a different quantity than the number beside it;
- the **WebUI** asks for `getDecoration(disk.name, 'read_bytes_rate_per_sec')`, which nothing ever set, so it rendered no colour at all.

Network sets both keys for exactly this reason:

```python
self.views[...]['bytes_recv']['decoration'] = alert_rx
self.views[...]['bytes_recv_rate_per_sec']['decoration'] = alert_rx
```

Diskio now does the same, guarded: the `_rate_per_sec` view only exists once there is a timespan to divide by, and setting it unconditionally raises `KeyError` on the first sample — the repo's existing `TestDiskioPluginViews` cases catch that, which is how I found it.

## Tests

`tests/test_plugin_diskio.py`, new `TestDiskioBitrateAlert`, four cases over injected stats carrying a large lifetime counter and a separate rate:

- quiet disk (rate 10) with 5 GB of history → `OK` — this is the case the old code got wrong
- busy disk (rate 95) → `CRITICAL`
- `read_bytes_rate_per_sec` decorated `CRITICAL` while `write_bytes_rate_per_sec` is `OK` — the WebUI's key, and asymmetric so a blanket assignment cannot pass it
- first sample with no rate field at all → no `KeyError`

Thresholds in the fixture are named `diskio_sda_rx_*`: `get_stat_name()` composes plugin + `action_key` + header, so a per-disk threshold carries the disk name, exactly as the network plugin's docstring documents with `network_wlan0_rx_careful`.

**Mutation-checked**, one per defect:

| mutation | result |
|---|---|
| alert on `i['read_bytes']` again | 2 fail — the quiet-disk case and the WebUI-key case |
| stop setting `*_rate_per_sec` | 1 fail — only the WebUI-key case |

```
python -m pytest tests/test_plugin_diskio.py -q
41 passed
```

(37 before this PR, plus the 4 added.) Python only, so no WebUI rebuild — the bundle already reads whatever the plugin publishes.
