### PR TITLE
fix(ports): scope the TCP scan timeout to the scanning socket

### DIFF
--- a/glances/plugins/ports/__init__.py
+++ b/glances/plugins/ports/__init__.py
@@ -391,12 +391,24 @@ class ThreadScanner(threading.Thread):
         """Scan the (TCP) port structure (dict) and update the status key."""
         ret = None
 
-        # Create and configure the scanning socket
+        # Create and configure the scanning socket.
+        #
+        # The timeout belongs to this socket, not to the process:
+        # socket.setdefaulttimeout() is global and was never restored, so once
+        # a port had been scanned every socket built afterwards anywhere in
+        # Glances silently inherited the last scanned port's timeout.
+        #
+        # Returning here also matters: if the socket cannot be created, the
+        # code below used to run anyway and _socket was unbound, so the
+        # connect_ex raised UnboundLocalError into the "Error while scanning
+        # port" handler and the finally clause then raised it again, this time
+        # with nothing to catch it.
         try:
-            socket.setdefaulttimeout(port['timeout'])
             _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            _socket.settimeout(port['timeout'])
         except Exception as e:
             logger.debug(f"{self.plugin_name}: Error while creating scanning socket ({e})")
+            return ret
 
         # Scan port
         ip = self._resolv_name(port['host'])

--- a/tests/test_plugin_ports.py
+++ b/tests/test_plugin_ports.py
@@ -9,6 +9,8 @@
 
 """Tests for the Ports plugin."""
 
+import socket
+
 import pytest
 
 import glances.plugins.ports as ports_mod
@@ -119,3 +121,74 @@ class TestIcmpPingCommand:
         monkeypatch.setattr(ThreadScanner, '_resolv_name', lambda self, host: resolved.append(host) or host)
         scanner._port_scan_icmp({'host': 'example.net', 'port': 0, 'timeout': 3})
         assert resolved == ['example.net']
+
+
+class TestTcpScanSocket:
+    """Test that a TCP scan configures its own socket and cleans up after itself."""
+
+    @pytest.fixture
+    def tcp_port(self):
+        """Return a port entry pointing at the discard port, which nothing listens on."""
+        return {'host': '127.0.0.1', 'port': 9, 'timeout': 3, 'status': None, 'indice': 'port_0'}
+
+    def test_the_timeout_is_set_on_the_scanning_socket(self, scanner, tcp_port, monkeypatch):
+        """The scan must configure the socket it actually uses."""
+        seen = {}
+        real_socket = socket.socket
+
+        def spy(*args, **kwargs):
+            sock = real_socket(*args, **kwargs)
+            seen['sock'] = sock
+            return sock
+
+        monkeypatch.setattr(ports_mod.socket, 'socket', spy)
+        monkeypatch.setattr(ThreadScanner, '_resolv_name', lambda self, host: host)
+        scanner._port_scan_tcp(tcp_port)
+
+        assert seen['sock'].gettimeout() == 3
+
+    def test_scanning_does_not_change_the_process_wide_default_timeout(self, scanner, tcp_port, monkeypatch):
+        """A port scan must not reconfigure sockets it does not own.
+
+        socket.setdefaulttimeout() applies to every socket created afterwards
+        in the process -- exporters, the hddtemp grabber, anything that does
+        not set a timeout of its own -- and nothing here ever restored it.
+        """
+        monkeypatch.setattr(ThreadScanner, '_resolv_name', lambda self, host: host)
+        # Pin the starting point. The default is process-wide, so an earlier
+        # scan in the same session would otherwise have already set it and this
+        # test would pass against the very state it exists to forbid.
+        previous = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(None)
+        try:
+            scanner._port_scan_tcp(tcp_port)
+
+            assert socket.getdefaulttimeout() is None
+            unrelated = socket.socket()
+            try:
+                assert unrelated.gettimeout() is None
+            finally:
+                unrelated.close()
+        finally:
+            socket.setdefaulttimeout(previous)
+
+    def test_a_socket_that_cannot_be_created_is_reported_not_raised(self, scanner, tcp_port, monkeypatch):
+        """A failed socket creation must not escape as an UnboundLocalError."""
+
+        def refuse(*args, **kwargs):
+            raise OSError("no file descriptors available")
+
+        monkeypatch.setattr(ports_mod.socket, 'socket', refuse)
+        monkeypatch.setattr(ThreadScanner, '_resolv_name', lambda self, host: host)
+        # Set by ThreadScanner.__init__; the fixture skips it, and the failure
+        # path logs with it.
+        scanner.plugin_name = 'ports'
+
+        assert scanner._port_scan_tcp(tcp_port) is None
+
+    def test_a_closed_port_is_still_reported_offline(self, scanner, tcp_port, monkeypatch):
+        """The scan result itself must be unchanged by how the timeout is set."""
+        monkeypatch.setattr(ThreadScanner, '_resolv_name', lambda self, host: host)
+        scanner._port_scan_tcp(tcp_port)
+
+        assert tcp_port['status'] is False


