### PR TITLE
fix(programs): sum a program's io_counters instead of concatenating them

### DIFF
--- a/glances/programs.py
+++ b/glances/programs.py
@@ -43,13 +43,11 @@ NO_IO_COUNTERS = (0, 0, 0, 0, 0)
 
 
 def sum_io_counters(total, addition):
-    """Add addition into total slot by slot.
-
-    `+=` concatenates these lists rather than adding them, so a program reported only its
-    first process's disk IO - and, because the program borrowed that process's own list,
-    every aggregation extended it in place. The last slot is a flag rather than a total:
-    processlist displays a rate only when it is exactly 1, so it is OR-ed, not added.
-    """
+    """Add addition into total slot by slot."""
+    # `+=` concatenates these lists rather than adding them, so a program reported only its
+    # first process's disk IO - and, because the program borrowed that process's own list,
+    # every aggregation extended it in place. The last slot is a flag rather than a total:
+    # processlist displays a rate only when it is exactly 1, so it is OR-ed, not added.
     total = total or NO_IO_COUNTERS
     addition = addition or NO_IO_COUNTERS
     summed = [a + b for a, b in zip(total[:IO_COUNTERS_TAG], addition[:IO_COUNTERS_TAG])]

--- a/glances/programs.py
+++ b/glances/programs.py
@@ -22,7 +22,8 @@ def create_program_dict(p):
         'memory_percent': p['memory_percent'] or 0,
         'cpu_times': p['cpu_times'] or {},
         'memory_info': p['memory_info'] or {},
-        'io_counters': p['io_counters'] or {},
+        # A copy: the program must not borrow - and then grow - the process's own list.
+        'io_counters': list(p['io_counters'] or NO_IO_COUNTERS),
         'childrens': [p['pid']],
         # Others keys are not used
         # but should be set to be compliant with the existing process_list
@@ -33,6 +34,26 @@ def create_program_dict(p):
         'nice': p['nice'],
         'status': p['status'],
     }
+
+
+# io_counters is a fixed list, not a mapping:
+# [read_bytes, write_bytes, read_bytes_old, write_bytes_old, io_tag]
+IO_COUNTERS_TAG = 4
+NO_IO_COUNTERS = (0, 0, 0, 0, 0)
+
+
+def sum_io_counters(total, addition):
+    """Add addition into total slot by slot.
+
+    `+=` concatenates these lists rather than adding them, so a program reported only its
+    first process's disk IO - and, because the program borrowed that process's own list,
+    every aggregation extended it in place. The last slot is a flag rather than a total:
+    processlist displays a rate only when it is exactly 1, so it is OR-ed, not added.
+    """
+    total = total or NO_IO_COUNTERS
+    addition = addition or NO_IO_COUNTERS
+    summed = [a + b for a, b in zip(total[:IO_COUNTERS_TAG], addition[:IO_COUNTERS_TAG])]
+    return summed + [max(total[IO_COUNTERS_TAG], addition[IO_COUNTERS_TAG])]
 
 
 def sum_field_dict(total, addition):
@@ -57,7 +78,7 @@ def update_program_dict(program, p):
     program['cpu_times'] = sum_field_dict(program['cpu_times'], p['cpu_times'])
     program['memory_info'] = sum_field_dict(program['memory_info'], p['memory_info'])
 
-    program['io_counters'] += p['io_counters']
+    program['io_counters'] = sum_io_counters(program['io_counters'], p['io_counters'])
     program['childrens'].append(p['pid'])
     # If all the subprocess has the same value, display it
     program['username'] = p.get('username', '_') if p.get('username') == program['username'] else '_'

--- a/tests/test_program_io_counters.py
+++ b/tests/test_program_io_counters.py
@@ -6,8 +6,12 @@ from glances.programs import processes_to_programs
 # [read_bytes, write_bytes, read_bytes_old, write_bytes_old, io_tag].
 READ, WRITE, READ_OLD, WRITE_OLD, IO_TAG = range(5)
 
+# The io_tag values, named so an assertion on them reads as a flag rather than a total.
+IO_ABSENT, IO_PRESENT = 0, 1
+
 
 def make_process(pid, name, io_counters):
