### PR TITLE
Fix return value in timeout permission fallback

### DIFF
--- a/glances/globals.py
+++ b/glances/globals.py
@@ -631,7 +631,7 @@ def exit_after(seconds, default=None):
                 # There is a "dirty" hack:
                 # https://forum.snapcraft.io/t/python-multiprocessing-permission-denied-in-strictly-confined-snap/15518/2
                 # But i prefer to just disable the timeout feature in this case
-                func(*args, **kwargs)
+                return func(*args, **kwargs)
             else:
                 p = ctx_mp_fork.Process(target=handler, args=(q, func, args, kwargs))
                 p.start()

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -13,23 +13,26 @@ import errno
 import socket
 from collections import OrderedDict
 from types import SimpleNamespace
+from unittest import TestCase
 from unittest.mock import patch
 
 from glances.globals import exit_after, get_ip_address
 
 
-def test_exit_after_preserves_result_when_queue_is_denied():
-    # Strict Snap confinement can prevent creation of the timeout queue.
-    # The synchronous fallback must still return the wrapped function's result.
-    with (
-        patch('glances.globals.LINUX', True),
-        patch('glances.globals.ctx_mp_fork.Queue', side_effect=PermissionError(errno.EACCES, 'Permission denied')),
-    ):
-        @exit_after(2, default=None)
-        def calculate_free(total, *, used):
-            return total - used
+class TestExitAfter(TestCase):
+    def test_preserves_result_when_queue_is_denied(self):
+        # Strict Snap confinement can prevent creation of the timeout queue.
+        # The synchronous fallback must still return the wrapped function's result.
+        with (
+            patch('glances.globals.LINUX', True),
+            patch('glances.globals.ctx_mp_fork.Queue', side_effect=PermissionError(errno.EACCES, 'Permission denied')),
+        ):
 
-        assert calculate_free(100, used=40) == 60
+            @exit_after(2, default=None)
+            def calculate_free(total, *, used):
+                return total - used
+
+            self.assertEqual(calculate_free(100, used=40), 60)
 
 
 def _stat(isup=True):

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -9,12 +9,27 @@
 
 """Tests for glances.globals helper functions."""
 
+import errno
 import socket
 from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from glances.globals import get_ip_address
+from glances.globals import exit_after, get_ip_address
+
+
+def test_exit_after_preserves_result_when_queue_is_denied():
+    # Strict Snap confinement can prevent creation of the timeout queue.
+    # The synchronous fallback must still return the wrapped function's result.
+    with (
+        patch('glances.globals.LINUX', True),
+        patch('glances.globals.ctx_mp_fork.Queue', side_effect=PermissionError(errno.EACCES, 'Permission denied')),
+    ):
+        @exit_after(2, default=None)
+        def calculate_free(total, *, used):
+            return total - used
+
+        assert calculate_free(100, used=40) == 60
 
 
 def _stat(isup=True):


### PR DESCRIPTION
#### Description

When creation of the multiprocessing queue raises a permission error, `exit_after` runs the wrapped function synchronously but discards its result. This can cause successful filesystem usage queries to return `None` in restricted environments such as strict Snap confinement.

Return the wrapped result from the fallback. Add a regression test that simulates queue permission denial and checks that positional and keyword arguments produce the expected return value.

#### Validation

* `python -m pytest tests/test_globals.py tests/test_core.py -q`: 55 passed, 6 skipped
* `python -m ruff check glances/globals.py tests/test_globals.py`: passed
* `python -m ruff format --check glances/globals.py tests/test_globals.py`: passed
* `git diff --check`: passed

An isolated reproduction failed before the fix and passed afterwards, with additional checks for zero and `None` results and exception propagation. Project tests ran on Windows with Python 3.12; the regression test simulates Linux queue permission denial. A real Snap environment has not been tested.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none
