### PR TITLE
Read web_x_ssl_verify as a boolean, not as a CA bundle path

### DIFF
--- a/conf/glances.conf
+++ b/conf/glances.conf
@@ -615,6 +615,8 @@ port_default_gateway=True
 # web_x_description is optional (if not set, define to URL)
 # web_x_timeout is optional and overwrite the default timeout value
 # web_x_rtt_warning is optional and defines the warning respond time in ms (approximately)
+# web_x_ssl_verify is optional (default is True): False to skip the certificate check,
+# or the path to a CA bundle file
 #
 #web_1_url=https://blog.nicolargo.com
 #web_1_description=My Blog

--- a/docs/aoa/ports.rst
+++ b/docs/aoa/ports.rst
@@ -51,6 +51,8 @@ configuration file.
     # web_x_description is optional (if not set, define to URL)
     # web_x_timeout is optional and overwrite the default timeout value
     # web_x_rtt_warning is optional and defines the warning respond time in ms (approximately)
+    # web_x_ssl_verify is optional (default is True): False to skip the certificate check,
+    # or the path to a CA bundle file
     #
     web_1_url=https://blog.nicolargo.com
     web_1_description=My Blog

--- a/glances/web_list.py
+++ b/glances/web_list.py
@@ -83,8 +83,15 @@ class GlancesWebList:
                 # Indice
                 new_web['indice'] = 'web_' + str(i)
 
-                # ssl_verify
-                new_web['ssl_verify'] = config.get_value(self._section, f'{postfix}ssl_verify', default=True)
+                # ssl_verify: a boolean, or the path to a CA bundle (both are valid
+                # values for Requests' verify argument). get_value returns the raw
+                # string, and Requests reads a string as a path, so 'false' and even
+                # 'true' were looked up as CA bundle file names and every scan of the
+                # URL failed with "Could not find a suitable TLS CA certificate bundle".
+                try:
+                    new_web['ssl_verify'] = config.get_bool_value(self._section, f'{postfix}ssl_verify')
+                except ValueError:
+                    new_web['ssl_verify'] = config.get_value(self._section, f'{postfix}ssl_verify')
                 # Proxy
                 http_proxy = config.get_value(self._section, f'{postfix}http_proxy', default=None)
 

--- a/tests/test_web_list_ssl_verify.py
+++ b/tests/test_web_list_ssl_verify.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Glances - An eye on your system
+#
+# SPDX-FileCopyrightText: 2026 Nicolas Hennion <nicolas@nicolargo.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+
+"""Tests for web_x_ssl_verify in the URL monitoring list."""
+
+import pytest
+
+from glances.config import Config
+from glances.web_list import GlancesWebList
+
+CONFIG = """
+[ports]
+refresh=30
+timeout=3
+port_default_gateway=False
+web_1_url=https://example.com
+web_1_ssl_verify=false
+web_2_url=https://example.com
+web_2_ssl_verify=true
+web_3_url=https://example.com
+web_3_ssl_verify=/etc/ssl/certs/ca-bundle.crt
+web_4_url=https://example.com
+"""
+
+
+@pytest.fixture
+def web_list(tmp_path):
+    conf_file = tmp_path / 'glances.conf'
+    conf_file.write_text(CONFIG)
+    return GlancesWebList(config=Config(config_dir=str(conf_file))).get_web_list()
+
+
+def ssl_verify(web_list, indice):
+    return next(web['ssl_verify'] for web in web_list if web['indice'] == indice)
+
+
+# Requests reads a string `verify` as the path to a CA bundle, so a boolean written
+# in the configuration file has to reach it as a boolean: 'false' (and 'true') used
+# to fail every scan of the URL with "Could not find a suitable TLS CA certificate
+# bundle, invalid path: false".
+def test_ssl_verify_false_is_a_boolean(web_list):
+    assert ssl_verify(web_list, 'web_1') is False
+
+
+def test_ssl_verify_true_is_a_boolean(web_list):
+    assert ssl_verify(web_list, 'web_2') is True
+
+
+def test_ssl_verify_keeps_a_ca_bundle_path(web_list):
+    assert ssl_verify(web_list, 'web_3') == '/etc/ssl/certs/ca-bundle.crt'
+
+
+def test_ssl_verify_defaults_to_true(web_list):
+    assert ssl_verify(web_list, 'web_4') is True


### PR DESCRIPTION
## Description

`web_x_ssl_verify` reaches `requests` as a string, and Requests reads a string `verify` as the path to a CA bundle. So the value written in `glances.conf` is looked up as a file name, measured with Requests locally:

| `verify` | result |
| --- | --- |
| `'false'` | `OSError: Could not find a suitable TLS CA certificate bundle, invalid path: false` |
| `'true'` | `OSError: ... invalid path: true` |
| `False` / `True` | the request is actually performed |

`GlancesWebList` (`glances/web_list.py:87`) builds the value with `config.get_value()`, which returns the raw string, and `ThreadScanner._web_scan` (`glances/plugins/ports/__init__.py:312`) passes it straight to `requests.head(verify=...)`. The `except Exception` two lines below turns the `OSError` into `web['status'] = 'Error'` with only a `logger.debug` line, and `status not in [200, 301, 302]` is CRITICAL in both the curses view and the WebUI.

So a healthy URL shows as permanently red as soon as the user sets the key — including setting it to `true`, which is what you write to turn verification back on explicitly.

The sibling key in the same section reads its boolean properly (`glances/ports_list.py:43` `port_default_gateway`), and `Config.get_bool_value()` exists for exactly this, already used by the network and diskio plugins.

## Resume

- Read the key with `config.get_bool_value()`.
- Keep a non-boolean value as a string: a path to a CA bundle is a valid value for Requests' `verify`, and it is the one form that worked before, so `web_1_ssl_verify=/etc/ssl/certs/ca-bundle.crt` keeps working.
- The key was undocumented (no mention in `conf/glances.conf` or `docs/aoa/ports.rst`), which is probably how this survived; documented next to the other `web_x_` options.

New tests in `tests/test_web_list_ssl_verify.py` build a real `Config` from a temp `glances.conf` and read the list through `GlancesWebList`:

- `false` → `False`, `true` → `True`
- guard: a CA bundle path stays a string
- guard: the key omitted still means `True`

With `glances/web_list.py` reverted, the first two fail (`assert 'false' is False`) and the two guards pass. `pytest tests/test_web_list_ssl_verify.py tests/test_plugin_ports.py tests/test_core.py` → 70 passed, 6 skipped. `ruff check` and `ruff format --check` clean on both files.

## Fixed tickets

None open; I did not find an issue for this.
