### PR TITLE
fix(webui): colour each DISK I/O column by the direction it prints

### DIFF
--- a/glances/outputs/static/js/components/plugin-diskio.vue
+++ b/glances/outputs/static/js/components/plugin-diskio.vue
@@ -18,19 +18,19 @@
                         {{ $filters.minSize(disk.alias ? disk.alias : disk.name, 16) }}
                     </td>
                     <td v-show="!args.diskio_iops && !args.diskio_latency" class="text-end w-25"
-                        :class="getDecoration(disk.name, 'write_bytes_rate_per_sec')">
+                        :class="getDecoration(disk.name, 'read_bytes_rate_per_sec')">
                         {{ disk.bitrate.txps }}
                     </td>
                     <td v-show="!args.diskio_iops && !args.diskio_latency" class="text-end w-25"
-                        :class="getDecoration(disk.name, 'read_bytes_rate_per_sec')">
+                        :class="getDecoration(disk.name, 'write_bytes_rate_per_sec')">
                         {{ disk.bitrate.rxps }}
                     </td>
                     <td v-show="args.diskio_latency" class="text-end w-25"
-                        :class="getDecoration(disk.name, 'write_latency')">
+                        :class="getDecoration(disk.name, 'read_latency')">
                         {{ disk.latency.txps }}
                     </td>
                     <td v-show="args.diskio_latency" class="text-end w-25"
-                        :class="getDecoration(disk.name, 'read_latency')">
+                        :class="getDecoration(disk.name, 'write_latency')">
                         {{ disk.latency.rxps }}
                     </td>
                     <td v-show="args.diskio_iops" class="text-end w-25">
@@ -78,6 +78,10 @@ export default {
 						name: diskioData["disk_name"],
 						alias:
 							diskioData["alias"] !== undefined ? diskioData["alias"] : null,
+						// txps/rxps are misleading here: txps holds the READ value and
+						// rxps the WRITE one. Each cell above must take the decoration
+						// of the field it actually prints, not the one its key rhymes
+						// with.
 						bitrate: {
 							txps: bytes(diskioData["read_bytes_rate_per_sec"]),
 							rxps: bytes(diskioData["write_bytes_rate_per_sec"]),


### PR DESCRIPTION
In the WebUI's DISK I/O table the read and write columns wear each other's alert.

`disks()` builds each row's values like this (`plugin-diskio.vue:79-86`):

```js
bitrate: {
  txps: bytes(diskioData["read_bytes_rate_per_sec"]),
  rxps: bytes(diskioData["write_bytes_rate_per_sec"]),
},
```

`txps` holds the **read** rate and `rxps` the **write** rate — the keys read the other way round, which is the whole trap. The cells then did:

| column | prints | decoration it asked for |
|---|---|---|
| `Rps` | `bitrate.txps` (read) | `write_bytes_rate_per_sec` |
| `Wps` | `bitrate.rxps` (write) | `read_bytes_rate_per_sec` |
| `ms/opR` | `latency.txps` (read) | `write_latency` |
| `ms/opW` | `latency.rxps` (write) | `read_latency` |

`update_views()` computes the two directions separately — `get_alert(..., header='rx')` and `header='tx'` for the bitrates, `rx_latency`/`tx_latency` for the latencies — so these are four distinct values, not one shared style. A disk saturated by reads therefore left the read column plain and lit up the write column instead.

The curses UI is not affected: `msg_curse` pairs each printed value with its own field (`read_bytes` with the read rate, `write_bytes` with the write rate), so the two interfaces disagreed.

The change swaps the four `getDecoration` field names so each cell asks for the field it prints, and names the `txps`/`rxps` trap in the one place those keys are assigned, since that naming is what makes the mistake easy to repeat.

## Verification

`npx eslint js/components/plugin-diskio.vue` reports the same 5 warnings before and after the change (4 × `vue/first-attribute-linebreak`, 1 × `vue/require-default-prop`, all pre-existing) and 0 errors. There is no test runner under `glances/outputs/static` — only `lint` — so there is nothing to add a unit test to; the argument is the field mapping above, which is checkable by reading `disks()` next to the four cells.
