### PR TITLE
fix(sensors): alert on a sensor reading exactly zero

### DIFF
--- a/glances/plugins/sensors/__init__.py
+++ b/glances/plugins/sensors/__init__.py
@@ -220,7 +220,10 @@ class SensorsPlugin(GlancesPluginModel):
         # Add specifics information
         # Alert
         for i in self.stats:
-            if not i['value']:
+            # Skip a sensor with no reading, but not one reading zero: a battery
+            # at 0% is alerted on 100 - value, so it is the most critical case
+            # there is, and 'not 0' would drop it out of the alert entirely.
+            if not i['value'] and i['value'] != 0:
                 continue
             # Alert processing
             if i['type'] == sensors_definition.get('cpu_temp').get('type'):

--- a/tests/test_plugin_sensors.py
+++ b/tests/test_plugin_sensors.py
@@ -406,3 +406,53 @@ class TestSensorsPluginConfigThresholds:
         """Sensors without config and system thresholds are not decorated."""
         plugin = self.build_plugin(tmp_path, '')
         assert self.decoration(plugin, 95) == 'DEFAULT'
+
+
+class TestSensorsPluginZeroValueAlert:
+    """A sensor reading exactly zero must still be alerted on."""
+
+    @staticmethod
+    def build_plugin(tmp_path, sensors_section=''):
+        """Return a sensors plugin configured with the given [sensors] section."""
+        config_file = tmp_path / 'glances.conf'
+        config_file.write_text('[sensors]\ndisable=False\n' + sensors_section, encoding='utf-8')
+        return SensorsPlugin(args=None, config=Config(config_dir=str(config_file)))
+
+    @staticmethod
+    def decoration(plugin, value, sensor_type='battery', unit='%', label='BAT0'):
+        """Return the view decoration for a single fake sensor reading."""
+        plugin.stats = [{'label': label, 'unit': unit, 'value': value, 'type': sensor_type, 'key': 'label'}]
+        plugin.update_views()
+        return plugin.get_views(item=label, key='value', option='decoration')
+
+    # Battery is alerted on 100 - value, so a flat battery is the most severe
+    # reading there is. It used to be dropped by a `if not value` guard, which
+    # is also true for a legitimate 0, leaving 0% less decorated than 1%.
+    @pytest.mark.parametrize(
+        ('percent', 'expected'),
+        [(40, 'OK'), (30, 'CAREFUL'), (20, 'WARNING'), (10, 'CRITICAL'), (1, 'CRITICAL'), (0, 'CRITICAL')],
+    )
+    def test_battery_alert_covers_zero_percent(self, tmp_path, percent, expected):
+        """An empty battery is CRITICAL, like the values just above it."""
+        plugin = self.build_plugin(tmp_path, 'battery_careful=70\nbattery_warning=80\nbattery_critical=90\n')
+        assert self.decoration(plugin, percent).startswith(expected)
+
+    def test_absent_battery_is_still_skipped(self, tmp_path):
+        """No battery is reported as an empty list and must not be decorated."""
+        plugin = self.build_plugin(tmp_path, 'battery_careful=70\n')
+        plugin.stats = [{'label': 'BAT0', 'unit': '%', 'value': [], 'type': 'battery', 'key': 'label'}]
+        plugin.update_views()
+        # The base update_views() seeds every field with DEFAULT, so an untouched
+        # DEFAULT is what "the alert code skipped this sensor" looks like. It also
+        # guards the skip itself: the battery branch computes 100 - value, which
+        # raises TypeError on a list.
+        assert plugin.views['BAT0']['value']['decoration'] == 'DEFAULT'
+
+    def test_zero_fan_speed_is_alerted(self, tmp_path):
+        """A stopped fan reads 0 RPM and must reach the alert code.
+
+        OK rather than DEFAULT is the whole assertion: DEFAULT is what the
+        view holds when the alert code never ran for this sensor.
+        """
+        plugin = self.build_plugin(tmp_path, 'fan_speed_careful=100\n')
+        assert self.decoration(plugin, 0, sensor_type='fan_speed', unit='R', label='fan1') == 'OK'


### PR DESCRIPTION
## Description

`SensorsPlugin.update_views()` skips any sensor whose value is falsy:

```python
for i in self.stats:
    if not i['value']:
        continue
```

The intent is to skip a sensor with no reading — an absent battery comes back as `[]`, which
`msg_curse` also special-cases. But `not i['value']` is equally true for a legitimate **0**, so a
sensor reading zero never reaches the alert code and keeps the `DEFAULT` decoration.

Battery is the case that matters, because its alert is computed on `100 - value`, which makes
0% the most severe reading there is. With the thresholds documented in `conf/glances.conf`
(`battery_careful=70`, `battery_warning=80`, `battery_critical=90`), measured on `develop`:

| battery | decoration on `develop` | with this PR |
| ---: | --- | --- |
| 40% | OK | OK |
| 30% | CAREFUL | CAREFUL |
| 20% | WARNING | WARNING |
| 10% | CRITICAL | CRITICAL |
| 1% | CRITICAL | CRITICAL |
| **0%** | **DEFAULT** | **CRITICAL** |

So the severity ramp ran OK → CAREFUL → WARNING → CRITICAL → *nothing*: a flat battery lost the
critical highlight that 1% had, at the moment it is most worth showing. A stopped fan reading
0 RPM was dropped the same way.

## Fix

```python
if not i['value'] and i['value'] != 0:
    continue
```

Deliberately narrow. Behaviour is identical to before for every value except a numeric zero:
`[]` and `None` are still skipped, and the byte sentinels (`b'ERR'`, `b'SLP'`, …) are truthy and
still fall through exactly as they did. Keeping the skip matters — the battery branch computes
`100 - value`, which raises `TypeError` on a list.

## Tests

Added `TestSensorsPluginZeroValueAlert` to `tests/test_plugin_sensors.py`, following the config
driven pattern of the existing `TestSensorsPluginConfigThresholds` class:

- the battery ramp above, parametrized, including 0%
- a stopped fan at 0 RPM reaches the alert code
- an absent battery (`[]`) is still skipped — the guard for the other direction

Verified red before, green after. Reverting only `glances/plugins/sensors/__init__.py` and
keeping the new tests:

```
2 failed, 47 passed, 3 skipped     # test_battery_alert_covers_zero_percent[0-CRITICAL]
                                   # test_zero_fan_speed_is_alerted
```

and with the fix applied:

```
49 passed, 3 skipped
```

The four non-zero battery rows pass either way on purpose — they pin the ramp that already
worked, so a future change cannot "fix" 0% by flattening everything else.

## Checks

- `ruff check` and `ruff format --check` clean on both files.
- Full suite, `pytest tests/` (excluding `test_browser_tui.py` and `test_browser_restful.py`,
  which need to spawn a server this Windows box cannot):
  **53 failed / 598 passed on clean `develop`**, and **53 failed / 606 passed** with this branch —
  same failures, +8 from the new cases. The 53 are pre-existing here (xmlrpc server spawn,
  selenium/webui `FileNotFoundError`), not related to this change.
- Targets `develop`.

## Note

The `if not i['value']` guard in `msg_curse` is a different one and is fine as it stands — it
compares against `[]` explicitly. I have not touched it.
