### PR TITLE
fix(webui): match the VM status colour to the plugin's vm_alert

### DIFF
--- a/glances/outputs/static/js/components/plugin-vms.vue
+++ b/glances/outputs/static/js/components/plugin-vms.vue
@@ -32,7 +32,7 @@
                 <tr v-for="(vm, vmId) in vms" :key="vmId">
                     <td v-show="showEngine">{{ vm.engine }}</td>
                     <td>{{ vm.name }}</td>
-                    <td :class="vm.status == 'stopped' ? 'careful' : 'ok'">
+                    <td :class="getStatusClass(vm.status)">
                         {{ vm.status }}
                     </td>
                     <td>
@@ -157,6 +157,20 @@ export default {
 					};
 				}
 			},
+		},
+	},
+	methods: {
+		// Mirrors VmsPlugin.vm_alert() in glances/plugins/vms/__init__.py,
+		// which is the authority — the TUI calls it directly. Statuses follow
+		// multipass' instance states.
+		getStatusClass(status) {
+			if (status === "running") {
+				return "ok";
+			}
+			if (["starting", "restarting", "delayed shutdown"].includes(status)) {
+				return "warning";
+			}
+			return "info";
 		},
 	},
 };


### PR DESCRIPTION
`plugin-vms.vue` decided the status colour inline:

```html
<td :class="vm.status == 'stopped' ? 'careful' : 'ok'">
```

`VmsPlugin.vm_alert()` — which the TUI calls directly at `vms/__init__.py:271` — knows three states the WebUI had never heard of:

| status | plugin | WebUI (before) |
|---|---|---|
| `running` | OK | ok ✅ |
| `starting` | **WARNING** | **ok** ❌ |
| `restarting` | **WARNING** | **ok** ❌ |
| `delayed shutdown` | **WARNING** | **ok** ❌ |
| `stopped` | INFO | careful ❌ |
| anything else | INFO | **ok** ❌ |

The only status the WebUI recognised was `stopped`, so **every other non-running state fell through to green**. A VM stuck restarting looked healthy in the browser while the TUI flagged it WARNING. `stopped` went the other way and was over-reported as CAREFUL.

## The fix

`getStatusClass` mirrors `vm_alert`, and follows the shape `plugin-containers.vue` already uses for its equivalent (`container_alert`) — including returning `info` for the fallback, which is that component's existing convention.

I checked `plugin-containers.vue` against `container_alert` while I was here, since it is the closest sibling: it matches exactly, so nothing to do there.

## Evidence

The WebUI has no JS test runner, so the proof is the rebuilt bundle: the string `delayed shutdown` goes **0 → 1** occurrences. It was absent entirely before — which is the finding, not just the diff: that state had no representation in the WebUI at all.

`glances.js` 686883 → 686996 bytes, only the component and the bundle changed.

`npx eslint` on the component: **0 errors**. Its 5 warnings sit at lines 9/15/19/24 (header attributes) and 69 (the props block); this change touches line 35 and appends a methods block, so none of them are new.