### PR TITLE
fix(webui): match the AMP alert to the plugin's get_alert

### DIFF
--- a/glances/outputs/static/js/components/plugin-amps.vue
+++ b/glances/outputs/static/js/components/plugin-amps.vue
@@ -45,24 +45,22 @@ export default {
 		},
 	},
 	methods: {
+		// Mirrors AmpsPlugin.get_alert() in glances/plugins/amps/__init__.py,
+		// which is the authority: an unset bound defaults to the observed count,
+		// an out-of-range count is WARNING (not CAREFUL), and a configured
+		// minimum of 0 means a count of 0 is fine.
 		getNameDecoration(process) {
 			const count = process.count;
 			const countMin = process.countmin;
 			const countMax = process.countmax;
-			let decoration = "ok";
+
 			if (count > 0) {
-				if (
-					(countMin === null || count >= countMin) &&
-					(countMax === null || count <= countMax)
-				) {
-					decoration = "ok";
-				} else {
-					decoration = "careful";
-				}
-			} else {
-				decoration = countMin === null ? "ok" : "critical";
+				const min = countMin === null ? count : Number(countMin);
+				const max = countMax === null ? count : Number(countMax);
+				return min <= count && count <= max ? "ok" : "warning";
 			}
-			return decoration;
+
+			return countMin === null || Number(countMin) === 0 ? "ok" : "critical";
 		},
 	},
 };


### PR DESCRIPTION
`plugin-amps.vue` computes its own decoration instead of reading the server's. It disagrees with `AmpsPlugin.get_alert()`, which is the authority — the TUI calls it directly at `amps/__init__.py:114` with the same three fields the component reads (`count`, `countmin`, `countmax`).

## 1. Out-of-range count is WARNING, not CAREFUL

```js
} else {
    decoration = "careful";   // plugin returns 'WARNING'
}
```

These are different levels with different colours in `style.scss`:

| class | colour |
|---|---|
| `.careful` | `#295183` (blue) |
| `.warning` | `#5D4062` (purple) |

So an AMP outside its configured bounds is **under-reported in the WebUI relative to the TUI** — the same monitor shows one severity in `glances` and a milder one in the browser.

## 2. `countmin=0` with a count of 0 rendered critical

```js
decoration = countMin === null ? "ok" : "critical";
```

The plugin defaults an unset bound to the observed count and then:

```python
if int(countmin) == 0:
    return 'OK'
return 'CRITICAL'
```

So a configured minimum of **0** means zero processes is fine. That is a value the plugin supports deliberately — the `int(countmin) == 0` branch exists for it — and `conf/glances.conf` documents `countmin` as optional. The WebUI flagged it red instead.

## What did not change

The range check already matched. It is rewritten to default the bounds the way the plugin does rather than short-circuiting on `null`, so the two now read alike, but the behaviour for `count > 0` with either bound unset is identical.

**Deliberately not mirrored:** the plugin's `if nbprocess is None: return 'OK'` guard. `count` is initialised to `0` in `glances/amps/amp.py` and only ever assigned a real count, so that branch is unreachable from the API — porting it would be dead code. Say the word if you would rather have it for symmetry.

## Evidence

The WebUI has no JS test runner, so the proof is the rebuilt bundle: `careful` occurrences drop **18 → 17**, and `glances.js` goes 686883 → 686922 bytes with only the component and the bundle changed.

`npx eslint` on the component: **0 errors**. The two warnings (`vue/require-default-prop`, `vue/no-v-html`) are on untouched code and predate this change.