### PR TITLE
fix(wifi): honour a partially configured set of signal thresholds

### DIFF
--- a/glances/plugins/wifi/__init__.py
+++ b/glances/plugins/wifi/__init__.py
@@ -143,16 +143,26 @@ class WifiPlugin(GlancesPluginModel):
 
         :returns: string -- Signal alert
         """
-        ret = 'OK'
+        critical = self.get_limit('critical', stat_name=self.plugin_name)
+        warning = self.get_limit('warning', stat_name=self.plugin_name)
+        careful = self.get_limit('careful', stat_name=self.plugin_name)
+
+        # Each threshold is tested on its own. Chaining them meant the first
+        # undefined level raised TypeError against None and dropped the whole
+        # result to DEFAULT, so a config setting only 'careful' lost its alert
+        # entirely. GlancesPluginModel.get_alert already guards each level this
+        # way; `is not None` is used here because these limits are negative dBm
+        # values, where a plain truthiness test would discard a 0 threshold.
+        ret = 'DEFAULT' if critical is None and warning is None and careful is None else 'OK'
         try:
-            if value <= self.get_limit('critical', stat_name=self.plugin_name):
+            if critical is not None and value <= critical:
                 ret = 'CRITICAL'
-            elif value <= self.get_limit('warning', stat_name=self.plugin_name):
+            elif warning is not None and value <= warning:
                 ret = 'WARNING'
-            elif value <= self.get_limit('careful', stat_name=self.plugin_name):
+            elif careful is not None and value <= careful:
                 ret = 'CAREFUL'
-        except (TypeError, KeyError):
-            # Catch TypeError for issue1373
+        except TypeError:
+            # A non-numeric signal level (issue #1373) is not comparable at all.
             ret = 'DEFAULT'
 
         return ret

--- a/tests/test_plugin_wifi.py
+++ b/tests/test_plugin_wifi.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the Wifi plugin."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from glances.plugins.wifi import WifiPlugin
+
+# Signal quality is reported in dBm, so the thresholds are negative and lower is worse.
+ALL_LEVELS = {'wifi_careful': -65, 'wifi_warning': -75, 'wifi_critical': -85}
+
+
+def decoration(limits, value):
+    plugin = WifiPlugin(args=MagicMock(), config=None)
+    plugin._limits = dict(limits)
+    return plugin.get_alert(value)
+
+
+class TestWifiAlertThresholds:
+    """get_alert must honour whichever levels the config defines."""
+
+    @pytest.mark.parametrize(
+        ('value', 'expected'),
+        [(-50, 'OK'), (-70, 'CAREFUL'), (-80, 'WARNING'), (-90, 'CRITICAL')],
+    )
+    def test_all_levels_configured(self, value, expected):
+        assert decoration(ALL_LEVELS, value) == expected
+
+    def test_only_careful_still_alerts(self):
+        # Chaining the comparisons meant the undefined 'critical' level was compared
+        # against None first, raising TypeError and dropping the result to DEFAULT —
+        # so a config defining only 'careful' never produced an alert at all.
+        assert decoration({'wifi_careful': -65}, -70) == 'CAREFUL'
+
+    def test_only_warning_still_alerts(self):
+        assert decoration({'wifi_warning': -75}, -80) == 'WARNING'
+
+    def test_only_critical_still_alerts(self):
+        assert decoration({'wifi_critical': -85}, -90) == 'CRITICAL'
+
+    @pytest.mark.parametrize(
+        'limits',
+        [{'wifi_careful': -65}, {'wifi_warning': -75}, {'wifi_critical': -85}],
+    )
+    def test_a_good_signal_is_ok_under_any_partial_config(self, limits):
+        # A signal above every defined threshold is OK, not undecorated.
+        assert decoration(limits, -50) == 'OK'
+
+    def test_the_most_severe_level_wins(self):
+        assert decoration(ALL_LEVELS, -90) == 'CRITICAL'
+        assert decoration({'wifi_warning': -75, 'wifi_critical': -85}, -90) == 'CRITICAL'
+
+    def test_no_threshold_at_all_is_not_decorated(self):
+        assert decoration({}, -90) == 'DEFAULT'
+
+    def test_a_non_numeric_level_is_not_decorated(self):
+        # Regression guard for issue #1373: an unparsed signal level is not comparable.
+        assert decoration(ALL_LEVELS, None) == 'DEFAULT'
+        assert decoration(ALL_LEVELS, 'n/a') == 'DEFAULT'


### PR DESCRIPTION
## The defect

`WifiPlugin.get_alert` overrides the base implementation and chains its three comparisons (`glances/plugins/wifi/__init__.py:146`):

```python
try:
    if value <= self.get_limit('critical', stat_name=self.plugin_name):
        ret = 'CRITICAL'
    elif value <= self.get_limit('warning', stat_name=self.plugin_name):
        ret = 'WARNING'
    elif value <= self.get_limit('careful', stat_name=self.plugin_name):
        ret = 'CAREFUL'
except (TypeError, KeyError):
    # Catch TypeError for issue1373
    ret = 'DEFAULT'
```

`get_limit` returns `None` for a level the config does not define (`plugin/model.py:969`). `value <= None` raises `TypeError`, the blanket handler catches it, and the whole result collapses to `DEFAULT`.

Because `critical` is tested **first**, omitting it silences the other two as well.

## Measured on `develop`

```
all three thresholds configured:
  quality_level= -50 dBm -> OK
  quality_level= -70 dBm -> CAREFUL
  quality_level= -80 dBm -> WARNING
  quality_level= -90 dBm -> CRITICAL

only 'critical' configured (careful/warning left out):
  quality_level= -50 dBm -> DEFAULT      <- a strong signal is not even OK
  quality_level= -90 dBm -> CRITICAL

only 'careful' configured:
  quality_level= -50 dBm -> DEFAULT
  quality_level= -70 dBm -> DEFAULT      <- past the careful threshold, no alert

For comparison, the base class handles partial thresholds:
  sensors base get_alert(95) with only 'critical' -> CRITICAL
```

A user who sets just `wifi_careful` in `glances.conf` gets no wifi alert at all, silently.

## The fix

Each level is read once and guarded on its own, the way `GlancesPluginModel.get_alert` already does (`plugin/model.py:854-862`) — and the way the sensors plugin is already tested for (`test_partial_type_thresholds_are_used`, `test_partial_sensor_thresholds_are_used`).

Two details worth calling out:

- **`is not None`, not truthiness.** The base class uses `if critical and value >= critical`. These limits are negative dBm values, so a `0` threshold would be discarded by a truthiness test; `is not None` is exact.
- **The `TypeError` handler is kept but narrowed.** It was added for issue #1373 (a non-numeric signal level). With the `None` comparisons gone that is now the only way it can fire, so it still does its original job and nothing else. `KeyError` is dropped because `get_limit` returns `None` rather than raising.

After:

```
only 'careful' configured:
  quality_level= -50 dBm -> OK
  quality_level= -70 dBm -> CAREFUL
```

## Tests

New `tests/test_plugin_wifi.py`, 13 cases:

- all four levels with a full config;
- each level alone still alerts (`careful` only, `warning` only, `critical` only);
- a strong signal is `OK` under any partial config, not undecorated;
- the most severe matching level wins;
- no thresholds at all stays `DEFAULT`;
- a non-numeric level stays `DEFAULT` — the #1373 guard.

**5 of the 13 fail on `develop`** and all 13 pass with the patch.

```
$ pytest tests/test_plugin_wifi.py -q
13 passed
```
