### PR TITLE
fix(quicklook): colour each --percpu bar by that core's own load

### DIFF
--- a/glances/outputs/static/js/components/plugin-quicklook.vue
+++ b/glances/outputs/static/js/components/plugin-quicklook.vue
@@ -23,7 +23,7 @@
 				<tr v-for="(percpu, percpuId) in percpus" v-if="args.percpu" :key="percpuId">
 					<td scope="col">CPU{{ percpu.number }}</td>
 					<td scope="col" class="progress">
-						<div :class="`progress-bar progress-bar-${getDecoration('cpu')}`" role="progressbar"
+						<div :class="`progress-bar progress-bar-${getPercpuDecoration(percpu)}`" role="progressbar"
 							:aria-valuenow="percpu.total" aria-valuemin="0" aria-valuemax="100"
 							:style="`width: ${percpu.total}%;`">
 							&nbsp;
@@ -123,6 +123,18 @@ export default {
 				return;
 			}
 			return this.view[value].decoration.toLowerCase();
+		},
+		// A core's bar is coloured by that core's own load. Reading the aggregate
+		// 'cpu' style here painted a core pegged at 100% with the colour of the
+		// average. The "x" row averages the cores that are not shown, and the
+		// server styles it under 'other'.
+		getPercpuDecoration(percpu) {
+			const decorations = this.view.percpu_decoration || {};
+			const decoration =
+				decorations[percpu.number === "x" ? "other" : percpu.number];
+			return decoration === undefined
+				? this.getDecoration("cpu")
+				: decoration.toLowerCase();
 		},
 	},
 };

--- a/glances/plugins/quicklook/__init__.py
+++ b/glances/plugins/quicklook/__init__.py
@@ -199,6 +199,53 @@ class QuicklookPlugin(GlancesPluginModel):
         # Define the list of stats to display
         self.views['list'] = self.stats_list
 
+        # A style per core for the --percpu bars.
+        # The cores share the aggregate's thresholds but not its value, so reading
+        # views['cpu'] for every bar painted a core pegged at 100% with the colour
+        # of the average.
+        self.views['percpu_decoration'] = self._build_percpu_decoration()
+
+    def _build_percpu_decoration(self):
+        """Return {cpu_number: style} for every core, plus 'other' for the summary row.
+
+        Both interfaces show at most `max_cpu_display` cores, sorted by load, and add
+        one row averaging the cores they left out; 'other' is that row's style.
+        """
+        percpu = self.stats.get('percpu') or []
+        if not percpu:
+            return {}
+
+        ret = {str(cpu[cpu['key']]): self._decoration_for_percent(cpu['total']) for cpu in percpu}
+        if len(percpu) > self.max_cpu_display:
+            hidden = sorted(percpu, key=lambda cpu: cpu['total'], reverse=True)[self.max_cpu_display :]
+            ret['other'] = self._decoration_for_percent(sum(cpu['total'] for cpu in hidden) / len(hidden))
+
+        return ret
+
+    def _decoration_for_percent(self, percent):
+        """Return the style for a CPU percentage, without get_alert's side effects.
+
+        get_alert() is the usual road, but it also records a threshold that the event
+        list reads (glances.events_list) and can run a configured action, and both are
+        keyed by the stat name alone. Every core shares 'quicklook_cpu' with the
+        aggregate, so sending the cores through get_alert() would leave whichever core
+        went last as the value those two see.
+        """
+        stat_name = self.get_stat_name(header='cpu').lower()
+        critical = self.get_limit('critical', stat_name=stat_name)
+        warning = self.get_limit('warning', stat_name=stat_name)
+        careful = self.get_limit('careful', stat_name=stat_name)
+
+        if critical and percent >= critical:
+            return 'CRITICAL'
+        if warning and percent >= warning:
+            return 'WARNING'
+        if careful and percent >= careful:
+            return 'CAREFUL'
+        if not careful and not warning and not critical:
+            return 'DEFAULT'
+        return 'OK'
+
     def msg_curse(self, args=None, max_width=10):
         """Return the list to display in the UI."""
         # Init the return message
@@ -287,6 +334,8 @@ class QuicklookPlugin(GlancesPluginModel):
         if type(data[key]).__name__ == 'Sparkline':
             raw_cpu = self.get_raw_history(item='percpu', nb=data[key].size)
 
+        percpu_decoration = self.views.get('percpu_decoration', {})
+
         # Manage the maximum number of CPU to display (related to enhancement request #2734)
         if len(self.stats['percpu']) > self.max_cpu_display:
             # If the number of CPU is > max_cpu_display then sort and display top 'n'
@@ -309,7 +358,7 @@ class QuicklookPlugin(GlancesPluginModel):
                 msg = f'{key.upper():3}{cpu_id} '
             else:
                 msg = f'{cpu_id:4} '
