### PR TITLE
fix(network): a rate of 0 in one direction must not mute the other

### DIFF
--- a/glances/plugins/network/__init__.py
+++ b/glances/plugins/network/__init__.py
@@ -210,13 +210,16 @@ class NetworkPlugin(GlancesPluginModel):
         for i in self.get_raw():
             if_real_name = i['interface_name'].split(':')[0]
 
-            # Skip alert if no timespan to measure
-            if not i.get('bytes_recv_rate_per_sec') or not i.get('bytes_sent_rate_per_sec'):
-                continue
-
-            # Convert rate to bps (to be able to compare to interface speed)
-            bps_rx = int(i['bytes_recv_rate_per_sec'] * 8)
-            bps_tx = int(i['bytes_sent_rate_per_sec'] * 8)
+            # Convert rate to bps (to be able to compare to interface speed).
+            # A missing rate defaults to 0 rather than skipping the interface:
+            # the guard here was `or`, so one idle direction suppressed the
+            # alert for BOTH. A send-only interface saturating its uplink went
+            # undecorated because its rx rate happened to be exactly 0, and a
+            # receive-only one (a monitor port) the same way. 0 is a real
+            # measurement, not a missing one. Same fix as the diskio plugin,
+            # which dropped this guard for the same reason (#3684).
+            bps_rx = int((i.get('bytes_recv_rate_per_sec') or 0) * 8)
+            bps_tx = int((i.get('bytes_sent_rate_per_sec') or 0) * 8)
 
             # Decorate the bitrate with the configuration file thresholds
             alert_rx = self.get_alert(bps_rx, header='rx', action_key=if_real_name)

--- a/tests/test_plugin_network.py
+++ b/tests/test_plugin_network.py
@@ -323,3 +323,64 @@ class TestNetworkPluginAlerts:
             if iface_name in views and 'bytes_recv' in views[iface_name]:
                 # Check that decoration exists for rate fields
                 assert 'decoration' in views[iface_name]['bytes_recv']
+
+
+class TestNetworkPluginZeroRateAlerts:
+    """A rate of exactly 0 in one direction must not suppress the other.
+
+    `update_views` skipped the whole interface when either direction measured
+    0 bytes/s, so a saturated uplink went undecorated whenever the downlink
+    happened to be idle -- and vice versa for a receive-only interface.
+    """
+
+    #: 1 Gbps, in bits, which is what the `speed` field carries.
+    LINK_SPEED_BPS = 1_000_000_000
+
+    #: 120 MB/s == 960 Mbps == 96% of the link above.
+    SATURATED_BYTES_PER_SEC = 120_000_000
+
+    def _views_for(self, plugin, rx_rate, tx_rate):
+        plugin.stats = [
+            {
+                'interface_name': 'eth0',
+                'alias': None,
+                'bytes_recv': 0,
+                'bytes_sent': 0,
+                'bytes_all': 0,
+                'bytes_recv_rate_per_sec': rx_rate,
+                'bytes_sent_rate_per_sec': tx_rate,
+                'bytes_all_rate_per_sec': rx_rate + tx_rate,
+                'speed': self.LINK_SPEED_BPS,
+                'is_up': True,
+            }
+        ]
+        plugin.update_views()
+        return plugin.get_views()['eth0']
+
+    def test_saturated_tx_is_flagged_while_rx_is_idle(self, network_plugin):
+        """A send-only interface at 96% of link speed must still alert."""
+        views = self._views_for(network_plugin, rx_rate=0, tx_rate=self.SATURATED_BYTES_PER_SEC)
+        assert views['bytes_sent_rate_per_sec']['decoration'] == 'CRITICAL'
+        assert views['bytes_sent']['decoration'] == 'CRITICAL'
+
+    def test_saturated_rx_is_flagged_while_tx_is_idle(self, network_plugin):
+        """The mirror case: a receive-only interface, e.g. a monitor port."""
+        views = self._views_for(network_plugin, rx_rate=self.SATURATED_BYTES_PER_SEC, tx_rate=0)
+        assert views['bytes_recv_rate_per_sec']['decoration'] == 'CRITICAL'
+        assert views['bytes_recv']['decoration'] == 'CRITICAL'
+
+    def test_a_fully_idle_interface_is_ok_not_undecorated(self, network_plugin):
+        """0 in both directions is a real measurement, not a missing one."""
+        views = self._views_for(network_plugin, rx_rate=0, tx_rate=0)
+        assert views['bytes_recv_rate_per_sec']['decoration'] == 'OK'
+        assert views['bytes_sent_rate_per_sec']['decoration'] == 'OK'
+
+    def test_both_directions_busy_still_alert(self, network_plugin):
+        """The path that already worked must keep working."""
+        views = self._views_for(
+            network_plugin,
+            rx_rate=self.SATURATED_BYTES_PER_SEC,
+            tx_rate=self.SATURATED_BYTES_PER_SEC,
+        )
+        assert views['bytes_recv_rate_per_sec']['decoration'] == 'CRITICAL'
+        assert views['bytes_sent_rate_per_sec']['decoration'] == 'CRITICAL'


### PR DESCRIPTION
## The bug

`network`'s `update_views` skipped the whole interface when either direction measured 0 bytes/s:

```python
# Skip alert if no timespan to measure
if not i.get('bytes_recv_rate_per_sec') or not i.get('bytes_sent_rate_per_sec'):
    continue
```

The guard is `or`, so **one idle direction suppressed the alert for both**:

- a send-only interface saturating its uplink goes undecorated because its **rx** rate happens to be exactly 0;
- a receive-only interface — a monitor/SPAN port, a multicast receiver — the same way on **tx**;
- a fully idle interface never reaches `get_alert` at all, so its bitrate cells read `DEFAULT` instead of `OK`.

0 bytes/s is a real measurement, not a missing one.

## The fix

The rates default to `0` instead of skipping. This is what the **diskio** plugin already does — it dropped this same guard in #3684 and reads the rate through `or 0` for exactly this reason, so the two plugins now agree again.

The WebUI needs no change: `plugin-network.vue` renders `getDecoration(...)` straight from the server-supplied view, so it inherits the fix.

## Tests

Four cases in `TestNetworkPluginZeroRateAlerts`, driving the real `update_views` and reading the rendered decoration:

| case | before | after |
|---|---|---|
| saturated tx, idle rx | `DEFAULT` ❌ | `CRITICAL` ✅ |
| saturated rx, idle tx | `DEFAULT` ❌ | `CRITICAL` ✅ |
| both directions idle | `DEFAULT` ❌ | `OK` ✅ |
| both directions busy | `CRITICAL` ✅ | `CRITICAL` ✅ |

The fourth is deliberately included and passes **before and after** — it is the path that already worked, and it keeps this change honest about what it does not alter.

`tests/test_plugin_network.py`: **39 passed**.

## Note on the full local suite

Running the whole suite on this Windows host gives 53 failures, all confined to `test_restful.py`, `test_xmlrpc.py`, `test_mcp.py`, `test_perf.py` and `test_memoryleak.py` — the server/perf ones fail because `shlex.split` strips the backslashes out of the interpreter path (`D:ProjectsPersonalglances.venvScriptspython.exe`). A clean `develop` on the same host gives 52 in the same five files. **No plugin test fails on either side**, and the ±1 sits in the timing-sensitive perf/leak pair. Please read CI as the authority over my local run.