### PR TITLE
fix(webui): colour a container's CPU and MEM the way curses already does

### DIFF
--- a/glances/outputs/static/js/components/plugin-containers.vue
+++ b/glances/outputs/static/js/components/plugin-containers.vue
@@ -38,10 +38,12 @@
                         <td v-show="!getDisableStats().includes('status')" scope="row" :class="getStatusClass(container.status)">
                             {{ container.status }}
                         </td>
-                        <td v-show="!getDisableStats().includes('cpu')" scope="row">
+                        <td v-show="!getDisableStats().includes('cpu')" scope="row"
+                            :class="getDecoration(container.name, 'cpu')">
                             {{ $filters.number(container.cpu_percent, 1) }}
                         </td>
-                        <td v-show="!getDisableStats().includes('mem')" scope="row">
+                        <td v-show="!getDisableStats().includes('mem')" scope="row"
+                            :class="getDecoration(container.name, 'mem')">
                             {{
                                 isNaN(container.memory_usage ?? NaN)
                                     ? '-'
@@ -138,10 +140,12 @@
                         <td v-show="!getDisableStats().includes('uptime')" scope="row">
                             {{ container.uptime }}
                         </td>
-                        <td v-show="!getDisableStats().includes('cpu')" scope="row">
+                        <td v-show="!getDisableStats().includes('cpu')" scope="row"
+                            :class="getDecoration(container.name, 'cpu')">
                             {{ $filters.number(container.cpu_percent, 1) }}
                         </td>
-                        <td v-show="!getDisableStats().includes('mem')" scope="row">
+                        <td v-show="!getDisableStats().includes('mem')" scope="row"
+                            :class="getDecoration(container.name, 'mem')">
                             {{
                                 isNaN(container.memory_usage ?? NaN)
                                     ? '-'
@@ -326,6 +330,20 @@ export default {
 			return (
 				GlancesHelper.getLimit("containers", "containers_disable_stats") || []
 			);
+		},
+		// The server decorates a container's cpu and mem against that
+		// container's own threshold from the config file, falling back to the
+		// global one. Curses reads it; this table did not, so a container over
+		// its limit was red in the terminal and plain black in the browser.
+		getDecoration(containerName, field) {
+			const containerViews = this.views[containerName];
+			if (containerViews == undefined || containerViews[field] == undefined) {
+				// A container seen in stats but not yet in views (they are
+				// published from the same snapshot, but a rename lands in one
+				// first). Leave it undecorated rather than throwing.
+				return;
+			}
+			return containerViews[field].decoration.toLowerCase();
 		},
 		getStatusClass(status) {
 			const lowerStatus = status.toLowerCase();

--- a/tests/test_plugin_containers_views.py
+++ b/tests/test_plugin_containers_views.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""The container CPU and MEM views carry the decoration both front ends read.
+
+The curses view reads these through get_views(item=..., key='cpu'|'mem',
+option='decoration'), and plugin-containers.vue reads the same two entries. A
+missing decoration is silent in both: get_views() answers 'DEFAULT' for a key it
+cannot find, so an over-threshold container simply renders in plain text.
+"""
+
+import os
+
+import pytest
+
+from glances.config import Config
+from glances.plugins.containers import ContainersPlugin
+
+
+def container(name, cpu_total, memory_usage, limit=1000):
+    return {
+        'name': name,
+        'id': name,
+        'engine': 'docker',
+        'status': 'running',
+        'cpu': {'total': cpu_total},
+        'memory': {'usage': memory_usage, 'limit': limit},
+    }
+
+
+@pytest.fixture
+def plugin(tmp_path):
+    """A plugin with explicit container thresholds, so the alerts are predictable."""
+    config_file = tmp_path / 'glances.conf'
+    config_file.write_text(
+        # Keys are section-relative: [containers] cpu_careful becomes the
+        # containers_cpu_careful limit.
+        '[containers]\n'
+        'cpu_careful=50\n'
+        'cpu_warning=70\n'
+        'cpu_critical=90\n'
+        'mem_careful=50\n'
+        'mem_warning=70\n'
+        'mem_critical=90\n',
+        encoding='utf-8',
+    )
+    return ContainersPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+
+
+class TestContainerDecorationViews:
+    def test_cpu_and_mem_views_exist_for_each_container(self, plugin):
+        plugin.stats = [container('quiet', 5.0, 50), container('busy', 95.0, 950)]
+        plugin.update_views()
+
+        for name in ('quiet', 'busy'):
+            assert name in plugin.views, f'{name} has no view entry'
+            for field in ('cpu', 'mem'):
+                assert field in plugin.views[name], f'{name} has no {field} view'
+                assert 'decoration' in plugin.views[name][field]
+
+    def test_a_container_over_its_threshold_is_not_left_plain(self, plugin):
+        plugin.stats = [container('quiet', 5.0, 50), container('busy', 95.0, 950)]
+        plugin.update_views()
+
+        # The point of the pair: something above the critical threshold must not
+        # come out as DEFAULT, which is what both front ends render as no colour.
+        assert plugin.views['busy']['cpu']['decoration'] != 'DEFAULT'
+        assert plugin.views['busy']['mem']['decoration'] != 'DEFAULT'
+        assert plugin.views['quiet']['cpu']['decoration'] == 'OK'
+
+    def test_the_view_is_keyed_by_container_name(self, plugin):
+        # Both readers index by name: curses passes item=container['name'], and
+        # the WebUI does this.views[container.name]. get_key() says 'name'; this
+        # pins that the views dict actually agrees.
+        assert plugin.get_key() == 'name'
+        plugin.stats = [container('named-thing', 10.0, 100)]
+        plugin.update_views()
+        assert 'named-thing' in plugin.views


### PR DESCRIPTION
## The defect

The containers plugin decorates each container's CPU and MEM in `update_views()`, against **that container's own threshold** from the config file (`[containers] cpu_careful=…`), falling back to the global one:

```python
alert = self.get_alert(i['cpu']['total'], header='cpu', action_key=i['name'])
if alert == 'DEFAULT':
    alert = self.get_alert(i['cpu']['total'], header='cpu')
self.views[i[self.get_key()]]['cpu']['decoration'] = alert
```

The curses view reads both back. `plugin-containers.vue` did not — it rendered the two cells as plain text, in **both** its narrow (`d-md-none`) and wide (`d-none d-md-block`) tables.

So a container above its limit is red in the terminal and black in the browser. It is silent from either side: `get_views()` answers `'DEFAULT'` for a key it cannot find, so a missing binding looks exactly like a deliberately undecorated column.

## The change

`.vue` only, plus a test. The component already exposes the views it needs — it uses them for `show_engine_name` and `show_pod_name` — so this adds a `getDecoration()` reader and four class bindings (two cells × two tables).

The reader is defensive the same way `plugin-diskio.vue` is: a container present in `stats` but not yet in `views` returns undefined rather than throwing.

The **limit** column next to memory usage stays undecorated on purpose: the server classifies usage *against* that limit, so the limit itself carries no alert.

## Evidence

There is no JS test harness here, so the added test pins the **server half of the pair** — the half the new binding depends on. Without it, removing the decoration upstream would take the colour out of both front ends with nothing failing.

Two-way mutation, run locally:

| Mutation | Result |
| --- | --- |
| none | 3 / 3 pass; with the existing `test_plugin_containers.py`, 18 / 18 |
| drop the server-side `['cpu']['decoration'] = alert` | **2 fail** |

One note on the test itself: my first version configured `containers_cpu_careful=…` and the alert came back `DEFAULT`, which looked like a second bug. It was my config — inside `[containers]` the key is section-relative (`cpu_careful`). The test now says so in a comment, since it is an easy trap for the next person writing one.
