### PR TITLE
fix(webui): colour the process MEM% cell by memory_percent, not cpu_percent

### DIFF
--- a/glances/outputs/static/js/components/plugin-processlist.vue
+++ b/glances/outputs/static/js/components/plugin-processlist.vue
@@ -702,7 +702,7 @@ export default {
 			return GlancesHelper.getAlert(
 				"processlist",
 				"processlist_mem_",
-				process.cpu_percent,
+				process.memory_percent,
 			);
 		},
 		getDisableStats() {


### PR DESCRIPTION
## The bug

`plugin-processlist.vue` decorates the **MEM%** column using the **CPU%** value:

```js
getMemoryPercentAlert(process) {
    return GlancesHelper.getAlert("processlist", "processlist_mem_", process.cpu_percent);
}
```

The cell right next to it renders `process.memory_percent`, so in the most-looked-at table in Glances the number and its colour come from different fields. Both render paths — the flat list and the tree view — go through this one helper.

The curses UI gets it right:

```python
def _get_process_curses_memory_percent(self, p, selected, args):
    msg = self.layout_stat['mem'].format(p['memory_percent'])
    alert = self.get_alert(p['memory_percent'], ..., header="mem")
```

## What a user sees, with the shipped defaults

`conf/glances.conf` ships `mem_careful/warning/critical = 50/70/90`. Running the real `getAlert` from `services.js` against them:

```
a memory hog, idle CPU (cpu 0.3%, mem 94.2%)
   MEM% cell BEFORE: ok           <- 94% of RAM, no alert
   MEM% cell AFTER : critical

a busy loop, tiny RSS (cpu 99%, mem 0.4%)
   MEM% cell BEFORE: critical     <- red on a 0.4% footprint
   MEM% cell AFTER : ok
```

The process you'd open Glances to find — the one eating memory — is exactly the one that stays green, while a CPU-busy process with a negligible footprint is flagged instead.

## Bundle

`public/glances.js` is rebuilt. A byte-offset diff is useless here because `memory_percent` is 3 bytes longer than `cpu_percent`, so everything after it shifts. Instead, undoing just that identifier in the rebuilt bundle:

```js
const normalized = rebuilt.replace('processlist_mem_",t.memory_percent',
                                   'processlist_mem_",t.cpu_percent');
normalized === committed   // true
```

Byte-identical. So the rebuild carried nothing but this change, and the size delta is exactly +3.

## Related

Same class of defect as #3698, which I opened for `plugin-percpu.vue` (the iowait cell coloured by `system`). They're independent files, so I kept them as separate PRs — merge order doesn't matter.

I checked every other `GlancesHelper.getAlert` call site in `js/components/`; these two were the only mismatches. `plugin-raid.vue` already mirrors `RaidPlugin.raid_alert` correctly.
