### PR TITLE
fix(npu): alert on the temperature both interfaces already ask for

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -238,6 +238,10 @@ load_critical=90
 freq_careful=50
 freq_warning=70
 freq_critical=90
+# Default NPU temperature thresholds in degrees Celsius
+temperature_careful=60
+temperature_warning=70
+temperature_critical=80
 
 [mpp]
 disable=True

--- a/glances/plugins/npu/__init__.py
+++ b/glances/plugins/npu/__init__.py
@@ -174,8 +174,11 @@ class NpuPlugin(GlancesPluginModel):
         # Add specifics information
         # Alert
         for i in self.stats:
-            # Init the views for the current GPU
-            self.views[i[self.get_key()]] = {'load': {}, 'freq': {}, 'mem': {}}
+            # Init the views for the current NPU.
+            # This replaces the per-field views the base class just built, so a field
+            # left out here has no view at all: both interfaces then read a decoration
+            # that is never written. That is what happened to temperature.
+            self.views[i[self.get_key()]] = {'load': {}, 'freq': {}, 'mem': {}, 'temperature': {}}
             # Load alert
             if 'load' in i:
                 alert = self.get_alert(i['load'], header='load')
@@ -188,6 +191,12 @@ class NpuPlugin(GlancesPluginModel):
             if 'mem' in i:
                 alert = self.get_alert(i['mem'], header='mem')
                 self.views[i[self.get_key()]]['mem']['decoration'] = alert
+            # Temperature alert
+            # msg_curse and the WebUI both ask for this decoration, and the Intel
+            # driver is the one that reports the reading. Same shape as the GPU plugin.
+            if i.get('temperature') is not None:
+                alert = self.get_alert(i['temperature'], header='temperature')
+                self.views[i[self.get_key()]]['temperature']['decoration'] = alert
 
         return True
 

--- a/tests/test_plugin_npu.py
+++ b/tests/test_plugin_npu.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for the NPU plugin views."""
+
+import os
+
+import pytest
+
+from glances.config import Config
+from glances.plugins.npu import NpuPlugin
+
+
+@pytest.fixture
+def plugin_for(tmp_path):
+    """Build an NPU plugin from a `[npu]` config body, with one card's stats set."""
+
+    def build(config_body, stats):
+        config_file = tmp_path / f'glances-npu-{abs(hash(tuple(config_body)))}.conf'
+        config_file.write_text('\n'.join(['[npu]', *config_body]), encoding='utf-8')
+        plugin = NpuPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+        plugin.stats = [{'key': 'npu_id', 'npu_id': 'npu0', **stats}]
+        plugin.update_views()
+        return plugin
+
+    return build
+
+
+DEFAULT_LIMITS = [
+    'load_careful=50',
+    'load_warning=70',
+    'load_critical=90',
+    'freq_careful=50',
+    'freq_warning=70',
+    'freq_critical=90',
+    'temperature_careful=60',
+    'temperature_warning=70',
+    'temperature_critical=80',
+]
+
+
+class TestNpuTemperatureAlert:
+    """`msg_curse` and the WebUI both read a temperature decoration that was never set.
+
+    `update_views` replaced the base class's per-field views with a dict naming only
+    load, freq and mem, so `views[npu_id]['temperature']` did not exist. The curses
+    line fell back to 'DEFAULT' and the WebUI's `getDecoration` returned undefined,
+    which is why a hot Intel NPU -- the one driver that reports the reading -- was
+    printed in the plain style at any temperature.
+    """
+
+    def test_a_hot_npu_is_alerted(self, plugin_for):
+        plugin = plugin_for(DEFAULT_LIMITS, {'load': 10, 'freq': 10, 'mem': 10, 'temperature': 85})
+
+        assert plugin.views['npu0']['temperature']['decoration'] == 'CRITICAL'
+
+    @pytest.mark.parametrize(
+        ('celsius', 'expected'),
+        [(20, 'OK'), (59, 'OK'), (60, 'CAREFUL'), (70, 'WARNING'), (80, 'CRITICAL')],
+    )
+    def test_each_threshold_boundary(self, plugin_for, celsius, expected):
+        plugin = plugin_for(DEFAULT_LIMITS, {'temperature': celsius})
+
+        assert plugin.views['npu0']['temperature']['decoration'] == expected
+
+    def test_the_curses_line_reads_the_decoration_that_is_written(self, plugin_for):
+        """The wiring: `msg_curse` asks for it by (item, key), not off a bare view."""
+        plugin = plugin_for(DEFAULT_LIMITS, {'temperature': 85})
+
+        assert plugin.get_views(item='npu0', key='temperature', option='decoration') == 'CRITICAL'
+
+    def test_a_card_that_reports_no_temperature_keeps_a_view_without_a_decoration(self, plugin_for):
+        """The AMD and Rockchip drivers leave it None; that must not become an alert."""
+        plugin = plugin_for(DEFAULT_LIMITS, {'load': 10, 'temperature': None})
+
+        assert plugin.views['npu0']['temperature'] == {}
+        assert plugin.get_views(item='npu0', key='temperature', option='decoration') == 'DEFAULT'
+
+    def test_the_other_fields_still_carry_their_own_alerts(self, plugin_for):
+        """Adding a key to the view dict must not disturb the three already there."""
+        plugin = plugin_for(DEFAULT_LIMITS, {'load': 95, 'freq': 10, 'temperature': 20})
+
+        assert plugin.views['npu0']['load']['decoration'] == 'CRITICAL'
+        assert plugin.views['npu0']['freq']['decoration'] == 'OK'
+        assert plugin.views['npu0']['temperature']['decoration'] == 'OK'
+
+
+class TestShippedNpuLimits:
+    """The code half is inert without thresholds: `get_alert` returns DEFAULT when a
+    stat has none configured, so the shipped config has to carry them for the alert to
+    be visible out of the box -- exactly as `[gpu]` already does."""
+
+    @staticmethod
+    def _limits(section):
+        config = Config(config_dir='./conf/glances.conf')
+        return dict(config.as_dict()[section])
+
+    @pytest.mark.parametrize('criticality', ['careful', 'warning', 'critical'])
+    def test_the_npu_section_defines_a_temperature_threshold(self, criticality):
+        assert f'temperature_{criticality}' in self._limits('npu')
+
+    def test_the_npu_thresholds_match_the_gpu_ones(self):
+        """Both read a die temperature in Celsius; two different ladders would be a
+        difference with no reason behind it."""
+        npu, gpu = self._limits('npu'), self._limits('gpu')
+
+        for criticality in ('careful', 'warning', 'critical'):
+            key = f'temperature_{criticality}'
+            assert npu[key] == gpu[key]