-            ret.extend(self._msg_create_line(msg, data[key], key))
+            ret.extend(self._msg_create_line(msg, data[key], key, decoration=percpu_decoration.get(str(cpu_id))))
             ret.append(self.curse_new_line())
 
         # Add a new line with sum of all others CPU
@@ -330,18 +379,22 @@ class QuicklookPlugin(GlancesPluginModel):
                 sum_other.percent = sum([i['total'] for i in percpu_list[self.max_cpu_display :]]) / len(
                     percpu_list[self.max_cpu_display :]
                 )
-            msg = msg = f'{key.upper():3}* '
-            ret.extend(self._msg_create_line(msg, sum_other, key))
+            msg = f'{key.upper():3}* '
+            ret.extend(self._msg_create_line(msg, sum_other, key, decoration=percpu_decoration.get('other')))
             ret.append(self.curse_new_line())
 
         return ret
 
-    def _msg_create_line(self, msg, data, key):
-        """Create a new line to the Quick view."""
+    def _msg_create_line(self, msg, data, key, decoration=None):
+        """Create a new line to the Quick view.
+
+        `decoration` overrides the field's own style, for a bar that shows one core
+        rather than the value views[key] was computed from.
+        """
         return [
             self.curse_add_line(msg),
             self.curse_add_line('[', decoration='BOLD'),
-            self.curse_add_line(data.get(), self.get_views(key=key, option='decoration')),
+            self.curse_add_line(data.get(), decoration or self.get_views(key=key, option='decoration')),
             self.curse_add_line(']', decoration='BOLD'),
             self.curse_add_line('  '),
         ]

--- a/tests/test_plugin_quicklook.py
+++ b/tests/test_plugin_quicklook.py
@@ -76,6 +76,123 @@ class TestQuicklookStatsList:
         assert plugin.stats_list == QuicklookPlugin.DEFAULT_STATS_LIST
 
 
+class TestQuicklookPercpuDecoration:
+    """Every --percpu bar used to be coloured by the aggregate CPU alert.
+
+    `_msg_create_line` read `views['cpu']['decoration']` for every row, and the WebUI
+    read `getDecoration('cpu')` in the same loop, so a core pegged at 100% was drawn
+    in the colour of the average across all cores.
+    """
+
+    @staticmethod
+    def _plugin(tmp_path, cores, max_cpu_display=4):
+        config_file = tmp_path / 'glances-percpu.conf'
+        config_file.write_text(
+            '\n'.join(
+                [
+                    '[quicklook]',
+                    'list=cpu',
+                    'cpu_careful=50',
+                    'cpu_warning=70',
+                    'cpu_critical=90',
+                    '[percpu]',
+                    f'max_cpu_display={max_cpu_display}',
+                ]
+            ),
+            encoding='utf-8',
+        )
+        plugin = QuicklookPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+        plugin.stats = {
+            'cpu': sum(cores) / len(cores),
+            'percpu': [
+                {'key': 'cpu_number', 'cpu_number': number, 'total': total} for number, total in enumerate(cores)
+            ],
+        }
+        plugin.update_views()
+        return plugin
+
+    def test_a_busy_core_is_not_hidden_by_a_quiet_average(self, tmp_path):
+        """One core at 95% among three idle ones: the aggregate is 24%, an OK value."""
+        plugin = self._plugin(tmp_path, [95.0, 1.0, 1.0, 1.0])
+
+        assert plugin.views['cpu']['decoration'] == 'OK'
+        assert plugin.views['percpu_decoration']['0'] == 'CRITICAL'
+        assert plugin.views['percpu_decoration']['1'] == 'OK'
+
+    @pytest.mark.parametrize(
+        ('percent', 'expected'),
+        [(0.0, 'OK'), (49.9, 'OK'), (50.0, 'CAREFUL'), (69.9, 'CAREFUL'), (70.0, 'WARNING'), (90.0, 'CRITICAL')],
+    )
+    def test_each_threshold_boundary(self, tmp_path, percent, expected):
+        """The cores use the plugin's own quicklook_cpu_* limits, not a second set."""
+        plugin = self._plugin(tmp_path, [percent, 0.0, 0.0, 0.0])
+
+        assert plugin.views['percpu_decoration']['0'] == expected
+
+    def test_the_summary_row_is_styled_by_the_cores_it_averages(self, tmp_path):
+        """With more cores than max_cpu_display, both UIs add one averaged row.
+
+        Cores are sorted by load and the four busiest are shown, so the row labelled
+        `CPU*` (`x` in the WebUI) always averages the quietest ones. Here its 60% is
+        CAREFUL, which is neither the shown cores' CRITICAL nor the 83% aggregate's
+        WARNING -- so the assertion fails if the row borrows either.
+        """
+        plugin = self._plugin(tmp_path, [95.0, 95.0, 95.0, 95.0, 60.0, 60.0])
+
+        assert plugin.views['cpu']['decoration'] == 'WARNING'
+        assert plugin.views['percpu_decoration']['0'] == 'CRITICAL'
+        assert plugin.views['percpu_decoration']['other'] == 'CAREFUL'
+
+    def test_no_summary_row_when_every_core_is_shown(self, tmp_path):
+        plugin = self._plugin(tmp_path, [10.0, 10.0, 10.0, 10.0])
+
+        assert 'other' not in plugin.views['percpu_decoration']
+
+    def test_the_styles_reach_the_curses_bars(self, tmp_path):
+        """The wiring, not just the map: `_msg_per_cpu` must use the per-core style.
+
+        Reverting `_msg_create_line` to the aggregate lookup leaves every assertion
+        above passing and fails only this one.
+        """
+        plugin = self._plugin(tmp_path, [95.0, 1.0, 1.0, 1.0])
+        data = {'cpu': _StubBar()}
+
+        decorations = [
+            line['decoration'] for line in plugin._msg_per_cpu(data, 'cpu', 10) if line['msg'] == _StubBar.RENDERED
+        ]
+
+        assert decorations == ['CRITICAL', 'OK', 'OK', 'OK']
+
+    def test_scanning_the_cores_does_not_move_the_global_threshold(self, tmp_path):
+        """The per-core styles must not be computed with get_alert().
+
+        get_alert() records a threshold the event list reads and can run a [quicklook]
+        action, and both are keyed by 'quicklook_cpu' alone. The per-core pass runs
+        after the aggregate one, so calling get_alert() there would leave the last
+        core — an idle one here — as the value those two see.
+
+        The values are chosen so the two disagree: the aggregate is 71.5% (WARNING)
+        while the last core is 1% (OK).
+        """
+        from glances.thresholds import glances_thresholds
+
+        self._plugin(tmp_path, [95.0, 95.0, 95.0, 1.0])
+
+        assert glances_thresholds.get()['quicklook_cpu'].description() == 'WARNING'
+
+
+class _StubBar:
+    """Stands in for Bar/Sparkline: `_msg_per_cpu` only sets a value and renders."""
+
+    RENDERED = '<bar>'
+
+    def __init__(self):
+        self.percent = None
+
+    def get(self):
+        return self.RENDERED
+
+
 class TestConfigListParsing:
     """The strip belongs to `load_limits`, so every plugin reading a list gets it."""
 


