### PR TITLE
Let --disable-separator and --disable-bg override glances.conf

### DIFF
--- a/glances/outputs/glances_curses.py
+++ b/glances/outputs/glances_curses.py
@@ -211,14 +211,19 @@ class _GlancesCurses:
         """Load the outputs section of the configuration file."""
         if config is not None and config.has_section('outputs'):
             logger.debug('Read the outputs section in the configuration file')
+            # The command line overrides the configuration file (docs/config.rst).
+            # --disable-separator (and --disable-unicode, see main.py) can only turn
+            # the separator off, and --disable-bg can only turn the background off,
+            # so a flag that is set keeps its value and the file decides otherwise.
+            # Passing the flag in as the default let any value in the file win.
             # Separator
-            self.args.enable_separator = config.get_bool_value(
-                'outputs', 'separator', default=self.args.enable_separator
+            self.args.enable_separator = self.args.enable_separator and config.get_bool_value(
+                'outputs', 'separator', default=True
             )
             # Set the left sidebar list
             self._left_sidebar = config.get_list_value('outputs', 'left_menu', default=self._left_sidebar)
             # Background color
-            self.args.disable_bg = config.get_bool_value('outputs', 'disable_bg', default=self.args.disable_bg)
+            self.args.disable_bg = self.args.disable_bg or config.get_bool_value('outputs', 'disable_bg', default=False)
 
     def _right_sidebar(self):
         return [

--- a/tests/test_glances_curses.py
+++ b/tests/test_glances_curses.py
@@ -213,3 +213,38 @@ class TestCursorDisable:
         glancescreen.args.arrow_keys_sort = False
         self._dispatch(glancescreen, curses.KEY_LEFT)
         assert glancescreen.args.cursor_process_name_position == 2  # nosec B101
+
+
+class TestLoadConfigPrecedence:
+    """docs/config.rst: options given on the command line override the file."""
+
+    @staticmethod
+    def load(outputs, **args):
+        from glances.config import Config
+
+        config = Config()
+        config.parser.read_dict({'outputs': outputs})
+        screen = _GlancesCurses.__new__(_GlancesCurses)
+        screen.args = SimpleNamespace(**args)
+        screen._left_sidebar = ['network']
+        screen.load_config(config)
+        return screen.args
+
+    def test_disable_separator_flag_beats_config(self):
+        # --disable-separator, or --disable-unicode via main.py, leaves it False.
+        args = self.load({'separator': 'True'}, enable_separator=False, disable_bg=False)
+        assert args.enable_separator is False
+
+    def test_disable_bg_flag_beats_config(self):
+        args = self.load({'disable_bg': 'False'}, enable_separator=True, disable_bg=True)
+        assert args.disable_bg is True
+
+    def test_config_applies_when_no_flag_is_given(self):
+        args = self.load({'separator': 'False', 'disable_bg': 'True'}, enable_separator=True, disable_bg=False)
+        assert args.enable_separator is False
+        assert args.disable_bg is True
+
+    def test_defaults_are_kept_when_the_keys_are_absent(self):
+        args = self.load({'left_menu': 'network'}, enable_separator=True, disable_bg=False)
+        assert args.enable_separator is True
+        assert args.disable_bg is False


### PR DESCRIPTION
#### Description

Same class as #3728: `docs/config.rst` says

> options given on the command line overrides both.

but in the curses UI a value in `[outputs]` beats the matching command-line flag.
`_GlancesCurses.load_config` (`glances/outputs/glances_curses.py`) passes the flag in as
the *default*:

```python
self.args.enable_separator = config.get_bool_value(
    'outputs', 'separator', default=self.args.enable_separator
)
...
self.args.disable_bg = config.get_bool_value('outputs', 'disable_bg', default=self.args.disable_bg)
```

so whenever the key is present in the file, the file wins. Measured with the real
`GlancesMain().get_args()` parser against `develop`:

```
glances --disable-separator   [outputs] separator=True    -> enable_separator=True   (flag ignored)
glances --disable-unicode     [outputs] separator=True    -> enable_separator=True   (flag ignored)
glances --disable-bg          [outputs] disable_bg=False  -> disable_bg=False        (flag ignored)
glances                       [outputs] separator=False   -> enable_separator=False  (file applies)
```

The `--disable-unicode` row also undoes `main.py`'s own `# Unicode => No separator`, which
sets `enable_separator = False` before the curses UI loads its config.

Both keys ship commented out in `conf/glances.conf` (`#separator=True`, `#disable_bg=True`),
so this only bites someone who uncomments them — which is exactly when a one-off flag is
supposed to win.

The fix relies on both flags moving in one direction only: `--disable-separator` is
`store_false` and `--disable-bg` is `store_true`. So a flag that is set keeps its value, and
the file decides otherwise:

```python
self.args.enable_separator = self.args.enable_separator and config.get_bool_value('outputs', 'separator', default=True)
self.args.disable_bg = self.args.disable_bg or config.get_bool_value('outputs', 'disable_bg', default=False)
```

With no flag, or with the key absent, the result is identical to before — only the "flag and
key disagree" case changes. After the fix, the same four runs give `False`, `False`, `True`,
`False`.

#### Resume

* Bug fix: yes
* New feature: no
* Fixed tickets: none open

#### Tests

`TestLoadConfigPrecedence` in `tests/test_glances_curses.py`, built like the existing
`glancescreen` fixture (`_GlancesCurses.__new__` + `SimpleNamespace`, no terminal):

- `--disable-separator` beats `separator=True`
- `--disable-bg` beats `disable_bg=False`
- with no flag, the file still applies both keys
- with the keys absent, the defaults are kept

Reverting `glances_curses.py` alone fails exactly the first two; the last two pass either
way, which is the point — they guard that the file keeps working when no flag is given.

`tests/test_core.py` + `tests/test_glances_curses.py`: 61 passed, 6 skipped (curses via
`windows-curses` on this machine). `ruff check` and `ruff format --check` are clean on both
changed files.
