### PR TITLE
IP plugin: prefer the default-route address over interface order

### DIFF
--- a/glances/globals.py
+++ b/glances/globals.py
@@ -17,6 +17,7 @@ import base64
 import errno
 import functools
 import importlib
+import ipaddress
 import multiprocessing
 import os
 import platform
@@ -744,14 +745,50 @@ def split_esc(input_string, sep=None, maxsplit=-1, esc='\\'):
 
 
 def get_ip_address(ipv6=False):
-    """Get current IP address and netmask as a tuple."""
+    """Get current IP address and netmask as a tuple.
+
+    The address the OS routing table selects for default-route traffic is
+    preferred, so that virtual bridge interfaces (docker0, vmnet...) cannot
+    shadow the real one (see #3465). If no default route is available, fall
+    back to the first up, non-loopback interface carrying an address of the
+    requested family.
+    """
     family = socket.AF_INET6 if ipv6 else socket.AF_INET
 
-    # Get IP address
-    stats = psutil.net_if_stats()
     addrs = psutil.net_if_addrs()
 
+    # Ask the kernel which source address it would use for default-route
+    # traffic. connect() on a SOCK_DGRAM socket sends no packet: it only
+    # resolves the route, honouring metrics, policy routing and per-route
+    # source hints. The probe address is from the documentation range
+    # (RFC 5737 / RFC 3849) and is never actually contacted.
     ip_address = None
+    try:
+        with socket.socket(family, socket.SOCK_DGRAM) as sock:
+            sock.connect(('2001:db8::1' if ipv6 else '192.0.2.1', 53))
+            candidate = sock.getsockname()[0]
+        # On hosts that locally blackhole documentation/bogon ranges via the
+        # loopback, the probe can resolve to a loopback source: only trust a
+        # real, routable address (also protects the zeroconf bind address in
+        # servers_list_dynamic.py from ever becoming 127.0.0.1).
+        parsed = ipaddress.ip_address(candidate.split('%')[0])
+        if not (parsed.is_loopback or parsed.is_unspecified):
+            ip_address = candidate
+    except (OSError, ValueError):
+        # No default route for this family: fall back to interface scan
+        ip_address = None
+
+    if ip_address:
+        for interface_addrs in addrs.values():
+            for addr in interface_addrs:
+                if addr.family == family and addr.address.split('%')[0] == ip_address.split('%')[0]:
+                    return ip_address, addr.netmask
+        # Routed address not listed by psutil: still correct, just no netmask
+        # (ip_to_cidr() in the IP plugin handles a None netmask, see #1528)
+        return ip_address, None
+
+    # Fallback: first up, non-loopback interface with an address of the family
+    stats = psutil.net_if_stats()
     ip_netmask = None
     for interface, stat in stats.items():
         if stat.isup and interface != 'lo':

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -25,8 +25,66 @@ def _addr(family, address, netmask='255.255.255.0'):
     return SimpleNamespace(family=family, address=address, netmask=netmask, broadcast=None, ptp=None)
 
 
+def _no_route(*args, **kwargs):
+    """Simulate a host without a default route (socket probe fails)."""
+    raise OSError("Network is unreachable")
+
+
+class _FakeSocket:
+    """A connected UDP socket whose kernel-chosen source address we control."""
+
+    def __init__(self, address):
+        self._address = address
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def connect(self, target):
+        pass
+
+    def getsockname(self):
+        return (self._address, 0)
+
+
 class TestGetIpAddress:
-    """get_ip_address() should return the FIRST up, non-loopback interface's address."""
+    """get_ip_address() should return the default-route interface's address,
+    falling back to the first up, non-loopback interface."""
+
+    def test_default_route_address_wins_over_interface_order(self):
+        # Regression test for #3465: the interface order must not matter.
+        # docker0 comes FIRST here; the kernel routes default traffic from
+        # eth0's address, so eth0's address must be returned.
+        addrs = {
+            'docker0': [_addr(socket.AF_INET, '172.18.0.1')],
+            'eth0': [_addr(socket.AF_INET, '192.168.0.150')],
+        }
+
+        with (
+            patch('glances.globals.socket.socket', _FakeSocket('192.168.0.150')),
+            patch('glances.globals.psutil.net_if_addrs', return_value=addrs),
+        ):
+            ip_address, ip_netmask = get_ip_address()
+
+        assert ip_address == '192.168.0.150'
+        assert ip_netmask == '255.255.255.0'
+
+    def test_routed_address_without_psutil_entry_returns_none_netmask(self):
+        # ip_to_cidr() handles a None netmask (#1528), so the correct address
+        # must not be discarded just because its netmask cannot be found.
+        with (
+            patch('glances.globals.socket.socket', _FakeSocket('10.9.8.7')),
+            patch('glances.globals.psutil.net_if_addrs', return_value={}),
+        ):
+            ip_address, ip_netmask = get_ip_address()
+
+        assert ip_address == '10.9.8.7'
+        assert ip_netmask is None
 
     def test_returns_first_matching_interface_not_last(self):
         # Regression test for #3617: on hosts with Docker, a virtual bridge
