### PR TITLE
Replace the focus filter list on set instead of extending it

### DIFF
--- a/glances/filter.py
+++ b/glances/filter.py
@@ -36,7 +36,14 @@ class GlancesFilterList:
 
     @filter.setter
     def filter(self, value):
-        """Add a comma separated list of filters"""
+        """Set the filter list from a comma separated list of filters"""
+        # The setter is the whole list, not an addition to it, the way
+        # GlancesFilter's is. glances.conf is read when the plugin loads and the
+        # command line is applied just after, so appending left both live and
+        # OR-ed together -- --process-focus could widen the list set in
+        # glances.conf but never narrow it, against the precedence config.rst
+        # documents.
+        self._filter = []
         for f in value.split(','):
             self._add_filter(f)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -705,6 +705,16 @@ class TestGlances(unittest.TestCase):
         self.assertFalse(gfl.is_filtered({'name': 'snake is in the place'}))
         self.assertTrue(gfl.is_filtered({'name': 'snake is in the place', 'username': 'nicolargo'}))
         self.assertFalse(gfl.is_filtered({'name': 'snake is in the place', 'username': 'notme'}))
+        # Setting the filter replaces the list rather than adding to it. glances.conf
+        # is read when the processlist plugin loads and --process-focus is applied
+        # just after, so a setter that appended left both lists live and OR-ed: the
+        # command line could widen the focus set in glances.conf but never narrow it.
+        gfl = GlancesFilterList()
+        gfl.filter = '.*firefox.*'
+        gfl.filter = '.*python.*'
+        self.assertEqual([f.filter for f in gfl.filter], ['.*python.*'])
+        self.assertTrue(gfl.is_filtered({'name': 'python is in the place'}))
+        self.assertFalse(gfl.is_filtered({'name': 'firefox is in the place'}))
 
     def test_021_pretty_date(self):
         """Test pretty_date"""


### PR DESCRIPTION
#### Description

`GlancesFilterList.filter` appends to the existing list rather than replacing it, so
the property never describes *the current* filter — each assignment adds to whatever
was already there. Its sibling in the same file, `GlancesFilter.filter`, replaces.

That matters because both `process_focus` and `export_process_filter` are written
**twice** during a normal startup:

| | focus | export |
|---|---|---|
| `glances.conf` | `plugins/processlist/__init__.py:254` | `plugins/processlist/__init__.py:250` |
| command line | `processes.py:163` (`set_args`) | `standalone.py:71` |

The plugin loads the configuration file first, the command line is applied just
after, and `is_filtered()` ORs the accumulated list. So with

```ini
[processlist]
focus=.*firefox.*
```

```bash
glances --process-focus .*python.*
```

Glances focuses on **firefox and python together**. The command line can widen the
list set in `glances.conf`, but never narrow it — while `docs/config.rst` states:

> User-specific options override system-wide options, and options given on
> the command line overrides both.

Assigning the whole list restores that precedence: the configuration file is read
first, the command line replaces it. `--process-focus a,b` still yields both, since
that is one assignment.

Reproduced against `develop` before the change:

```
config focus=nginx      -> ['nginx']
--process-focus python  -> ['nginx', 'python']
is_filtered({'name': 'nginx'})  = True     <- command line could not narrow it
```

#### Resume

* Bug fix: **yes**
* New feature: no
* Fixed tickets: none open that I could find

#### Tests

Added to `test_020_filter` in `tests/test_core.py`: assign twice, assert the second
assignment is the whole filter. Verified by reverting `glances/filter.py` alone — the
new assertions fail with `['.*firefox.*', '.*python.*'] != ['.*python.*']`, and every
pre-existing assertion passes both with and without the change.

`tests/test_core.py`: 48 passed, 6 skipped. The process- and filter-related suites
(`test_processes_cache`, `test_plugin_processcount`, `test_sort_missing_values`,
`test_program_aggregation`, `test_globals`, `test_glances_stats`, `test_lazy_views`):
115 passed. `ruff check` clean; `ruff format --check` reports only a pre-existing
complaint at `tests/test_core.py:422`, which is present on an unmodified `develop`.
