### PR TITLE
fix(network): read the hide_threshold_bytes the plugin documents

### DIFF
--- a/glances/plugins/network/__init__.py
+++ b/glances/plugins/network/__init__.py
@@ -84,8 +84,10 @@ class NetworkPlugin(GlancesPluginModel):
         # Hide stats if it has never been != 0
         if config is not None:
             self.hide_zero = config.get_bool_value(self.plugin_name, 'hide_zero', default=False)
+            self.hide_threshold_bytes = config.get_int_value(self.plugin_name, 'hide_threshold_bytes', default=0)
         else:
             self.hide_zero = False
+            self.hide_threshold_bytes = 0
         self.hide_zero_fields = ['bytes_recv_rate_per_sec', 'bytes_sent_rate_per_sec']
 
         #  Add support for automatically hiding network interfaces that are down

--- a/tests/test_network_hide_threshold.py
+++ b/tests/test_network_hide_threshold.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""The network plugin honours the hide_threshold_bytes it documents.
+
+Both the reference configuration and docs/aoa/network.rst offer the option
+under [network]:
+
+    [network]
+    hide_zero=True
+    hide_threshold_bytes=0
+
+Nothing reports an option a plugin does not read -- the value simply stays at
+the base class default of 0 and every interface with any traffic at all is
+shown. These tests read the boundary back out of the views dict, so they fail
+if the option stops being wired up again.
+"""
+
+import os
+
+import pytest
+
+from glances.config import Config
+from glances.plugins.network import NetworkPlugin
+
+RECV = 'bytes_recv_rate_per_sec'
+SENT = 'bytes_sent_rate_per_sec'
+
+THRESHOLD = 1024
+
+
+def make_plugin(tmp_path, extra=''):
+    config_file = tmp_path / 'glances.conf'
+    config_file.write_text(f'[network]\nhide_zero=True\n{extra}', encoding='utf-8')
+    return NetworkPlugin(args=None, config=Config(config_dir=os.fspath(config_file)))
+
+
+@pytest.fixture
+def plugin(tmp_path):
+    return make_plugin(tmp_path, f'hide_threshold_bytes={THRESHOLD}\n')
+
+
+def interface(recv_rate, sent_rate, name='eth0'):
+    return {
+        'interface_name': name,
+        'key': 'interface_name',
+        'alias': None,
+        'is_up': True,
+        'speed': 0,
+        'time_since_update': 1.0,
+        'bytes_recv': 0,
+        'bytes_sent': 0,
+        'bytes_all': 0,
+        RECV: recv_rate,
+        SENT: sent_rate,
+        'bytes_all_rate_per_sec': recv_rate + sent_rate,
+    }
+
+
+def sample(plugin, stats):
+    """Feed one refresh and return the views for the single interface."""
+    plugin.stats = [stats]
+    plugin.update_views()
+    return plugin.views[stats['interface_name']]
+
+
+class TestNetworkHideThresholdBytes:
+    def test_the_option_reaches_the_plugin(self, plugin):
+        assert plugin.hide_threshold_bytes == THRESHOLD
+
+    def test_it_defaults_to_zero_when_not_configured(self, tmp_path):
+        assert make_plugin(tmp_path).hide_threshold_bytes == 0
+
+    def test_traffic_below_the_threshold_leaves_the_interface_hidden(self, plugin):
+        sample(plugin, interface(0, 0))
+        views = sample(plugin, interface(THRESHOLD - 500, THRESHOLD - 500))
+        assert views[RECV]['hidden'] is True
+        assert views[SENT]['hidden'] is True
+
+    def test_traffic_above_the_threshold_reveals_the_interface(self, plugin):
+        sample(plugin, interface(0, 0))
+        views = sample(plugin, interface(THRESHOLD * 2, 0))
+        assert views[RECV]['hidden'] is False
+
+    def test_without_a_threshold_any_traffic_reveals_the_interface(self, tmp_path):
+        # The default of 0 must keep behaving as it always did: a trickle that a
+        # configured threshold would swallow is still traffic.
+        no_threshold = make_plugin(tmp_path)
+        sample(no_threshold, interface(0, 0))
+        assert sample(no_threshold, interface(THRESHOLD - 500, 0))[RECV]['hidden'] is False


### PR DESCRIPTION
## The bug

`hide_threshold_bytes` is offered to users under `[network]` in two places:

`conf/glances.conf`
```ini
# Set hide_zero to True to automatically hide interface with no traffic
hide_zero=False
# Set hide_threshold_bytes to an integer value to automatically hide
# interface with traffic less or equal than this value
#hide_threshold_bytes=0
```

`docs/aoa/network.rst`
```ini
[network]
hide_zero=True
hide_threshold_bytes=0
```

`NetworkPlugin.__init__()` never read it. `diskio` has read it since the option was introduced; `network` was left out:

```python
# glances/plugins/diskio/__init__.py
self.hide_zero = config.get_bool_value(self.plugin_name, 'hide_zero', default=False)
self.hide_threshold_bytes = config.get_int_value(self.plugin_name, 'hide_threshold_bytes', default=0)

# glances/plugins/network/__init__.py
self.hide_zero = config.get_bool_value(self.plugin_name, 'hide_zero', default=False)
```

So the attribute stayed at the base-class default of `0` whatever the user wrote. Nothing reports it: `hide_zero` keeps working, it simply never applies the threshold, and an interface carrying a trickle of background traffic is shown when the user asked for it to be hidden.

## The change

Read it beside `hide_zero`, exactly as diskio does. Two lines, no new behaviour of its own.

## Tests

`tests/test_network_hide_threshold.py`, 5 tests. The wiring assertion alone would be weak, so the boundary is also read back out of the views dict: with `hide_threshold_bytes=1024`, an interface at 524 B/s stays hidden and one at 2048 B/s is revealed. The last test pins that the unconfigured default of `0` still reveals that same 524 B/s trickle, so this does not quietly change anyone's current behaviour.

Mutation — delete the added `get_int_value` line: **2 fail**, the wiring test and the "below the threshold stays hidden" behavioural test.

`tests/test_plugin_network.py` and `tests/test_lazy_views.py` — 45 passed. `ruff check` and `ruff format --check` clean.

Independent of #3725, which fixes the comparison this threshold is used in; either can go first.
