### PR TITLE
fix(config): strip whitespace around comma-separated config values

### DIFF
--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -742,7 +742,14 @@ class GlancesPluginModel:
                 try:
                     self._limits[limit] = config.get_float_value(self.plugin_name, level)
                 except ValueError:
-                    self._limits[limit] = config.get_value(self.plugin_name, level).split(",")
+                    # Strip each item: `list=cpu, mem, load` is how a comma-separated
+                    # value is normally written, and glances.conf writes it that way in
+                    # its own comments. A bare split kept the spaces, so ' mem' matched
+                    # nothing and plugins that validate their list against a set of
+                    # known names silently rejected a config the user got right.
+                    self._limits[limit] = [
+                        item.strip() for item in config.get_value(self.plugin_name, level).split(",")
+                    ]
                 logger.debug(f"Load limit: {limit} = {self._limits[limit]}")
 
         return True

--- a/glances/plugins/quicklook/__init__.py
+++ b/glances/plugins/quicklook/__init__.py
@@ -109,9 +109,17 @@ class QuicklookPlugin(GlancesPluginModel):
 
         # Define the stats list
         self.stats_list = self.get_conf_value('list', default=self.DEFAULT_STATS_LIST)
-        if not set(self.stats_list).issubset(self.AVAILABLE_STATS_LIST):
-            logger.warning(f'Quicklook plugin: Invalid stats list: {self.stats_list}')
-            self.stats_list = self.AVAILABLE_STATS_LIST
+        # A misconfigured list falls back to the DEFAULT, not to everything available.
+        # Falling back to AVAILABLE_STATS_LIST answered a config mistake by showing MORE
+        # than the user asked for, and the two GPU entries in it flip the gpu_stats
+        # polling flags below — so a typo silently started polling the GPU.
+        unknown = [stat for stat in self.stats_list if stat not in self.AVAILABLE_STATS_LIST]
+        if unknown:
+            logger.warning(
+                f'Quicklook plugin: unknown stats in the list: {unknown} '
+                f'(available: {self.AVAILABLE_STATS_LIST}), falling back to {self.DEFAULT_STATS_LIST}'
+            )
+            self.stats_list = self.DEFAULT_STATS_LIST
         if "gpu_mem" in self.stats_list:
             gpu_stats.get_gpu_mem = True
         if "gpu_proc" in self.stats_list:

