### PR TITLE
fix(webui): colour the per-CPU iowait cell by iowait, not system

### DIFF
--- a/glances/outputs/static/js/components/plugin-percpu.vue
+++ b/glances/outputs/static/js/components/plugin-percpu.vue
@@ -11,7 +11,7 @@
                         <td scope="col">system</td>
                         <td scope="col">idle</td>
                         <td scope="col">iowait</td>
-                        <td scope="col">steel</td>
+                        <td scope="col">steal</td>
                     </tr>
                 </thead>
                 <tbody>
@@ -66,7 +66,7 @@ export default {
 			return GlancesHelper.getAlert("percpu", "percpu_system_", cpu.system);
 		},
 		getIOWaitAlert(cpu) {
-			return GlancesHelper.getAlert("percpu", "percpu_iowait_", cpu.system);
+			return GlancesHelper.getAlert("percpu", "percpu_iowait_", cpu.iowait);
 		},
 	},
 };


### PR DESCRIPTION
## The bug

`plugin-percpu.vue` decorates the **iowait** column using the **system** value:

```js
getIOWaitAlert(cpu) {
    return GlancesHelper.getAlert("percpu", "percpu_iowait_", cpu.system);
}
```

The template renders `{{ percpu.iowait }}%` in that cell, so the number and its colour come from two different fields.

The curses UI does it correctly — `display_cpu_stats_in_columns` colours every per-CPU stat by its own value:

```python
return_.append(self.curse_add_line(msg, self.get_alert(cpu[stat], header=stat)))
```

So this is the web UI disagreeing with the terminal UI about the same machine.

## It's visible with the shipped defaults

`conf/glances.conf` ships `iowait_careful/warning/critical = 50/70/90`. Running the real `getAlert` from `services.js` against those limits:

```
cpu: {"cpu_number":0,"user":3,"system":5,"iowait":95}
  iowait cell, BEFORE (passes cpu.system): ok          <- 95% iowait, no alert
  iowait cell, AFTER  (passes cpu.iowait): critical

cpu: {"cpu_number":1,"user":3,"system":95,"iowait":2}
  iowait cell, BEFORE: critical                        <- red on a 2% iowait
  iowait cell, AFTER : ok
```

Both directions are wrong: the alert is missed where it matters, and raised where it doesn't. An iowait-bound machine — the exact case that column exists for — is the one where it silently stays green.

## Also in this diff

The column header read `steel`; it's `steal` everywhere else (the field name, the fields_description, the curses header).

## Bundle

`public/glances.js` is rebuilt. It's a minified artifact so a line diff is unreadable, but here it's checkable byte for byte:

```
$ cmp -l <committed> <rebuilt> | wc -l
7
```

Seven bytes: the six of `system` → `iowait`, and the one `e` → `a` of `steel` → `steal`. Same file size, no unrelated drift from the rebuild — so nothing else rode along with this change.

## Notes

- `npx eslint js/components/plugin-percpu.vue` reports the same 2 issues before and after (an unused `chunk` import and a missing default prop). Both pre-existing; I left them alone rather than widen the diff.
- While reading this I noticed the web UI also leaves `total`, `idle` and `steal` undecorated, while curses colours every stat in the header row. That's a gap rather than a wrong value, and it needs threshold decisions that are yours to make, so I've left it out of this PR — happy to follow up if you want it.
