### PR TITLE
fix(WebUI): Make container IO and network columns sortable

### DIFF
--- a/glances/outputs/static/js/components/plugin-containers.vue
+++ b/glances/outputs/static/js/components/plugin-containers.vue
@@ -89,10 +89,38 @@
                             MEM
                         </td>
                         <td v-show="!getDisableStats().includes('mem')" scope="col">MAX</td>
-                        <td v-show="!getDisableStats().includes('diskio')" scope="col">IORps</td>
-                        <td v-show="!getDisableStats().includes('diskio')" scope="col">IOWps</td>
-                        <td v-show="!getDisableStats().includes('networkio')" scope="col">RXps</td>
-                        <td v-show="!getDisableStats().includes('networkio')" scope="col">TXps</td>
+                        <td
+                            v-show="!getDisableStats().includes('diskio')"
+                            scope="col"
+                            :class="['sortable', sorter.column === 'io_rx' && 'sort']"
+                            @click="args.sort_processes_key = 'io_rx'"
+                        >
+                            IORps
+                        </td>
+                        <td
+                            v-show="!getDisableStats().includes('diskio')"
+                            scope="col"
+                            :class="['sortable', sorter.column === 'io_wx' && 'sort']"
+                            @click="args.sort_processes_key = 'io_wx'"
+                        >
+                            IOWps
+                        </td>
+                        <td
+                            v-show="!getDisableStats().includes('networkio')"
+                            scope="col"
+                            :class="['sortable', sorter.column === 'network_rx' && 'sort']"
+                            @click="args.sort_processes_key = 'network_rx'"
+                        >
+                            RXps
+                        </td>
+                        <td
+                            v-show="!getDisableStats().includes('networkio')"
+                            scope="col"
+                            :class="['sortable', sorter.column === 'network_tx' && 'sort']"
+                            @click="args.sort_processes_key = 'network_tx'"
+                        >
+                            TXps
+                        </td>
                         <td v-show="!getDisableStats().includes('ports')" scope="col">Ports</td>
                         <td v-show="!getDisableStats().includes('command')" scope="col">Command</td>
                     </tr>
@@ -255,7 +283,15 @@ export default {
 		sortProcessesKey: {
 			immediate: true,
 			handler(sortProcessesKey) {
-				const sortable = ["cpu_percent", "memory_percent", "name"];
+				const sortable = [
+					"cpu_percent",
+					"memory_percent",
+					"name",
+					"io_rx",
+					"io_wx",
+					"network_rx",
+					"network_tx",
+				];
 				function isReverseColumn(column) {
 					return !["name"].includes(column);
 				}
@@ -266,6 +302,10 @@ export default {
 						memory_usage: "memory consumption",
 						cpu_times: "uptime",
 						name: "container name",
+						io_rx: "disk read rate",
+						io_wx: "disk write rate",
+						network_rx: "network receive rate",
+						network_tx: "network transmit rate",
 						None: "None",
 					};
 					return labels[value] || value;


### PR DESCRIPTION
## Problem

The container table exposes disk read/write and network receive/transmit rates, but those columns cannot be selected as sort keys. This makes it harder to identify the busiest containers from the Web UI.

Fixes https://github.com/nicolargo/glances/issues/3662

## Changes

- Make the IORps, IOWps, RXps, and TXps headers use the existing sortable-column interaction.
- Add the four underlying rate fields to the container sort allowlist and give each a readable sort label.

Only `js/components/plugin-containers.vue` is touched. The generated `public/glances.js` bundle is left untouched for the release build.

## User impact

Users can click any container IO or network-rate header to sort the table by that metric, with the active column shown using the same styling and summary used for CPU, memory, and name.

## Verification

- `npx eslint js/components/plugin-containers.vue`: 0 errors; the component's 7 pre-existing warnings remain.
- `git diff --check`: clean.