@@ -44,6 +102,24 @@ class TestGetIpAddress:
         }
 
         with (
+            patch('glances.globals.socket.socket', _no_route),
+            patch('glances.globals.psutil.net_if_stats', return_value=stats),
+            patch('glances.globals.psutil.net_if_addrs', return_value=addrs),
+        ):
+            ip_address, ip_netmask = get_ip_address()
+
+        assert ip_address == '192.168.0.150'
+        assert ip_netmask == '255.255.255.0'
+
+    def test_loopback_probe_result_falls_back_to_interface_scan(self):
+        # Hosts that locally blackhole documentation/bogon ranges can resolve
+        # the probe to a loopback source; that must never be reported as the
+        # primary address (nor used as the zeroconf bind address).
+        stats = OrderedDict([('eth0', _stat())])
+        addrs = {'eth0': [_addr(socket.AF_INET, '192.168.0.150')]}
+
+        with (
+            patch('glances.globals.socket.socket', _FakeSocket('127.0.0.1')),
             patch('glances.globals.psutil.net_if_stats', return_value=stats),
             patch('glances.globals.psutil.net_if_addrs', return_value=addrs),
         ):
@@ -67,6 +143,7 @@ class TestGetIpAddress:
         }
 
         with (
+            patch('glances.globals.socket.socket', _no_route),
             patch('glances.globals.psutil.net_if_stats', return_value=stats),
             patch('glances.globals.psutil.net_if_addrs', return_value=addrs),
         ):
@@ -79,6 +156,7 @@ class TestGetIpAddress:
         addrs = {'lo': [_addr(socket.AF_INET, '127.0.0.1')]}
 
         with (
+            patch('glances.globals.socket.socket', _no_route),
             patch('glances.globals.psutil.net_if_stats', return_value=stats),
             patch('glances.globals.psutil.net_if_addrs', return_value=addrs),
         ):


### PR DESCRIPTION
<!-- PR title: IP plugin: prefer the default-route address over interface order -->

## The problem

`get_ip_address()` in `glances/globals.py` returns the address of the **first up,
non-loopback interface** psutil enumerates. On any host running Docker, VMware,
libvirt or similar, a virtual bridge (`docker0`, `vmnet8`, `br-*`, ...) can occupy
that position and silently win, so the IP plugin shows a bridge address (for
example `172.17.0.1`) as the host's primary IP. Reported by users in #3465.

The nasty part is that the result depends on **interface creation order**, so a
host can display the correct address for months and regress after something as
routine as a NetworkManager restart recreating a bond interface. On one of my
hosts (22 interfaces: a bond, 3 docker bridges, 2 VMware vmnets, 10 veths) the
correct answer currently survives only because the bond happens to enumerate
before six other candidates that would all "win" if ordered first.

I believe this regressed when the `netifaces` dependency (which provided
`gateways()`) was dropped — the same gap discussed in #3073.

## The fix

Ask the OS routing table which source address it would use for default-route
traffic: `connect()` on a `SOCK_DGRAM` socket **sends no packet** — it only
resolves the route — and honours metrics, policy routing and per-route source
hints, identically on every platform Glances supports (no `/proc` parsing, no
new dependency). The probe address is from the documentation range
(RFC 5737 / RFC 3849) and is never actually contacted.

The previous interface scan is kept as the fallback for hosts without a default
route, and the pre-existing tests now pin exactly that fallback behaviour. A
`None` netmask in the (unlikely) case where the routed address is not listed by
psutil is already handled by `ip_to_cidr()` (#1528). A loopback/unspecified
probe result (possible on hosts that locally blackhole documentation/bogon
ranges) is rejected and falls back to the scan, so a loopback address can
never be reported.

Two design notes for review:

- **Why not reuse `get_default_gateway()`?** It parses `/proc/net/route`, so it
  is Linux-only, and it returns the *gateway's* address rather than the local
  source address the plugin needs. The socket probe works on every supported
  platform and delegates the choice to the same code path real traffic uses.
- **Second consumer**: `servers_list_dynamic.py` uses `get_ip_address()[0]` as
  the zeroconf bind address. The change improves that case too — previously a
  virtual bridge address could be announced to LAN peers as the server address.

## Verification

- `pytest tests/test_globals.py` — 5 passed (2 new: default-route address wins
  over interface order; routed address without a psutil entry yields a `None`
  netmask. 3 pre-existing, now exercising the no-default-route fallback).
- `ruff check` / `ruff format --check` clean on both changed files.
- Live on the 22-interface host above: returns the bond address
  (`192.168.0.x`) for IPv4 and the global address for IPv6, independent of
  enumeration order. The old walk's order-dependence is reproduced in the new
  unit test, where `docker0` enumerating first used to win.

Fixes the behaviour discussed in #3465; related to #3073.
