### PR TITLE
fix(percpu): report the guest nice CPU value

### DIFF
--- a/glances/cpu_percent.py
+++ b/glances/cpu_percent.py
@@ -331,7 +331,7 @@ class CpuPercent:
                 'softirq': cpu_times.softirq if hasattr(cpu_times, 'softirq') else None,
                 'steal': cpu_times.steal if hasattr(cpu_times, 'steal') else None,
                 'guest': cpu_times.guest if hasattr(cpu_times, 'guest') else None,
-                'guest_nice': cpu_times.steal if hasattr(cpu_times, 'guest_nice') else None,
+                'guest_nice': cpu_times.guest_nice if hasattr(cpu_times, 'guest_nice') else None,
                 'dpc': cpu_times.dpc if hasattr(cpu_times, 'dpc') else None,
                 # In PsUtil 8+ the 'interrupt' field is renamed to 'irq' - See #3472
                 'interrupt': cpu_times.interrupt if hasattr(cpu_times, 'interrupt') else None,

--- a/tests/test_cpu_percent.py
+++ b/tests/test_cpu_percent.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+#
+# SPDX-FileCopyrightText: 2026 Aditya Raj Singh <aditya@bncw.in>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+
+from collections import namedtuple
+from unittest.mock import patch
+
+from glances.cpu_percent import cpu_percent
+
+
+def test_percpu_uses_guest_nice_value():
+    cpu_times_type = namedtuple(
+        'scputimes',
+        'user nice system idle iowait irq softirq steal guest guest_nice',
+    )
+    cpu_times = cpu_times_type(
+        user=1.0,
+        nice=2.0,
+        system=3.0,
+        idle=4.0,
+        iowait=5.0,
+        irq=6.0,
+        softirq=7.0,
+        steal=8.0,
+        guest=9.0,
+        guest_nice=10.0,
+    )
+
+    with patch('glances.cpu_percent.psutil.cpu_times_percent', return_value=[cpu_times]):
+        stats = cpu_percent._compute_percpu()
+
+    assert stats[0]['steal'] == 8.0
+    assert stats[0]['guest_nice'] == 10.0


### PR DESCRIPTION
#### Problem / Context

`CpuPercent._compute_percpu()` checks whether psutil exposes `guest_nice`, but currently returns the `steal` value for that field. When the two counters differ, per-CPU consumers receive incorrect guest nice usage.

#### Fix / Changes

Read `cpu_times.guest_nice` for the corresponding output field. Add a focused regression test with distinct steal and guest nice values so the mapping cannot silently regress.

#### User impact

Linux hosts running niced guest workloads now report the correct per-CPU `guest_nice` percentage instead of repeating stolen CPU time.

#### Verification

- `uv run python -m pytest tests/test_core.py tests/test_cpu_percent.py -q` — 47 passed, 6 skipped
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — 241 files already formatted
- `uv run python -m pytest -q` — 622 passed, 106 skipped; the remaining 58 failures and 15 errors were in Windows-sensitive shell, subprocess-server, web UI, memory, and performance tests. Neither the changed module nor the new regression test failed.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none