+    """Build the subset of a process entry that the aggregation reads."""
     return {
         'pid': pid,
         'time_since_update': 1.0,
@@ -19,38 +23,36 @@ def make_process(pid, name, io_counters):
         'num_threads': 1,
         'cpu_percent': 1.0,
         'memory_percent': 1.0,
-        'cpu_times': {'user': 1.0, 'system': 1.0, 'children_user': 0.0, 'children_system': 0.0, 'iowait': 0.0},
-        'memory_info': {'rss': 1024, 'vms': 2048, 'shared': 0, 'text': 0, 'data': 0},
+        'cpu_times': {'user': 1.0, 'system': 1.0, 'iowait': 0.0},
+        'memory_info': {'rss': 1024, 'vms': 2048},
         'io_counters': io_counters,
     }
 
 
 def one_program(processes):
+    """Aggregate processes that all share a name and return the single program."""
     programs = processes_to_programs(processes)
     assert len(programs) == 1
     return programs[0]
 
 
+def two_readers():
+    """Build two processes of one program, both reporting IO."""
+    return [
+        make_process(1, 'worker', [100, 200, 10, 20, IO_PRESENT]),
+        make_process(2, 'worker', [1000, 2000, 100, 200, IO_PRESENT]),
+    ]
+
+
 def test_io_counters_keep_their_five_slots():
     """The list is read by index, so merging must not change its length."""
-    program = one_program(
-        [
-            make_process(1, 'worker', [100, 200, 10, 20, 1]),
-            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
-            make_process(3, 'worker', [7, 8, 1, 2, 1]),
-        ]
-    )
-    assert len(program['io_counters']) == 5
+    processes = two_readers() + [make_process(3, 'worker', [7, 8, 1, 2, IO_PRESENT])]
+    assert len(one_program(processes)['io_counters']) == 5
 
 
 def test_io_counters_are_summed_slot_by_slot():
-    """A program's I/O is the sum of its processes', like cpu_times and memory_info."""
-    program = one_program(
-        [
-            make_process(1, 'worker', [100, 200, 10, 20, 1]),
-            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
-        ]
-    )
+    """A program's IO is the sum of its processes', like cpu_times and memory_info."""
+    program = one_program(two_readers())
     assert program['io_counters'][READ] == 1100
     assert program['io_counters'][WRITE] == 2200
     assert program['io_counters'][READ_OLD] == 110
@@ -58,82 +60,67 @@ def test_io_counters_are_summed_slot_by_slot():
 
 
 def test_io_tag_is_a_flag_not_a_total():
-    """processlist only displays a rate when io_tag == 1 exactly, so summing the flag
-    would blank the R/s and W/s columns for every program with two processes."""
-    program = one_program(
-        [
-            make_process(1, 'worker', [100, 200, 10, 20, 1]),
-            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
-        ]
-    )
-    assert program['io_counters'][IO_TAG] == 1
+    """The tag stays 1 rather than becoming 2."""
+    # processlist displays a rate only when io_tag == 1 exactly, so summing the flag would
+    # blank the R/s and W/s columns for every program with two processes.
+    assert one_program(two_readers())['io_counters'][IO_TAG] == IO_PRESENT
 
 
 def test_io_tag_is_set_when_any_process_reports_io():
     """One readable process is enough for the program to have a rate worth showing."""
-    program = one_program(
-        [
-            make_process(1, 'worker', [0, 0, 0, 0, 0]),
-            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
-        ]
-    )
-    assert program['io_counters'][IO_TAG] == 1
+    processes = [
+        make_process(1, 'worker', [0, 0, 0, 0, IO_ABSENT]),
+        make_process(2, 'worker', [1000, 2000, 100, 200, IO_PRESENT]),
+    ]
+    assert one_program(processes)['io_counters'][IO_TAG] == IO_PRESENT
 
 
-def test_io_tag_stays_zero_when_no_process_reports_io():
-    program = one_program(
-        [
-            make_process(1, 'worker', [0, 0, 0, 0, 0]),
-            make_process(2, 'worker', [0, 0, 0, 0, 0]),
-        ]
-    )
-    assert program['io_counters'][IO_TAG] == 0
+def test_io_tag_stays_unset_when_no_process_reports_io():
+    """A program of unreadable processes keeps the tag clear."""
+    processes = [
+        make_process(1, 'worker', [0, 0, 0, 0, IO_ABSENT]),
+        make_process(2, 'worker', [0, 0, 0, 0, IO_ABSENT]),
+    ]
+    assert one_program(processes)['io_counters'][IO_TAG] == IO_ABSENT
 
 
 def test_a_process_without_io_counters_is_skipped_not_fatal():