### PR DESCRIPTION
In `--percpu` mode the quicklook bars are per core, but their colour was not: every bar was drawn with the aggregate CPU style.

- curses: `_msg_create_line` reads `self.get_views(key=key, option='decoration')`, and `key` is `'cpu'` for every row `_msg_per_cpu` emits.
- WebUI: `plugin-quicklook.vue` calls `getDecoration('cpu')` inside the `v-for` over `percpus`.

So on a box where one core is pegged at 100% and the rest are idle, that core's bar is painted with the colour of the average — the one number that cannot show it. The `cpu_careful/warning/critical` limits are configured and correct; nothing reads them per core.

## The change

`update_views` now publishes `views['percpu_decoration']`, a style per `cpu_number` plus `'other'` for the row that averages the cores neither interface displays (`CPU*` in curses, `x` in the WebUI). Both interfaces read that one map, so they agree by construction rather than by both getting it right separately. The WebUI falls back to the old aggregate style when the key is absent, so an older server does not break a newer page.

The styles come from the plugin's own `quicklook_cpu_*` limits directly rather than through `get_alert()`. That is deliberate: `get_alert()` also calls `manage_threshold`, which writes `glances_thresholds[stat_name]` that `glances/events_list.py:153` reads, and `manage_action`, which can run a configured `[quicklook]` command. Both are keyed by the stat name alone, and every core shares `quicklook_cpu` with the aggregate — so running the cores through `get_alert()` would leave whichever core went last as the value the event list and any action see. `_decoration_for_percent` is the same threshold ladder with none of that.

One unrelated token: `msg = msg = f'{key.upper():3}* '` on a line the change already touches loses its duplicated assignment.

## Verification

`pytest tests/test_plugin_quicklook.py` is 22 passed; `tests/test_core.py tests/test_glances_curses.py tests/test_lazy_views.py` is 63 passed, 6 skipped. `ruff check` and `ruff format --check` are clean on both changed Python files.

Each claim was checked by breaking it, and each mutation fails only the test that owns it:

| reverted | fails |
|---|---|
| `_msg_create_line` back to the aggregate lookup | `test_the_styles_reach_the_curses_bars` only |
| the map built from `stats['cpu']` instead of each core's `total` | the six value tests |
| `_decoration_for_percent` replaced by `get_alert()` | `test_scanning_the_cores_does_not_move_the_global_threshold` only |

The first is the one that matters: without it the map is correct and unread, and every other test still passes.

The summary-row test picks values where the row disagrees with both of the things it could have borrowed — four cores at 95% and two at 60% give `CRITICAL` bars, a `WARNING` aggregate (83%), and a `CAREFUL` row.

I have no Linux box to hand for the curses rendering itself; the assertions above are on the message list `msg_curse` builds, not on the terminal output.
