### PR TITLE
fix(vms): colour the columns msg_curse already asks decorations for

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -623,6 +623,21 @@ port_default_gateway=True
 
 [vms]
 disable=True
+# Thresholds, same shape as [containers]. Leave commented to keep the VM table
+# uncoloured, which is what it was before these existed.
+# CPU is the per-second rate of the VM cpu_time; MEM is against that VM own
+# memory_total; LOAD is the 1 min load the engine reports, if it reports one.
+#cpu_careful=50
+#cpu_warning=70
+#cpu_critical=90
+#mem_careful=20
+#mem_warning=50
+#mem_critical=70
+#load_careful=70
+#load_warning=100
+#load_critical=500
+# Per-VM override, like containername_cpu_careful:
+#vmname_mem_careful=10
 # Define the maximum VMs size name (default is 20 chars)
 max_name_size=20
 # By default, Glances only display running VMs with states:

--- a/glances/plugins/vms/__init__.py
+++ b/glances/plugins/vms/__init__.py
@@ -237,9 +237,7 @@ class VmsPlugin(GlancesPluginModel):
             # sample and for engines that do not report CPU time.
             self._decorate(name, 'cpu_time_rate_per_sec', vm.get('cpu_time_rate_per_sec'), header='cpu')
             # MEM: as a percentage of that VM's own limit, like containers.
-            self._decorate(
-                name, 'memory_usage', vm.get('memory_usage'), header='mem', maximum=vm.get('memory_total')
-            )
+            self._decorate(name, 'memory_usage', vm.get('memory_usage'), header='mem', maximum=vm.get('memory_total'))
             # LOAD: engines that do not report it leave None (see the field
             # description), and msg_curse already skips the column in that case.
             self._decorate(name, 'load_1min', vm.get('load_1min'), header='load')

--- a/glances/plugins/vms/__init__.py
+++ b/glances/plugins/vms/__init__.py
@@ -189,6 +189,30 @@ class VmsPlugin(GlancesPluginModel):
             stats.extend(vms)
         return stats
 
+    def _decorate(self, name, field, value, header, maximum=None):
+        """Set one field's decoration from the configured thresholds.
+
+        A missing value needs no guard here: get_alert answers DEFAULT for one,
+        because the percentage it computes raises TypeError and is caught. A VM
+        whose engine reports no load, or whose rate has no previous sample yet,
+        is therefore left uncoloured rather than painted as idle. The base
+        update_views has already created the view, so this only replaces the
+        decoration and leaves optional/hidden as built.
+        """
+        if field not in self.views.get(name, {}):
+            return
+        if maximum is None:
+            alert = self.get_alert(value, header=header, action_key=name)
+            if alert == 'DEFAULT':
+                alert = self.get_alert(value, header=header)
+        else:
+            if not maximum:
+                return
+            alert = self.get_alert(value, maximum=maximum, header=header, action_key=name)
+            if alert == 'DEFAULT':
+                alert = self.get_alert(value, maximum=maximum, header=header)
+        self.views[name][field]['decoration'] = alert
+
     def update_views(self) -> bool:
         """Update stats views."""
         # Call the father's method
@@ -196,6 +220,29 @@ class VmsPlugin(GlancesPluginModel):
 
         if not self.stats:
             return False
+
+        # Thresholds for the columns msg_curse already asks decorations for.
+        # Without these every get_views(..., option='decoration') below returns
+        # 'DEFAULT', so the VM table is the one table in Glances that never
+        # changes colour -- the sibling containers plugin has done this since it
+        # was written.
+        #
+        # Per-VM overrides use the same action_key/fallback shape as containers,
+        # so `vmname_mem_careful=...` works the way `containername_cpu_careful`
+        # already does.
+        for vm in self.stats:
+            name = vm[self.get_key()]
+            # CPU: cpu_time is declared a rate in percent, so the derived
+            # *_rate_per_sec is the comparable number. It is absent on the first
+            # sample and for engines that do not report CPU time.
+            self._decorate(name, 'cpu_time_rate_per_sec', vm.get('cpu_time_rate_per_sec'), header='cpu')
+            # MEM: as a percentage of that VM's own limit, like containers.
+            self._decorate(
+                name, 'memory_usage', vm.get('memory_usage'), header='mem', maximum=vm.get('memory_total')
+            )
+            # LOAD: engines that do not report it leave None (see the field
+            # description), and msg_curse already skips the column in that case.
+            self._decorate(name, 'load_1min', vm.get('load_1min'), header='load')
 
         # Display Engine ?
         show_engine_name = False

