### PR TITLE
fix(webui): keep a row while any of its hide_zero fields is visible

### DIFF
--- a/glances/outputs/static/js/components/plugin-diskio.vue
+++ b/glances/outputs/static/js/components/plugin-diskio.vue
@@ -96,8 +96,11 @@ export default {
 					const readBytesRate = this.view[disk.name]["read_bytes_rate_per_sec"];
 					const writeBytesRate =
 						this.view[disk.name]["write_bytes_rate_per_sec"];
+					// A disk disappears only when every rate it is judged on has never
+					// moved -- the rule msg_curse applies. Requiring both to be visible
+					// instead hid a disk that has only ever been read, or only written.
 					return (
-						(!readBytesRate || readBytesRate.hidden === false) &&
+						(!readBytesRate || readBytesRate.hidden === false) ||
 						(!writeBytesRate || writeBytesRate.hidden === false)
 					);
 				});

--- a/glances/outputs/static/js/components/plugin-network.vue
+++ b/glances/outputs/static/js/components/plugin-network.vue
@@ -102,8 +102,12 @@ export default {
 						this.view[network.interfaceName]["bytes_recv_rate_per_sec"];
 					const bytesSentRate =
 						this.view[network.interfaceName]["bytes_sent_rate_per_sec"];
+					// An interface disappears only when every rate it is judged on has
+					// never moved -- the rule msg_curse applies. Requiring both to be
+					// visible instead hid an interface that has only ever received, or
+					// only ever sent.
 					return (
-						(!bytesRecvRate || bytesRecvRate.hidden === false) &&
+						(!bytesRecvRate || bytesRecvRate.hidden === false) ||
 						(!bytesSentRate || bytesSentRate.hidden === false)
 					);
 				});