-    """psutil hands back None for processes it cannot read - macOS system processes,
-    and anything the user lacks permission for."""
-    program = one_program(
-        [
-            make_process(1, 'worker', [100, 200, 10, 20, 1]),
-            make_process(2, 'worker', None),
-        ]
-    )
-    assert program['io_counters'] == [100, 200, 10, 20, 1]
+    """A process the aggregation cannot read contributes nothing and raises nothing."""
+    # psutil hands back None for processes it cannot read - macOS system processes, and
+    # anything the user lacks permission for.
+    processes = [
+        make_process(1, 'worker', [100, 200, 10, 20, IO_PRESENT]),
+        make_process(2, 'worker', None),
+    ]
+    assert one_program(processes)['io_counters'] == [100, 200, 10, 20, IO_PRESENT]
 
 
 def test_a_first_process_without_io_counters_still_yields_a_list():
-    """The None lands on the entry that seeds the program, so the fallback has to be a
-    list of five slots - a dict would raise on the very next merge and index as a key."""
-    program = one_program(
-        [
-            make_process(1, 'worker', None),
-            make_process(2, 'worker', [100, 200, 10, 20, 1]),
-        ]
-    )
-    assert program['io_counters'] == [100, 200, 10, 20, 1]
+    """A None on the entry that seeds the program still leaves five slots behind."""
+    # A dict would raise on the very next merge, and index as a key afterwards.
+    processes = [
+        make_process(1, 'worker', None),
+        make_process(2, 'worker', [100, 200, 10, 20, IO_PRESENT]),
+    ]
+    assert one_program(processes)['io_counters'] == [100, 200, 10, 20, IO_PRESENT]
 
 
 def test_the_program_does_not_borrow_the_process_list():
-    """`+=` on a list extends it in place. The program seeded itself with the first
-    process's own io_counters, so aggregating wrote back into the process list."""
-    processes = [
-        make_process(1, 'worker', [100, 200, 10, 20, 1]),
-        make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
-    ]
+    """Aggregating must leave the process entries it read untouched."""
+    # `+=` on a list extends it in place, and the program seeded itself with the first
+    # process's own io_counters, so aggregating wrote back into the process list.
+    processes = two_readers()
     one_program(processes)
-    assert processes[0]['io_counters'] == [100, 200, 10, 20, 1]
+    assert processes[0]['io_counters'] == [100, 200, 10, 20, IO_PRESENT]
 
 
 def test_repeated_aggregation_does_not_grow_the_counters():
-    """A re-sort aggregates the same process dicts again; in-place growth made the list
-    five slots longer per process on every pass, without bound."""
-    processes = [
-        make_process(1, 'worker', [100, 200, 10, 20, 1]),
-        make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
-    ]
-    # A copy: on the unfixed code the program aliases the process's list, so comparing
-    # against the live object would compare it with itself and pass while it grew.
+    """Aggregating the same processes again gives the same answer again."""
+    # A re-sort aggregates the same process dicts a second time; in-place growth made the
+    # list five slots longer per process on every pass, without bound. The expected value
+    # is copied because on the unfixed code the program aliases the process's list, so
+    # comparing it against the live object would compare it with itself and pass as it grew.
+    processes = two_readers()
     first = list(one_program(processes)['io_counters'])
     for _ in range(5):
         assert one_program(processes)['io_counters'] == first