--- a/tests/test_vms_decorations.py
+++ b/tests/test_vms_decorations.py
@@ -75,7 +75,9 @@ def test_a_column_reaches_critical_from_its_own_threshold(field, quiet, loud):
 def test_memory_is_measured_against_that_vm_own_total():
     # The same byte count is fine in a large VM and critical in a small one, so
     # a test that only moved memory_usage would pass against a fixed maximum.
-    plugin = build([vm(name='big', memory_usage=500, memory_total=10000), vm(name='small', memory_usage=500, memory_total=600)])
+    plugin = build(
+        [vm(name='big', memory_usage=500, memory_total=10000), vm(name='small', memory_usage=500, memory_total=600)]
+    )
     assert decoration(plugin, 'big', 'memory_usage') == 'OK'
     assert decoration(plugin, 'small', 'memory_usage') == 'CRITICAL'
 
@@ -109,7 +111,9 @@ def test_a_per_vm_override_wins_over_the_shared_threshold():
     # get_stat_name builds <plugin>_<action_key>_<header>, so the per-VM key
     # carries the plugin prefix too -- the conf line is `<vmname>_mem_careful`.
     limits = dict(LIMITS, vms_vm1_mem_careful=1, vms_vm1_mem_warning=2, vms_vm1_mem_critical=3)
-    plugin = build([vm(name='vm1', memory_usage=100, memory_total=1000), vm(name='vm2', memory_usage=100, memory_total=1000)])
+    plugin = build(
+        [vm(name='vm1', memory_usage=100, memory_total=1000), vm(name='vm2', memory_usage=100, memory_total=1000)]
+    )
     plugin._limits = limits
     plugin.update_views()
     assert decoration(plugin, 'vm1', 'memory_usage') == 'CRITICAL'

--- a/tests/test_vms_decorations.py
+++ b/tests/test_vms_decorations.py
@@ -1,0 +1,116 @@
+"""The VM table's colours.
+
+`msg_curse` in the vms plugin asks for a decoration on four columns, but no
+field declared `alert`/`log` and `update_views` set none, so every one of those
+reads returned 'DEFAULT': the VM table never changed colour, unlike the sibling
+containers table. These pin the thresholds that make those reads mean something,
+and the cases that must stay uncoloured.
+"""
+
+import pytest
+
+from glances.plugins.vms import VmsPlugin
+
+
+class _Args:
+    def __getattr__(self, name):
+        return False
+
+
+LIMITS = {
+    'vms_cpu_careful': 50,
+    'vms_cpu_warning': 70,
+    'vms_cpu_critical': 90,
+    'vms_mem_careful': 20,
+    'vms_mem_warning': 50,
+    'vms_mem_critical': 70,
+    'vms_load_careful': 70,
+    'vms_load_warning': 100,
+    'vms_load_critical': 500,
+}
+
+
+def vm(**overrides):
+    stat = {
+        'name': 'vm1',
+        'id': '1',
+        'status': 'running',
+        'engine': 'virsh',
+        'cpu_count': 2,
+        'cpu_time_rate_per_sec': 5.0,
+        'memory_usage': 100,
+        'memory_total': 1000,
+        'load_1min': 10.0,
+    }
+    stat.update(overrides)
+    return stat
+
+
+def build(stats, limits=LIMITS):
+    plugin = VmsPlugin(args=_Args())
+    plugin._limits = dict(limits)
+    plugin.stats = stats
+    plugin.update_views()
+    return plugin
+
+
+def decoration(plugin, name, field):
+    return plugin.get_views(item=name, key=field, option='decoration')
+
+
+@pytest.mark.parametrize(
+    ('field', 'quiet', 'loud'),
+    [
+        ('cpu_time_rate_per_sec', 5.0, 95.0),
+        ('memory_usage', 100, 950),
+        ('load_1min', 10.0, 600.0),
+    ],
+)
+def test_a_column_reaches_critical_from_its_own_threshold(field, quiet, loud):
+    plugin = build([vm(name='quiet', **{field: quiet}), vm(name='loud', **{field: loud})])
+    assert decoration(plugin, 'quiet', field) == 'OK'
+    assert decoration(plugin, 'loud', field) == 'CRITICAL'
+
+
+def test_memory_is_measured_against_that_vm_own_total():
+    # The same byte count is fine in a large VM and critical in a small one, so
+    # a test that only moved memory_usage would pass against a fixed maximum.
+    plugin = build([vm(name='big', memory_usage=500, memory_total=10000), vm(name='small', memory_usage=500, memory_total=600)])
+    assert decoration(plugin, 'big', 'memory_usage') == 'OK'
+    assert decoration(plugin, 'small', 'memory_usage') == 'CRITICAL'
+
+
+def test_a_missing_value_is_left_alone_rather_than_read_as_zero():
+    # Engines that do not report load leave None; painting it OK would claim a
+    # measurement that was never taken.
+    plugin = build([vm(load_1min=None)])
+    assert decoration(plugin, 'vm1', 'load_1min') == 'DEFAULT'
+
+
+def test_a_vm_with_no_memory_total_does_not_divide_by_zero():
+    plugin = build([vm(memory_total=0)])
+    assert decoration(plugin, 'vm1', 'memory_usage') == 'DEFAULT'
+
+
+def test_cpu_count_stays_uncoloured():
+    # A core count is not a threshold, so it keeps the read msg_curse already
+    # does and no colour.
+    plugin = build([vm(cpu_count=64)])
+    assert decoration(plugin, 'vm1', 'cpu_count') == 'DEFAULT'
+
+
+def test_no_configured_thresholds_leaves_the_table_as_it_was():
+    plugin = build([vm(cpu_time_rate_per_sec=99.0, memory_usage=999, load_1min=999.0)], limits={})
+    for field in ('cpu_time_rate_per_sec', 'memory_usage', 'load_1min'):
+        assert decoration(plugin, 'vm1', field) == 'DEFAULT'
+
+
+def test_a_per_vm_override_wins_over_the_shared_threshold():
+    # get_stat_name builds <plugin>_<action_key>_<header>, so the per-VM key
+    # carries the plugin prefix too -- the conf line is `<vmname>_mem_careful`.
+    limits = dict(LIMITS, vms_vm1_mem_careful=1, vms_vm1_mem_warning=2, vms_vm1_mem_critical=3)
+    plugin = build([vm(name='vm1', memory_usage=100, memory_total=1000), vm(name='vm2', memory_usage=100, memory_total=1000)])
+    plugin._limits = limits
+    plugin.update_views()
+    assert decoration(plugin, 'vm1', 'memory_usage') == 'CRITICAL'
+    assert decoration(plugin, 'vm2', 'memory_usage') == 'OK'


