### PR TITLE
Read a False config switch as False in get_conf_value

### DIFF
--- a/glances/plugins/plugin/model.py
+++ b/glances/plugins/plugin/model.py
@@ -1024,9 +1024,14 @@ class GlancesPluginModel:
 
         try:
             ret = self._limits[plugin_name + '_' + value]
-            return bool(ret[0]) if convert_bool else ret
         except KeyError:
             return default
+        if not convert_bool:
+            return ret
+        # load_limits stores a key as a one-item list of strings, or as a float when
+        # it parses as a number. bool('False') is True and a float has no [0], so
+        # read the text the way the *_log check above and the WebUI already do.
+        return ret[0].lower() == 'true' if isinstance(ret, list) else bool(ret)
 
     def is_show(self, value, header=""):
         """Return True if the value is in the show configuration list.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1410,6 +1410,33 @@ class TestGlances(unittest.TestCase):
     #         # but not on my localLinux computer...
     #         # self.assertEqual(secure_popen('echo FOO | grep FOO'), 'FOO\n')
 
+    def test_708_conf_value_convert_bool(self):
+        """Test get_conf_value(convert_bool=True) reads False as False."""
+        print('INFO: [TEST_708] get_conf_value convert_bool')
+        from glances.config import Config
+
+        def disable_vms(raw):
+            config = Config()
+            config.parser.read_string(f'[processlist]\ndisable_virtual_memory={raw}\n')
+            plugin = GlancesPluginModel(config=config)
+            plugin.plugin_name = 'processlist'
+            plugin.load_limits(config)
+            return plugin.get_conf_value('disable_virtual_memory', convert_bool=True, default=False)
+
+        self.assertIs(disable_vms('True'), True)
+        self.assertIs(disable_vms('true'), True)
+        # load_limits keeps text as ['False'], and bool('False') is True: the
+        # documented off switch used to hide the VIRT column instead.
+        self.assertIs(disable_vms('False'), False)
+        # A value that parses as a number is stored as a float, which has no [0].
+        self.assertIs(disable_vms('1'), True)
+        self.assertIs(disable_vms('0'), False)
+
+        # Unset still falls back to the caller's default.
+        plugin = GlancesPluginModel(config=Config())
+        plugin.plugin_name = 'processlist'
+        self.assertIs(plugin.get_conf_value('disable_virtual_memory', convert_bool=True, default=False), False)
+
     def test_999_the_end(self):
         """Free all the stats"""
         print('INFO: [TEST_999] Free the stats')


### PR DESCRIPTION
#### Description

`docs/aoa/ps.rst` documents `disable_virtual_memory` as a switch in `[processlist]`, but
setting it to `False` **hides** the VIRT column in the curses UI, and a numeric value
raises.

`get_conf_value(convert_bool=True)` (`glances/plugins/plugin/model.py`) returned:

```python
return bool(ret[0]) if convert_bool else ret
```

`load_limits` stores a value that is not a number as a one-item list of strings, so
`disable_virtual_memory=False` reaches this as `['False']`, and `bool('False')` is `True`.
A value that *is* a number is stored as a float, which has no `[0]`.

Against `develop`, building `ProcesslistPlugin` from a config with only that key:

```
disable_virtual_memory=True  -> True
disable_virtual_memory=False -> True        # should be False
disable_virtual_memory=0     -> TypeError: 'float' object is not subscriptable
disable_virtual_memory=1     -> TypeError: 'float' object is not subscriptable
```

The two other readers of boolean limits already do it right:

- the WebUI, for this very key (`plugin-processlist.vue`, `getDisableVms`):
  `return ret[0].toLowerCase() === "true" ? true : false;`
- the `*_log` check a few lines above in `model.py`:
  `return self._limits[stat_name + '_log'][0].lower() == 'true'`

so the same `glances.conf` currently shows VIRT in the WebUI and hides it in the curses UI.

The fix reads the text the same way and takes `bool()` of a float. The only callers of
`convert_bool=True` are the two `disable_virtual_memory` checks in
`plugins/processlist/__init__.py`.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none open — the option was added in #3299

#### Tests

`test_708_conf_value_convert_bool` in `tests/test_core.py` covers `True`, `true`, `False`,
`1`, `0`, and an unset key falling back to the default. Reverting `model.py` alone fails it
at the `False` case (`AssertionError: True is not False`).

`tests/test_core.py`: 49 passed, 6 skipped. `ruff check` clean; `ruff format --check`
reports only the existing `tests/test_core.py:422`, present on an unmodified `develop`.
