### PR TITLE
fix(sensors): alert on a reading of 0 instead of skipping it

### DIFF
--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -220,7 +220,13 @@ class SensorsPlugin(GlancesPluginModel):
         # Add specifics information
         # Alert
         for i in self.stats:
-            if not i['value']:
+            # A reading of 0 is a reading: a battery at 0% and a stopped fan are the
+            # states that most need an alert, and `not i['value']` swallowed both along
+            # with the absent ones. Test for a usable number instead. Sensors reporting a
+            # placeholder (no battery -> [], hddtemp -> b'ERR'/b'SLP'/...) keep the
+            # DEFAULT decoration the parent update_views() already gave them, and the
+            # battery branch below no longer subtracts from a non-number.
+            if not isinstance(i['value'], (int, float)):
                 continue
             # Alert processing
             if i['type'] == sensors_definition.get('cpu_temp').get('type'):

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -406,3 +406,62 @@ class TestSensorsPluginConfigThresholds:
         """Sensors without config and system thresholds are not decorated."""
         plugin = self.build_plugin(tmp_path, '')
         assert self.decoration(plugin, 95) == 'DEFAULT'
+
+
+class TestSensorsPluginZeroValue:
+    """A reading of 0 is a reading and must still be evaluated."""
+
+    LIMITS = {
+        'sensors_battery_careful': 70,
+        'sensors_battery_warning': 80,
+        'sensors_battery_critical': 90,
+        'sensors_fan_speed_careful': 60,
+        'sensors_fan_speed_warning': 70,
+        'sensors_fan_speed_critical': 80,
+    }
+
+    @staticmethod
+    def build_plugin(stats, limits):
+        from unittest.mock import MagicMock
+
+        plugin = SensorsPlugin(args=MagicMock(), config=None)
+        plugin._limits = dict(limits)
+        plugin.stats = stats
+        plugin.update_views()
+        return plugin
+
+    @classmethod
+    def decoration(cls, value, sensor_type, limits=None):
+        stats = [{'label': 'S', 'value': value, 'unit': '%', 'key': 'label', 'type': sensor_type}]
+        plugin = cls.build_plugin(stats, limits if limits is not None else cls.LIMITS)
+        return plugin.get_views(item='S', key='value', option='decoration')
+
+    def test_battery_at_zero_percent_is_critical(self):
+        # The battery alert is computed on 100 - value, so an empty battery is the
+        # most critical reading there is. `not i['value']` skipped it outright while
+        # 3% — a strictly better state — was flagged CRITICAL.
+        assert self.decoration(0, 'battery') == 'CRITICAL'
+
+    def test_battery_at_zero_is_not_less_alarming_than_a_small_charge(self):
+        for charge in (1, 3, 9):
+            assert self.decoration(0, 'battery') == self.decoration(charge, 'battery')
+
+    def test_stopped_fan_is_evaluated_rather_than_skipped(self):
+        # A stopped fan must go through the thresholds like any other reading; what
+        # the configured thresholds then say about it is a separate question.
+        assert self.decoration(0, 'fan_speed') != 'DEFAULT'
+
+    def test_absent_sensor_is_still_skipped(self):
+        # No battery detected is reported as an empty list, not as a number.
+        assert self.decoration([], 'battery') == 'DEFAULT'
+        assert self.decoration(None, 'battery') == 'DEFAULT'
+
+    def test_placeholder_reading_does_not_raise(self):
+        # hddtemp-style placeholders are not numbers; the battery branch subtracts
+        # from the value, so they must not reach it.
+        assert self.decoration(b'ERR', 'battery') == 'DEFAULT'
+        assert self.decoration(b'SLP', 'fan_speed') == 'DEFAULT'
+
+    def test_nonzero_readings_are_unaffected(self):
+        assert self.decoration(95, 'fan_speed') == 'CRITICAL'
+        assert self.decoration(50, 'fan_speed') == 'OK'


### PR DESCRIPTION
## The defect

`SensorsPlugin.update_views` guards its alert loop with a falsiness test (`glances/plugins/sensors/__init__.py:223`):

```python
for i in self.stats:
    if not i['value']:
        continue
```

`0` is falsy, so a genuine reading of zero is skipped along with the absent ones and never reaches `get_alert`.

That lands hardest on the battery, because its alert is computed on the **inverse** (`:238`):

```python
elif i['type'] == sensors_definition.get('battery').get('type'):
    # Battery is in %
    alert = self.get_alert(current=100 - i['value'], header=i['type'])
```

An empty battery is the most critical reading there is — and it is the one value the guard throws away.

## Measured on `develop`

With `sensors_battery_careful/warning/critical = 70/80/90` and `sensors_fan_speed_* = 60/70/80`:

```
  label  type          value  decoration
  BAT0   battery           0  DEFAULT      <- empty battery, no alert at all
  BAT1   battery           3  CRITICAL
  fan1   fan_speed         0  DEFAULT      <- stopped fan, never evaluated
  fan2   fan_speed        90  CRITICAL
```

A battery at 3% is CRITICAL; the same battery at 0% is not decorated at all.

After the patch:

```
  BAT0   battery           0  CRITICAL
  BAT1   battery           3  CRITICAL
  fan1   fan_speed         0  OK
  fan2   fan_speed        90  CRITICAL
```

## The fix

```diff
-            if not i['value']:
+            if not isinstance(i['value'], (int, float)):
                 continue
```

Testing for a usable number rather than for truthiness. This is deliberately narrower than it looks:

- **Nothing that was skipped before starts being decorated.** A sensor with no reading — no battery is reported as `[]` (`:280`), hddtemp uses `b'ERR'`/`b'SLP'`/`b'UNK'`/`b'NOS'` (`:286`) — keeps the `DEFAULT` decoration the parent `update_views()` already assigned to every field, which is exactly what it displayed before.
- **It also keeps non-numbers away from `100 - i['value']`.** That subtraction raises `TypeError` on a placeholder value today; the current truthiness guard lets `b'ERR'` through because it is truthy. Reaching it needs a non-numeric battery reading, which I have not seen in the wild — so this is hardening rather than a live crash, but the test pins it.

What the *thresholds* should then say about a stopped fan is a separate question and not touched here; the point is that the reading is evaluated instead of silently dropped.

## Tests

Six cases added to `tests/test_plugin_sensors.py` as `TestSensorsPluginZeroValue`:

- a battery at 0% is CRITICAL;
- 0% is never less alarming than 1/3/9%;
- a stopped fan is evaluated rather than skipped;
- an absent sensor (`[]`, `None`) is still skipped;
- a placeholder reading (`b'ERR'`, `b'SLP'`) does not raise;
- non-zero readings are unaffected.

**4 of the 6 fail on `develop`** — three on the wrong decoration, one with `TypeError` at `sensors/__init__.py:238`.

```
$ pytest tests/test_plugin_sensors.py -q
47 passed, 3 skipped
```
