### PR TITLE
fix(sort): read a missing sort value as zero instead of discarding the sort

### DIFF
--- a/glances/processes.py
+++ b/glances/processes.py
@@ -795,12 +795,18 @@ def sort_by_these_keys(first, second):
     return lambda process: (weighted(process.get(first)), weighted(process.get(second)))
 
 
+# A row whose value is missing sorts as zero rather than raising. sort_stats catches the
+# exception and falls back to cpu_percent for the *whole* list, so one such row silently
+# reorders every other one while the header still reads TIME or IOR/IOW.
 def _sort_io_counters(process, sorted_by='io_counters', sorted_by_secondary='memory_percent'):
     """Specific case for io_counters
 
     :return: Sum of io_r + io_w
     """
-    return process[sorted_by][0] - process[sorted_by][2] + process[sorted_by][1] - process[sorted_by][3]
+    counters = process.get(sorted_by) or []
+    # [read_bytes, write_bytes, read_bytes_old, write_bytes_old, io_tag]
+    read, write, read_old, write_old = (list(counters) + [0, 0, 0, 0])[:4]
+    return read - read_old + write - write_old
 
 
 def _sort_cpu_times(process, sorted_by='cpu_times', sorted_by_secondary='memory_percent'):
@@ -811,7 +817,8 @@ def _sort_cpu_times(process, sorted_by='cpu_times', sorted_by_secondary='memory_
     see (https://github.com/giampaolo/psutil/issues/1339)
     The following implementation takes user and system time into account
     """
-    return process[sorted_by]['user'] + process[sorted_by]['system']
+    times = process.get(sorted_by) or {}
+    return times.get('user', 0) + times.get('system', 0)
 
 
 def _sort_lambda(sorted_by='cpu_percent', sorted_by_secondary='memory_percent'):

--- a/tests/test_sort_missing_values.py
+++ b/tests/test_sort_missing_values.py
@@ -1,0 +1,65 @@
+"""Sorting must not be discarded because one row has nothing to sort on.
+
+`sort_stats` wraps the specific sort helpers in a try/except and falls back to
+`cpu_percent` for the whole list. So a single row whose `cpu_times` is `{}` or whose
+`io_counters` is empty does not fail loudly — it silently reorders every other row while
+the header still reads TIME or IOR/IOW.
+
+Those empty values are expected, not corrupt: `glances/programs.py` builds a program with
+`p['cpu_times'] or {}` and `list(p['io_counters'] or NO_IO_COUNTERS)`, and its own comment
+says "some values can be None, e.g. macOS system processes".
+"""
+
+from glances.processes import _sort_cpu_times, _sort_io_counters, sort_stats
+
+
+def _row(name, cpu_times, io_counters, cpu_percent):
+    return {
+        'name': name,
+        'cpu_times': cpu_times,
+        'io_counters': io_counters,
+        'cpu_percent': cpu_percent,
+        'memory_percent': 1.0,
+    }
+
+
+def test_sort_cpu_times_reads_a_missing_value_as_zero():
+    assert _sort_cpu_times({'cpu_times': {}}) == 0
+    assert _sort_cpu_times({'cpu_times': None}) == 0
+    assert _sort_cpu_times({}) == 0
+    assert _sort_cpu_times({'cpu_times': {'user': 5.0, 'system': 1.0}}) == 6.0
+
+
+def test_sort_io_counters_reads_a_missing_value_as_zero():
+    assert _sort_io_counters({'io_counters': []}) == 0
+    assert _sort_io_counters({'io_counters': None}) == 0
+    assert _sort_io_counters({}) == 0
+    # A tuple is what programs.NO_IO_COUNTERS is, and a short list must not raise either.
+    assert _sort_io_counters({'io_counters': (900, 90, 100, 10, 1)}) == 880
+    assert _sort_io_counters({'io_counters': [900, 90]}) == 990
+
+
+def test_one_row_without_cpu_times_does_not_reorder_the_others():
+    # 'idle' has no cpu_times and the highest cpu_percent, so a fallback to cpu_percent
+    # puts it first — which is exactly what used to happen.
+    rows = [
+        _row('editor', {'user': 5.0, 'system': 1.0}, [0, 0, 0, 0, 0], 1.0),
+        _row('idle', {}, [0, 0, 0, 0, 0], 99.0),
+        _row('compiler', {'user': 50.0, 'system': 9.0}, [0, 0, 0, 0, 0], 2.0),
+    ]
+
+    ordered = sort_stats(rows, sorted_by='cpu_times', sorted_by_secondary='memory_percent')
+
+    assert [row['name'] for row in ordered] == ['compiler', 'editor', 'idle']
+
+
+def test_one_row_without_io_counters_does_not_reorder_the_others():
+    rows = [
+        _row('editor', {'user': 0.0, 'system': 0.0}, [900, 90, 100, 10, 1], 1.0),
+        _row('idle', {'user': 0.0, 'system': 0.0}, [], 99.0),
+        _row('compiler', {'user': 0.0, 'system': 0.0}, [9000, 900, 1000, 100, 1], 2.0),
+    ]
+
+    ordered = sort_stats(rows, sorted_by='io_counters', sorted_by_secondary='memory_percent')
+
+    assert [row['name'] for row in ordered] == ['compiler', 'editor', 'idle']


### PR DESCRIPTION
## Problem

`sort_stats` wraps the specific sort helpers in `try/except` and, on any exception, falls back to `cpu_percent` **for the whole list**:

```python
try:
    stats = sorted(stats, key=sort_lambda, reverse=reverse)
except Exception as e:
    logger.debug(f'Error while sorting by {sorted_by}, fallback to cpu_percent ({e})')
    stats = sorted(stats, key=sort_by_these_keys('cpu_percent', sorted_by_secondary), ...)
```

Both helpers index without checking:

```python
_sort_cpu_times:   process[sorted_by]['user'] + process[sorted_by]['system']
_sort_io_counters: process[sorted_by][0] - process[sorted_by][2] + ...
```

So a single row whose `cpu_times` is `{}` raises `KeyError: 'user'`, the exception is swallowed at DEBUG level, and every other row is silently reordered — while the header still reads TIME.

Those empty values are expected rather than corrupt. `glances/programs.py` builds a program with

```python
'cpu_times': p['cpu_times'] or {},
'io_counters': list(p['io_counters'] or NO_IO_COUNTERS),
```

under its own comment, *"some values can be None, e.g. macOS system processes"*.

## Evidence

Three rows sorted by TIME. `idle` has no `cpu_times` and the highest `cpu_percent`, so the fallback puts it first:

| row | user + system | cpu_percent |
| --- | ---: | ---: |
| editor | 6.0 | 1.0 |
| idle | — | 99.0 |
| compiler | 59.0 | 2.0 |

```
on develop     ['idle', 'compiler', 'editor']      <- sorted by cpu_percent
with this PR   ['compiler', 'editor', 'idle']      <- sorted by TIME
```

## Change

Each helper reads a missing value as zero, so the degenerate row sorts last and the rest keep their order. `_sort_io_counters` also pads a short list, and accepts a tuple — `NO_IO_COUNTERS` is one.

Behaviour for rows that do have values is unchanged; the existing arithmetic is untouched.

## Tests

`tests/test_sort_missing_values.py`, four cases. **All four fail on `develop`** and pass with the change:

```
develop        4 failed
this branch    4 passed
```

Neighbouring suites stay green: `test_program_io_counters.py`, `test_program_aggregation.py`, `test_programs_aggregation.py`, `test_processes_cache.py`, `test_plugin_processcount.py` — 51 passed.

Run on Windows with the repo's uv environment. I did not reproduce on macOS, which is where `programs.py` says the `None` values come from — the tests construct the empty value directly rather than relying on the platform.