--- a/tests/test_program_io_counters.py
+++ b/tests/test_program_io_counters.py
@@ -1,0 +1,139 @@
+"""Tests for aggregating a program's disk I/O counters."""
+
+from glances.programs import processes_to_programs
+
+# io_counters is a fixed 5-slot list, not a mapping:
+# [read_bytes, write_bytes, read_bytes_old, write_bytes_old, io_tag].
+READ, WRITE, READ_OLD, WRITE_OLD, IO_TAG = range(5)
+
+
+def make_process(pid, name, io_counters):
+    return {
+        'pid': pid,
+        'time_since_update': 1.0,
+        'name': name,
+        'cmdline': [name],
+        'username': 'someone',
+        'nice': 0,
+        'status': 'S',
+        'num_threads': 1,
+        'cpu_percent': 1.0,
+        'memory_percent': 1.0,
+        'cpu_times': {'user': 1.0, 'system': 1.0, 'children_user': 0.0, 'children_system': 0.0, 'iowait': 0.0},
+        'memory_info': {'rss': 1024, 'vms': 2048, 'shared': 0, 'text': 0, 'data': 0},
+        'io_counters': io_counters,
+    }
+
+
+def one_program(processes):
+    programs = processes_to_programs(processes)
+    assert len(programs) == 1
+    return programs[0]
+
+
+def test_io_counters_keep_their_five_slots():
+    """The list is read by index, so merging must not change its length."""
+    program = one_program(
+        [
+            make_process(1, 'worker', [100, 200, 10, 20, 1]),
+            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
+            make_process(3, 'worker', [7, 8, 1, 2, 1]),
+        ]
+    )
+    assert len(program['io_counters']) == 5
+
+
+def test_io_counters_are_summed_slot_by_slot():
+    """A program's I/O is the sum of its processes', like cpu_times and memory_info."""
+    program = one_program(
+        [
+            make_process(1, 'worker', [100, 200, 10, 20, 1]),
+            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
+        ]
+    )
+    assert program['io_counters'][READ] == 1100
+    assert program['io_counters'][WRITE] == 2200
+    assert program['io_counters'][READ_OLD] == 110
+    assert program['io_counters'][WRITE_OLD] == 220
+
+
+def test_io_tag_is_a_flag_not_a_total():
+    """processlist only displays a rate when io_tag == 1 exactly, so summing the flag
+    would blank the R/s and W/s columns for every program with two processes."""
+    program = one_program(
+        [
+            make_process(1, 'worker', [100, 200, 10, 20, 1]),
+            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
+        ]
+    )
+    assert program['io_counters'][IO_TAG] == 1
+
+
+def test_io_tag_is_set_when_any_process_reports_io():
+    """One readable process is enough for the program to have a rate worth showing."""
+    program = one_program(
+        [
+            make_process(1, 'worker', [0, 0, 0, 0, 0]),
+            make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
+        ]
+    )
+    assert program['io_counters'][IO_TAG] == 1
+
+
+def test_io_tag_stays_zero_when_no_process_reports_io():
+    program = one_program(
+        [
+            make_process(1, 'worker', [0, 0, 0, 0, 0]),
+            make_process(2, 'worker', [0, 0, 0, 0, 0]),
+        ]
+    )
+    assert program['io_counters'][IO_TAG] == 0
+
+
+def test_a_process_without_io_counters_is_skipped_not_fatal():
+    """psutil hands back None for processes it cannot read - macOS system processes,
+    and anything the user lacks permission for."""
+    program = one_program(
+        [
+            make_process(1, 'worker', [100, 200, 10, 20, 1]),
+            make_process(2, 'worker', None),
+        ]
+    )
+    assert program['io_counters'] == [100, 200, 10, 20, 1]
+
+
+def test_a_first_process_without_io_counters_still_yields_a_list():
+    """The None lands on the entry that seeds the program, so the fallback has to be a
+    list of five slots - a dict would raise on the very next merge and index as a key."""
+    program = one_program(
+        [
+            make_process(1, 'worker', None),
+            make_process(2, 'worker', [100, 200, 10, 20, 1]),
+        ]
+    )
+    assert program['io_counters'] == [100, 200, 10, 20, 1]
+
+
+def test_the_program_does_not_borrow_the_process_list():
+    """`+=` on a list extends it in place. The program seeded itself with the first
+    process's own io_counters, so aggregating wrote back into the process list."""
+    processes = [
+        make_process(1, 'worker', [100, 200, 10, 20, 1]),
+        make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
+    ]
+    one_program(processes)
+    assert processes[0]['io_counters'] == [100, 200, 10, 20, 1]
+
+
+def test_repeated_aggregation_does_not_grow_the_counters():
+    """A re-sort aggregates the same process dicts again; in-place growth made the list
+    five slots longer per process on every pass, without bound."""
+    processes = [
+        make_process(1, 'worker', [100, 200, 10, 20, 1]),
+        make_process(2, 'worker', [1000, 2000, 100, 200, 1]),
+    ]
+    # A copy: on the unfixed code the program aliases the process's list, so comparing
+    # against the live object would compare it with itself and pass while it grew.
+    first = list(one_program(processes)['io_counters'])
+    for _ in range(5):
+        assert one_program(processes)['io_counters'] == first