### PR DESCRIPTION
`msg_curse` in the vms plugin asks for a decoration on four columns:

```python
self.get_views(item=vm['name'], key='cpu_count', option='decoration')
self.get_views(item=vm['name'], key='cpu_time_rate_per_sec', option='decoration')
self.get_views(item=vm['name'], key='memory_usage', option='decoration')
self.get_views(item=vm['name'], key='load_1min', option='decoration')
```

**Nothing ever set one.** No vms field declares `alert` or `log`, so the base `_build_field_decoration` returns `'DEFAULT'` for every field, and `update_views` only computed `show_engine_name`. All four reads have always come back `'DEFAULT'` — the VM table is the one table in Glances that never changes colour, while the sibling containers table has done this since it was written.

## The change

Three of the four columns get thresholds, using the per-VM override and `DEFAULT` fallback that containers already uses:

| column | measured against | conf key |
|---|---|---|
| `cpu_time_rate_per_sec` | percent (the field is declared `rate` + `percent`) | `cpu_*` |
| `memory_usage` | **that VM's own** `memory_total` | `mem_*` |
| `load_1min` | the engine's 1-min load | `load_*` |

`cpu_count` keeps its read and no colour — a core count is not a threshold.

Decorations are written **onto** the views the base already built, rather than replacing the per-item view. That keeps `optional`/`hidden` intact; containers replaces the whole view (`self.views[key] = {'cpu': {}, 'mem': {}}`), which is why its curses code reads nested `'cpu'`/`'mem'` keys rather than field names.

The conf entries ship commented out, so **the table looks exactly as it does today** until someone opts in.

## Verification

`tests/test_vms_decorations.py` — 9 passed. Each claim was checked by reverting it:

| reverted | fails |
|---|---|
| memory measured against a fixed `100` instead of the VM's own `memory_total` | 4 tests |
| per-VM override dropped | 1 test (`..._override_wins_over_the_shared_threshold`) |

One thing that did **not** survive that check, and is worth mentioning because it changed the patch: I first wrote a `value is None` guard so a VM whose engine reports no load would be left alone rather than painted as idle. Removing it broke no test — `get_alert` already answers `DEFAULT` for a missing value, because the percentage it computes raises `TypeError` and is caught. The guard was code no test could distinguish from its absence, so it is gone and a test pins the real behaviour instead.

`pytest tests/ -k "vms or view or conf or limit"` — 93 passed, 14 skipped. The `test_restful.py` failures there (`test_006_all_limits`, `test_007_all_views`, `test_008_plugins_limits`, `test_009_plugins_views`, `test_014_config`) need a live server and fail identically on `develop` with this change stashed — same test names, checked rather than assumed.