### PR DESCRIPTION
The NPU plugin's temperature is never alerted, in either interface, at any reading.

`update_views()` does not extend the views the base class built — it replaces them:

```python
self.views[i[self.get_key()]] = {'load': {}, 'freq': {}, 'mem': {}}
```

`temperature` is not in that dict, so `views[npu_id]['temperature']` does not exist, and both readers fall back to no style:

- `msg_curse` asks `get_views(item=..., key='temperature', option='decoration')` (`npu/__init__.py:249`), and `get_views` returns the string `'DEFAULT'` for a key it cannot find.
- `plugin-npu.vue:35` calls `getDecoration(npu.npu_id, 'temperature')`, whose first line returns `undefined` when the view is missing, so no class is bound.

Both sides were written expecting a decoration that nothing produces. The reading itself is real: `cards/intel.py:82` sets it from the driver (`temp_value / 1000.0`); AMD and Rockchip document it as not implemented and leave it `None`.

The sibling GPU plugin has had all three alerts — `proc`, `mem`, `temperature` — since it was written, so this is the NPU plugin missing one its own callers assume, not a feature neither has.

## The change

Adds `'temperature': {}` to the view dict and the alert beside the other three, in the GPU plugin's shape. A card that reports no reading keeps an empty view rather than being alerted on `None`, which `get_alert` would otherwise score through `(None * 100) / 100`.

`conf/glances.conf` gains the matching `[npu]` thresholds on the same 60/70/80 ladder `[gpu]` uses. That half is not cosmetic: with no limits configured, `get_alert` takes its `not careful and not warning and not critical` branch and returns `'DEFAULT'`, so the code change alone would be invisible.

I did not add `mem_*` thresholds to `[npu]`, although `update_views` computes a `mem` alert that is unconfigured for the same reason. Leaving a stat unthresholded is a normal default across the plugins; temperature is different only because two call sites already read a style for it.

## Verification

`pytest tests/test_plugin_npu.py` is 13 passed (new file); with `test_plugin_gpu.py` and `test_plugin_quicklook.py`, 56 passed / 9 skipped. `ruff check` and `ruff format --check` are clean.

Each half was checked by reverting it:

| reverted | fails |
|---|---|
| `'temperature'` dropped from the view dict (the shape on `develop`) | all 9 plugin tests |
| the alert block removed, the view key kept | 8 of 9 — the "driver reports None" test still passes, which is the discrimination it is for |
| the `[npu]` thresholds removed from `conf/glances.conf` | the 4 shipped-config tests only |

The last row is why the config assertions exist at all: without them the code change could be reverted in `conf/glances.conf` alone and every behavioural test would still pass while the alert stayed invisible.

I have no NPU to hand, so the assertions drive `update_views` over a synthetic card rather than a real one.