### PR DESCRIPTION
## The bug

`io_counters` is a fixed five-slot list, not a mapping — `glances/processes.py`
documents it as:

```
[read_bytes, write_bytes, read_bytes_old, write_bytes_old, io_tag]
```

`update_program_dict` merged it with `+=`, which **concatenates** lists rather than adding
them. `cpu_times` and `memory_info` next to it are dicts and go through `sum_field_dict`;
`io_counters` had no equivalent.

Three things follow from that one operator.

**1. A program reports only its first process's disk IO.** Every reader indexes the list
(`p['io_counters'][0]`, `[2]`, `[4]` in `processlist`), so slots 0–4 keep coming from
whichever process seeded the program and the rest are never looked at:

```
process 1 io_counters: [100, 200, 10, 20, 1]
process 2 io_counters: [1000, 2000, 100, 200, 1]
program   io_counters: [100, 200, 10, 20, 1, 1000, 2000, 100, 200, 1]

displayed R/s = (100 - 10) / 1.0 = 90.0     <- shown
correct   R/s = (1100 - 110) / 1.0 = 990.0  <- actual
```

**2. The aggregation writes back into the process list.** `create_program_dict` stored the
process's own list object, and `+=` on a list extends in place, so the program and the
process share it:

```
prog['io_counters'] is procs[0]['io_counters']  ->  True
process 1 io_counters after aggregation: [100, 200, 10, 20, 1, 1000, 2000, 100, 200, 1]
```

**3. It grows without bound.** A re-sort re-aggregates the same process dicts — the same
objects in a new list — and appends again each time. Driving it through
`GlancesProcesses.get_list(sorted=True, as_programs=True)`:

```
re-sort 0: len(io_counters) =  10
re-sort 1: len(io_counters) =  15
re-sort 2: len(io_counters) =  25
re-sort 3: len(io_counters) =  35
re-sort 4: len(io_counters) =  45
re-sort 5: len(io_counters) =  55
```

## The fix

A `sum_io_counters` alongside the existing `sum_field_dict`, and a copy rather than a
borrow when the program is created.

The last slot needs different treatment from the other four. `processlist` displays a rate
only when `p['io_counters'][4] == 1` exactly, so **adding** the tag would push it to 2 for
any program with two processes and blank the R/s and W/s columns instead of correcting
them. It is OR-ed.

## Tests

`tests/test_program_io_counters.py`, nine cases. On `develop` at c15ab4c73, seven of them
fail:

```
FAILED test_io_counters_keep_their_five_slots
FAILED test_io_counters_are_summed_slot_by_slot
FAILED test_io_tag_is_set_when_any_process_reports_io
FAILED test_a_process_without_io_counters_is_skipped_not_fatal
FAILED test_a_first_process_without_io_counters_still_yields_a_list
FAILED test_the_program_does_not_borrow_the_process_list
FAILED test_repeated_aggregation_does_not_grow_the_counters
7 failed, 2 passed
```

and all nine pass with the change.

The two that pass on `develop` are deliberate: they pin the tag to `1` and to `0`, which
guards against "fix it by summing the tag too" rather than against the current bug. The
docstrings say so.

The existing `tests/test_programs_aggregation.py` and `tests/test_program_aggregation.py`
did not catch any of this because their fixtures use `io_counters: [0, 0, 0, 0, 0]` —
concatenating zeros is invisible at every index that gets read.

`tests/test_core.py`, `test_glances_stats.py`, `test_lazy_views.py` and both existing
aggregation files: 78 passed, 6 skipped.

## One thing I could not reproduce

Two of the tests cover `io_counters` being `None`. `create_program_dict` already had an
`or {}` fallback for that, so the intent was there — but `{}` is the wrong type for a
field every reader indexes as a list, and `{} += [...]` raises `TypeError` on the very
next merge. I changed the fallback to a list of five zeros.

To be clear about what that is: I could **not** reach `None` through the live pipeline.
`GlancesProcesses.get_io_counters` normalises it to `[0, 0, 0, 0, 0]` before the
aggregation ever sees it, and that is the only producer. So this part makes an existing
defensive branch coherent; it is not a fix for a crash I observed. Happy to drop it if you
would rather not carry the branch at all.

`make lint` and `make format` are clean on both files.