--- a/tests/test_plugin_quicklook.py
+++ b/tests/test_plugin_quicklook.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the Quicklook plugin stats list configuration."""
+
+import os
+
+import pytest
+
+from glances.config import Config
+from glances.plugins.quicklook import QuicklookPlugin
+
+
+@pytest.fixture
+def plugin_for(tmp_path):
+    """Build a Quicklook plugin from a `[quicklook] list=...` config value."""
+
+    def build(list_value):
+        config_file = tmp_path / f'glances-{abs(hash(list_value))}.conf'
+        config_file.write_text(f'[quicklook]\nlist={list_value}\n', encoding='utf-8')
+        return QuicklookPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+
+    return build
+
+
+class TestQuicklookStatsList:
+    def test_a_plain_list_is_honoured(self, plugin_for):
+        assert plugin_for('cpu,mem,load').stats_list == ['cpu', 'mem', 'load']
+
+    @pytest.mark.parametrize(
+        'list_value',
+        [
+            'cpu, mem, load',
+            'cpu ,mem ,load',
+            ' cpu , mem , load ',
+            'cpu,\tmem,\tload',
+        ],
+    )
+    def test_whitespace_around_items_is_ignored(self, plugin_for, list_value):
+        """`list=cpu, mem, load` is how anyone writes a comma-separated value.
+
+        glances.conf writes it that way in its own `# Available stats are:` comment, so
+        a user copying that line got a list where every item but the first carried a
+        leading space, matched nothing, and was discarded whole.
+        """
+        assert plugin_for(list_value).stats_list == ['cpu', 'mem', 'load']
+
+    def test_a_typo_falls_back_to_the_default_not_to_everything(self, plugin_for):
+        """A config mistake must not answer by displaying MORE than was asked for.
+
+        The fallback used to be AVAILABLE_STATS_LIST, which includes both GPU entries —
+        and those flip the gpu_stats polling flags. A single typo therefore started
+        polling the GPU on a machine whose owner never asked for it.
+        """
+        plugin = plugin_for('cpu,mem,typo')
+
+        assert plugin.stats_list == QuicklookPlugin.DEFAULT_STATS_LIST
+        assert 'gpu_mem' not in plugin.stats_list
+        assert 'gpu_proc' not in plugin.stats_list
+
+    def test_the_gpu_entries_are_still_selectable_on_purpose(self, plugin_for):
+        """The fallback must not become a filter: an explicit request still works."""
+        assert plugin_for('cpu,gpu_mem,gpu_proc').stats_list == ['cpu', 'gpu_mem', 'gpu_proc']
+
+    def test_no_list_configured_uses_the_default(self, tmp_path):
+        config_file = tmp_path / 'glances-empty.conf'
+        config_file.write_text('[quicklook]\ndisable=False\n', encoding='utf-8')
+        plugin = QuicklookPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+
+        assert plugin.stats_list == QuicklookPlugin.DEFAULT_STATS_LIST
+
+
+class TestConfigListParsing:
+    """The strip belongs to `load_limits`, so every plugin reading a list gets it."""
+
+    def test_limits_carry_stripped_items(self, plugin_for):
+        assert plugin_for('cpu, mem, load').get_limits('list') == ['cpu', 'mem', 'load']
+
+    def test_a_hide_pattern_written_with_spaces_still_hides(self, tmp_path):
+        """The show/hide filters are the loudest symptom of the same parsing bug.
+
+        Every item in those lists is used as a `re.fullmatch` pattern, so a leading
+        space made the pattern match nothing at all — `hide=sda2, loop.*` hid `sda2`
+        and silently kept showing every loop device.
+        """
+        from glances.plugins.diskio import DiskioPlugin
+
+        config_file = tmp_path / 'glances-hide.conf'
+        config_file.write_text('[diskio]\nhide=sda2, loop.*\n', encoding='utf-8')
+        plugin = DiskioPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+
+        assert plugin.get_conf_value('hide') == ['sda2', 'loop.*']
+        assert plugin.is_hide('sda2')
+        assert plugin.is_hide('loop0')
+        assert not plugin.is_hide('sda1')
+
+    def test_internal_spaces_are_kept(self, tmp_path):
+        """Only the edges are stripped — a value may legitimately contain spaces."""
+        config_file = tmp_path / 'glances-alias.conf'
+        config_file.write_text('[quicklook]\nlist=cpu\nalias=sda1:System Disk , sdb1:Data Disk\n', encoding='utf-8')
+        plugin = QuicklookPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+
+        assert plugin.get_limits('alias') == ['sda1:System Disk', 'sdb1:Data Disk']


### PR DESCRIPTION
## `list=cpu, mem, load` does not work, and glances.conf documents it that way

`load_limits` splits a config list and keeps the spaces:

```python
self._limits[limit] = config.get_value(self.plugin_name, level).split(",")
```

So `list=cpu, mem, load` becomes `['cpu', ' mem', ' load']`. That is how anyone writes a comma-separated value, and it is how `conf/glances.conf` writes one in its own comment:

```ini
# Available stats are: cpu,mem,load,swap, gpu_mem, gpu_proc
```

A user copying that line gets a list where four of the six items carry a leading space.

## The loudest symptom is show/hide

Every item in those lists is used as a `re.fullmatch` pattern, so a leading space makes the pattern match **nothing at all**. With `hide=sda2, loop.*`:

```
=== on develop ===
hide patterns: ['sda2', ' loop.*']
  sda2   hidden=True   displayed=False
  loop0  hidden=False  displayed=True     <-- not hidden
  sda1   hidden=False  displayed=True

=== with this patch ===
hide patterns: ['sda2', 'loop.*']
  sda2   hidden=True   displayed=False
  loop0  hidden=True   displayed=False
  sda1   hidden=False  displayed=True
```

The rule is accepted, logged, and silently does nothing. Nothing tells the user their filter is dead.

## Quicklook: a config mistake showed *more* than the default

Separately, quicklook answered an unrecognised list by falling back to everything available:

```python
if not set(self.stats_list).issubset(self.AVAILABLE_STATS_LIST):
    logger.warning(f'Quicklook plugin: Invalid stats list: {self.stats_list}')
    self.stats_list = self.AVAILABLE_STATS_LIST
```

`AVAILABLE_STATS_LIST` contains `gpu_mem` and `gpu_proc`, and the next three lines use exactly those to flip `gpu_stats.get_gpu_mem` / `get_gpu_proc`. So a typo — or, before the first fix, an ordinary space — **started polling the GPU** on a machine whose owner never asked for it. That is not a neutral default; on the AMD runtime-PM hardware in #3590 it is reads against a suspended card.

Measured on `develop`:

```
list='cpu,mem,load'      -> ['cpu', 'mem', 'load']
list='cpu, mem, load'    -> ['cpu', 'mem', 'swap', 'load', 'gpu_mem', 'gpu_proc']
list='cpu,mem,typo'      -> ['cpu', 'mem', 'swap', 'load', 'gpu_mem', 'gpu_proc']
```

All three now resolve to what the user asked for, or to `DEFAULT_STATS_LIST` — the same list `get_conf_value` already uses as its `default=`. The warning also names which entries were unrecognised, instead of printing the whole list back.

## Scope

Two changes, kept together because fixing either alone leaves the other reachable: with only the strip, a genuine typo still turns on the GPU; with only the fallback, `list=cpu, mem, load` still silently degrades.

The strip lives in `load_limits`, so it is one place rather than one per plugin. It touches only the edges of each item — internal spaces survive, which matters for values like `alias=sda1:System Disk`, and there is a test pinning that.

I looked for anything that could depend on the old behaviour. `ConfigParser` already strips the value as a whole, so a leading or trailing space on a single-item value was never reachable; only *interior* items were affected, and for those the space was never wanted. `bar_char` reads `[0]` of its list and is a single item, so it is unaffected either way.

## Verification

11 new tests in `tests/test_plugin_quicklook.py`. Seven of them are red against `develop`:

```
FAILED test_whitespace_around_items_is_ignored[cpu, mem, load]
FAILED test_whitespace_around_items_is_ignored[cpu ,mem ,load]
FAILED test_whitespace_around_items_is_ignored[ cpu , mem , load ]
FAILED test_whitespace_around_items_is_ignored[cpu,\tmem,\tload]
FAILED test_a_typo_falls_back_to_the_default_not_to_everything
FAILED test_limits_carry_stripped_items
FAILED test_internal_spaces_are_kept
7 failed, 3 passed
```

(The hide/show test was added after that run and is red too; it is the `loop0` case shown above.)

Full suite, same invocation both times, only `glances/` reverted for the baseline:

| | failed | passed |
|---|---|---|
| `develop` (new test file excluded) | 40 | 641 |
| this branch | 40 | 652 |

652 = 641 + the 11 new tests, and the two **failure sets are identical** — I diffed the `FAILED` names, and both `comm` directions are empty. The 40 are pre-existing and environmental on this box: `test_restful.py` and `test_xmlrpc.py` cannot start their servers here, plus `test_perf` and `test_memoryleak`. `test_mcp.py` and the browser/webui suites were excluded from both runs for the same reason.

`ruff check` and `ruff format --check` clean on all three files.