--- a/tests/test_hide_zero_row_visibility.py
+++ b/tests/test_hide_zero_row_visibility.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""A row survives while any of its hide_zero fields is still visible.
+
+hide_zero is decided per field, but it is applied per row: msg_curse drops a
+disk only when *all* of its hide_zero_fields are hidden. plugin-diskio.vue and
+plugin-network.vue read the same views dict and must reach the same verdict, so
+these tests pin the rule on the side that can be tested here.
+
+The half-hidden state -- one rate above the threshold, the other below -- is the
+one where an "all fields visible" reading and an "all fields hidden" reading
+disagree, so that is what the tests build.
+"""
+
+import os
+from argparse import Namespace
+
+import pytest
+
+from glances.config import Config
+from glances.plugins.diskio import DiskioPlugin
+
+READ = 'read_bytes_rate_per_sec'
+WRITE = 'write_bytes_rate_per_sec'
+
+THRESHOLD = 1024
+
+
+def args():
+    """The plugin only draws when it is enabled, so msg_curse needs real args."""
+    return Namespace(
+        disable_diskio=False,
+        diskio_iops=False,
+        diskio_latency=False,
+        diskio_show_ramfs=False,
+        disable_history=True,
+    )
+
+
+@pytest.fixture
+def plugin(tmp_path):
+    config_file = tmp_path / 'glances.conf'
+    config_file.write_text(
+        f'[diskio]\nhide_zero=True\nhide_threshold_bytes={THRESHOLD}\n',
+        encoding='utf-8',
+    )
+    return DiskioPlugin(args=args(), config=Config(config_dir=os.fspath(config_file)))
+
+
+def disk(read_rate, write_rate, name='sda'):
+    return {
+        'disk_name': name,
+        'key': 'disk_name',
+        'time_since_update': 1.0,
+        'read_count': 0,
+        'write_count': 0,
+        'read_bytes': 0,
+        'write_bytes': 0,
+        'read_latency': 0,
+        'write_latency': 0,
+        READ: read_rate,
+        WRITE: write_rate,
+        'read_count_rate_per_sec': 0,
+        'write_count_rate_per_sec': 0,
+    }
+
+
+def sample(plugin, *disks):
+    plugin.stats = list(disks)
+    plugin.update_views()
+    return plugin.views
+
+
+def curse_text(plugin):
+    return ''.join(line['msg'] for line in plugin.msg_curse(args=plugin.args, max_width=40))
+
+
+class TestHalfHiddenRow:
+    """One rate above the threshold, the other below."""
+
+    def test_the_two_fields_really_do_disagree(self, plugin):
+        # Without this the tests below would pass on any rule at all.
+        sample(plugin, disk(0, 0))
+        views = sample(plugin, disk(THRESHOLD * 2, 0))
+        assert views['sda'][READ]['hidden'] is False
+        assert views['sda'][WRITE]['hidden'] is True
+
+    def test_a_read_only_disk_is_still_displayed(self, plugin):
+        sample(plugin, disk(0, 0))
+        sample(plugin, disk(THRESHOLD * 2, 0))
+        assert 'sda' in curse_text(plugin)
+
+    def test_a_write_only_disk_is_still_displayed(self, plugin):
+        sample(plugin, disk(0, 0))
+        sample(plugin, disk(0, THRESHOLD * 2))
+        assert 'sda' in curse_text(plugin)
+
+
+class TestFullyHiddenRow:
+    """Every field hidden is the only reason to drop a row."""
+
+    def test_a_disk_below_the_threshold_on_both_rates_is_dropped(self, plugin):
+        sample(plugin, disk(0, 0))
+        sample(plugin, disk(THRESHOLD - 500, THRESHOLD - 500))
+        assert 'sda' not in curse_text(plugin)
+
+    def test_a_busy_disk_is_displayed_beside_a_hidden_one(self, plugin):
+        sample(plugin, disk(0, 0, 'quiet'), disk(0, 0, 'busy'))
+        sample(plugin, disk(0, 0, 'quiet'), disk(THRESHOLD * 2, THRESHOLD * 2, 'busy'))
+        text = curse_text(plugin)
+        assert 'busy' in text
+        assert 'quiet' not in text


### PR DESCRIPTION
## The bug

`hide_zero` is decided per field but applied per row, and the two front ends read that per-field verdict in opposite directions.

`msg_curse` drops a row only when **all** of its `hide_zero_fields` are hidden:

```python
# glances/plugins/diskio/__init__.py, same in network
if all(self.get_views(item=i[self.get_key()], key=f, option='hidden') for f in self.hide_zero_fields):
    continue
```

`plugin-diskio.vue` and `plugin-network.vue` keep a row only when **all** of them are visible:

```js
return (
    (!readBytesRate || readBytesRate.hidden === false) &&
    (!writeBytesRate || writeBytesRate.hidden === false)
);
```

The two agree while both fields say the same thing, and disagree the moment one moves and the other does not — a disk that has only ever been read, an interface that has only ever received. Curses shows the row; the browser drops it entirely, with no indication that anything was filtered.

## Measured

`DiskioPlugin` with `hide_zero=True` and `hide_threshold_bytes=1024`, fed an idle sample then a read-only one (2048 B/s read, 0 B/s write). The views dict that both front ends then read:

```
sda.read_bytes_rate_per_sec.hidden  = false
sda.write_bytes_rate_per_sec.hidden = true
```

Both predicates run against exactly that payload:

| | verdict |
|---|---|
| `msg_curse` (`all(...hidden)` → drop) | shows the row |
| `.vue` before | **hides the row** |
| `.vue` after | shows the row |

## The change

Use the same rule as `msg_curse` in both components: `&&` → `||`, so a row survives while any of its fields is still visible. The existing `!rate ||` guard for a row that has stats but no view entry yet is untouched.

## Tests

The repo has no runner for the WebUI, so `tests/test_hide_zero_row_visibility.py` (5 tests) pins the rule on the side that can be tested here — including a test that first asserts the two fields really do disagree, so the rest cannot pass vacuously.

Mutation — turn the curses `all(...)` into `any(...)`, i.e. give it the reading the `.vue` had: **2 fail**, exactly the read-only and write-only cases.

`tests/test_plugin_diskio.py`, `tests/test_plugin_network.py`, `tests/test_lazy_views.py` — 86 passed. `ruff check` and `ruff format --check` clean.

## One note, not fixed here

`get_views()` answers `'DEFAULT'` for a key it cannot find, and `'DEFAULT'` is truthy, so `all(...)` treats a *missing* view as hidden while the `.vue` guard treats it as visible. That only bites in the window where a disk appears in stats before it appears in views, and fixing it is a different change from this one — happy to follow up if you want it.

Independent of #3725 and #3726.
