### PR TITLE
fix(webui): read the ports status as the API sends it, and use the web alert

### DIFF
--- a/glances/outputs/static/js/components/plugin-ports.vue
+++ b/glances/outputs/static/js/components/plugin-ports.vue
@@ -9,17 +9,17 @@
                     </td>
                     <template v-if="port.host">
                         <td scope="row" class="text-end" :class="getPortDecoration(port)">
-                            <span v-if="port.status == 'null'">Scanning</span>
-                            <span v-else-if="port.status == 'false'">Timeout</span>
-                            <span v-else-if="port.status == 'true'">Open</span>
+                            <span v-if="port.status === null">Scanning</span>
+                            <span v-else-if="port.status === true">Open</span>
+                            <span v-else-if="port.status === false">Timeout</span>
                             <span v-else>{{ $filters.number(port.status * 1000.0, 0) }}ms</span>
                         </td>
                     </template>
                     <template v-if="port.url">
-                        <td scope="row" class="text-end" :class="getPortDecoration(port)">
-                            <span v-if="port.status == 'null'">Scanning</span>
-                            <span v-else-if="port.status == 'Error'">Error</span>
-                            <span v-else>Code {{ port.status }}</span>
+                        <td scope="row" class="text-end" :class="getWebDecoration(port)">
+                            <span v-if="port.status === null">Scanning</span>
+                            <span v-else-if="typeof port.status === 'number'">Code {{ port.status }}</span>
+                            <span v-else>{{ port.status }}</span>
                         </td>
                     </template>
                 </tr>


### PR DESCRIPTION
`plugin-ports.vue` disagrees with the ports plugin on two counts. I verified both against a **live `/api/4/ports` response** rather than inferring them from the source.

## Ground truth

Ran a local server against a closed port and an unreachable URL:

```json
[{"host":"127.0.0.1","port":"1","description":"ClosedPort","status":false,"rtt_warning":null,...},
 {"url":"http://127.0.0.1:1/nope","description":"UnreachableWeb","status":"Error","elapsed":0,"rtt_warning":null,...}]
```

`status` is a JSON **boolean** / number / string. `rtt_warning` defaults to **null**. Both bugs fall out of that.

## 1. URL rows used the port alert; `getWebDecoration` was dead code

The template called `getPortDecoration(port)` for both branches. `getWebDecoration` is defined in the same file and never called.

`getPortDecoration` compares `status` against an rtt threshold, but a URL's status is an HTTP code or `'Error'`:

| URL state | `rtt_warning` | WebUI showed | TUI shows |
|---|---|---|---|
| `status: "Error"` (unreachable) | `null` (default) | **ok** 🟢 | CRITICAL |
| `status: 404` | `null` (default) | **ok** 🟢 | CRITICAL |
| `status: 404` | `1` | **warning** | CRITICAL |
| `status: 200` (healthy) | `1` | **warning** | OK |

The default row is the bad one: `200 > 1` and `404 > 1` are both true, but with no threshold configured everything falls through to `"ok"` — **an unreachable URL renders green.**

## 2. The status text compared against strings

```html
<span v-if="port.status == 'null'">Scanning</span>
<span v-else-if="port.status == 'false'">Timeout</span>
<span v-else-if="port.status == 'true'">Open</span>
<span v-else>{{ $filters.number(port.status * 1000.0, 0) }}ms</span>
```

`false == 'false'` is `0 == NaN` in JavaScript — **none of the three branches can ever match.** A closed or timed-out port falls through to `false * 1000` and renders **"0ms"**, which reads as an instant, perfect response for a port that is down. Scanning renders "0ms" too.

The `'true'` branch is dead twice over: `_port_scan_tcp` / the ping path only ever assign `None`, a float, or `False` — never `True`.

Note the file already knew this: `getPortDecoration` right below compares `=== null` and `=== false` against the real values. Only the template was written against strings.

## The fix

Both branches now mirror the plugin, which is the authority — `set_status_if_host`, `set_status_if_url`, `get_conds_if_url`. The URL branch falls through to the raw status string exactly as `set_status_if_url` does, instead of special-casing `'Error'`.

I checked the severity ordering too, since that is what bit #3690: `get_default_ret_value` resolves `CRITICAL → WARNING → CAREFUL`, and `getWebDecoration`'s existing order is equivalent for these mutually-exclusive conditions, so it needed no change — only calling.

## Evidence

The WebUI has no JS test runner, so the proof is the rebuilt bundle:

| symbol | before | after |
|---|---|---|
| `getPortDecoration` | 3 | 2 |
| `getWebDecoration` | 1 | 2 |
| `"null"` literals | 4 | 2 |
| `"false"` literals | 4 | 3 |

3 → 2 and 1 → 2 is definition-plus-two-call-sites becoming definition-plus-one, and definition-only becoming definition-plus-call-site. `glances.js` 686883 → 686888 bytes; only the component and the bundle changed.

`npx eslint` on the component: 0 errors. The single `vue/require-default-prop` warning is on the untouched `props` block and predates this change.