### PR DESCRIPTION
`_port_scan_tcp` configures its socket with `socket.setdefaulttimeout()`, which is **process-wide**, not per-socket — and nothing restores it. After the first port is scanned, every socket created afterwards anywhere in Glances that does not set its own timeout silently inherits the last scanned port's `timeout`.

Measured on `develop`, one scan of a closed port with `timeout = 3`:

```
1. default timeout at startup       : None
   a fresh socket's timeout         : None
2. after ONE ports scan (timeout=3) : 3.0
   a fresh, unrelated socket now    : 3.0
3. hddtemp's socket inherited it    : 3.0
```

Line 3 is the point: `GlancesGrabHDDTemp.fetch()` builds its socket with no timeout of its own, so what it gets now depends on whether the ports plugin happened to run first and on which port it scanned last. Nothing in the tree reads `socket.getdefaulttimeout()`, so this is not load-bearing anywhere — it is only reach.

`_socket.settimeout()` sets the same value on the socket the scan actually uses, and leaves the rest of the process alone. Scan results are unchanged: `connect_ex` behaves the same whether the timeout arrived from the global default or from the socket.

## A second defect in the same function

```python
try:
    socket.setdefaulttimeout(port['timeout'])
    _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
except Exception as e:
    logger.debug(f"{self.plugin_name}: Error while creating scanning socket ({e})")

# ... falls through anyway
ret = _socket.connect_ex(...)     # UnboundLocalError -> caught, logged as a *scan* error
finally:
    _socket.close()               # UnboundLocalError again -- nothing catches this one
```

If the socket cannot be created the function keeps going with `_socket` unbound. The `connect_ex` failure is swallowed by the "Error while scanning port" handler, which names the wrong thing, and then the `finally` raises the same error with no handler left:

```
ESCAPED the handlers -> UnboundLocalError: cannot access local variable '_socket'
where it is not associated with a value
```

Returning early in the `except` fixes both.

## Tests

`tests/test_plugin_ports.py` grows a `TestTcpScanSocket` class: 13 → 17.

Reverting only `glances/plugins/ports/__init__.py` and keeping the tests:

```
FAILED tests/test_plugin_ports.py::TestTcpScanSocket::test_scanning_does_not_change_the_process_wide_default_timeout
FAILED tests/test_plugin_ports.py::TestTcpScanSocket::test_a_socket_that_cannot_be_created_is_reported_not_raised
2 failed, 15 passed
```

With the fix: **17 passed**. `ruff check` and `ruff format --check` clean on both files.

One note on the first of those two, because it nearly went in useless: it originally read the default timeout at the top and asserted the scan did not change it. That passes on `develop` — an earlier test in the same session has already set the global to 3, so "unchanged" is trivially true against exactly the state the test exists to forbid. It now pins the default to `None` first and restores it afterwards, which is what makes it fail without the fix.

The other two cases in the class pin behaviour rather than catching the regression: the scanning socket carries the timeout, and a closed port is still reported offline. Both pass either way, and they are there so a future rewrite cannot quietly drop the timeout or change the result.

The full suite was run on `develop` and on this branch with the same invocation
(`pytest tests/ -q -p no:randomly`), and the failure **names** diffed in both directions:

| | failed | passed | errors |
|---|---|---|---|
| `develop` | 52 | 692 | 15 |
| this branch | 52 | **696** | 15 |

The two failure sets are identical — `comm` returns nothing in either direction — and the
+4 is exactly the four tests added here. Those 67 pre-existing failures are all in
`test_restful.py`, `test_xmlrpc.py`, `test_mcp.py`, `test_browser_restful.py`,
`test_webui.py` and `test_perf.py`, i.e. the integration tests that need a running server
or node on this (Windows) machine. None are in `test_plugin_*`.
