### PR TITLE
Remember that a connections probe was disabled

### DIFF
--- a/glances/plugins/connections/__init__.py
+++ b/glances/plugins/connections/__init__.py
@@ -102,12 +102,20 @@ class ConnectionsPlugin(GlancesPluginModel):
         # We want to display the stat in the curse interface
         self.display_curse = True
 
+        # A probe that fails is not tried again for the rest of the session. These
+        # have to live on the plugin: update() starts every refresh from a fresh copy
+        # of stats_init_value, so a flag written into stats was forgotten immediately
+        # and the call was made (and the warning logged) again on the next refresh.
+        self.net_connections_enabled = True
+        self.nf_conntrack_enabled = True
+
     def update_for_net_connections_method(self, stats):
         try:
             net_connections = psutil.net_connections(kind="tcp")
         except Exception as e:
             logger.warning(f'Can not get network connections stats ({e})')
             logger.info('Disable connections stats')
+            self.net_connections_enabled = False
             stats['net_connections_enabled'] = False
 
             return stats
@@ -136,12 +144,14 @@ class ConnectionsPlugin(GlancesPluginModel):
             except (OSError, FileNotFoundError) as e:
                 logger.warning(f'Can not get network connections track ({e})')
                 logger.info('Disable connections track')
+                self.nf_conntrack_enabled = False
                 stats['nf_conntrack_enabled'] = False
 
                 return stats
         if 'nf_conntrack_max' in stats and 'nf_conntrack_count' in stats:
             stats['nf_conntrack_percent'] = stats['nf_conntrack_count'] * 100 / stats['nf_conntrack_max']
         else:
+            self.nf_conntrack_enabled = False
             stats['nf_conntrack_enabled'] = False
 
         return stats
@@ -155,15 +165,17 @@ class ConnectionsPlugin(GlancesPluginModel):
         """
         # Init new stats
         stats = self.get_init_value()
+        stats['net_connections_enabled'] = self.net_connections_enabled
+        stats['nf_conntrack_enabled'] = self.nf_conntrack_enabled
 
         if self.input_method == 'local':
             # Update stats using the PSUtils lib
 
             # Grab network interface stat using the psutil net_connections method
-            if stats['net_connections_enabled']:
+            if self.net_connections_enabled:
                 stats = self.update_for_net_connections_method(stats)
 
-            if stats['nf_conntrack_enabled']:
+            if self.nf_conntrack_enabled:
                 stats = self.update_for_nf_conntrack_method(stats)
         elif self.input_method == 'snmp':
             # Update stats using SNMP

--- a/tests/test_connections_states.py
+++ b/tests/test_connections_states.py
@@ -1,5 +1,6 @@
 """Tests for the connections plugin state counters."""
 
+from time import time
 from unittest import mock
 
 import psutil
@@ -89,3 +90,74 @@ def test_conntrack_alert_reads_the_tracked_percentage(conntrack_plugin):
 
 def test_conntrack_alert_stays_ok_below_the_first_threshold(conntrack_plugin):
     assert conntrack_decoration(conntrack_plugin, 10) == 'OK'
+
+
+@pytest.fixture
+def enabled_plugin(plugin):
+    """A plugin the refresh decorator will actually let run."""
+    plugin.args = mock.Mock(time=2, disable_connections=False, disable_history=True)
+    plugin.input_method = 'local'
+    return plugin
+
+
+def refresh(plugin, times):
+    """Call update() as the main loop does, with the refresh delay behind us."""
+    for _ in range(times):
+        plugin.refresh_timer.target = time() - 1
+        plugin.update()
+
+
+@pytest.fixture
+def conntrack_reads(enabled_plugin, tmp_path, monkeypatch):
+    """Point the conntrack file at a path that does not exist, and count the reads."""
+    reads = []
+    missing = str(tmp_path / 'nf_conntrack_count')
+    monkeypatch.setattr(enabled_plugin, 'conntrack', {'nf_conntrack_count': missing})
+    real_open = open
+
+    def counting_open(path, *args, **kwargs):
+        if path == missing:
+            reads.append(path)
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.open', counting_open)
+    return reads
+
+
+# update() starts each refresh from a copy of stats_init_value, so a plugin that gave up
+# on a probe used to forget it: the missing /proc file was read, and the warning logged,
+# on every single refresh.
+def test_failed_conntrack_probe_is_not_retried(enabled_plugin, conntrack_reads):
+    with mock.patch('psutil.net_connections', return_value=[]):
+        refresh(enabled_plugin, 3)
+
+    assert len(conntrack_reads) == 1
+    assert enabled_plugin.get_raw()['nf_conntrack_enabled'] is False
+
+
+def test_failed_net_connections_probe_is_not_retried(enabled_plugin, conntrack_reads):
+    with mock.patch('psutil.net_connections', side_effect=OSError('nope')) as net_connections:
+        refresh(enabled_plugin, 3)
+
+    assert net_connections.call_count == 1
+    assert enabled_plugin.get_raw()['net_connections_enabled'] is False
+
+
+def test_working_probes_keep_running(enabled_plugin, tmp_path, monkeypatch):
+    count = tmp_path / 'nf_conntrack_count'
+    count.write_text('42' + chr(10))
+    maximum = tmp_path / 'nf_conntrack_max'
+    maximum.write_text('100' + chr(10))
+    monkeypatch.setattr(
+        enabled_plugin,
+        'conntrack',
+        {'nf_conntrack_count': str(count), 'nf_conntrack_max': str(maximum)},
+    )
+
+    with mock.patch('psutil.net_connections', return_value=[]) as net_connections:
+        refresh(enabled_plugin, 3)
+
+    assert net_connections.call_count == 3
+    stats = enabled_plugin.get_raw()
+    assert stats['nf_conntrack_enabled'] is True
+    assert stats['nf_conntrack_percent'] == 42.0


### PR DESCRIPTION
## Description

The connections plugin stops using a probe that fails — `psutil.net_connections()` raising, or the `nf_conntrack` files not being present — and records that by writing `net_connections_enabled` / `nf_conntrack_enabled` into `stats`.

But `update()` starts every refresh with `stats = self.get_init_value()`, which is `copy.copy(self.stats_init_value)`, and `stats_init_value` has both flags `True` (`glances/plugins/connections/__init__.py:98`). The flag is written into a dict that is thrown away at the end of the refresh, and the next refresh calls the failing probe again.

Measured by pointing `conntrack` at a file that does not exist and refreshing three times:

```
cycle 0: stats['nf_conntrack_enabled'] = False
cycle 1: stats['nf_conntrack_enabled'] = False
cycle 2: stats['nf_conntrack_enabled'] = False
conntrack read attempts: 3          (1 after this PR)
"Can not get network connections track" warnings: 3   (1 after this PR)
```

So on any host without `/proc/sys/net/netfilter/nf_conntrack_*` — macOS, Windows, a Linux kernel without the module — the warning plus its `Disable connections track` info line are logged on every single refresh.

The same applies to the `psutil.net_connections()` guard, and that one matters beyond the log: the plugin is disabled by default *"because it consumes lots of CPU"*, so a user who turns it on (config or the `K` key) on a host where the call raises, such as macOS without root, pays for the failing call every refresh.

Every other plugin that gives up keeps the flag outside the per-refresh stats: `mem` with `self.zfs_enabled` (`mem/__init__.py:134`, read at `:180`), `sensors` with its grabber's `init` flag, `wifi` with a module-level check.

## Resume

- Keep `net_connections_enabled` / `nf_conntrack_enabled` on the plugin instance, set to `False` the first time a probe fails.
- Copy them into `stats` at the start of each refresh, so `update_views()`, `msg_curse()` and the REST/WebUI payload still carry the same two fields as before.

Tests in `tests/test_connections_states.py`:

- a failed conntrack read happens once across three refreshes, and the flag stays `False`
- a raising `psutil.net_connections` is called once across three refreshes
- guard: when both probes work, they keep running every refresh and `nf_conntrack_percent` is still computed

The tests drive the real `update()` with the refresh timer pushed past its deadline between calls, the way the main loop reaches it; without that, the refresh timer alone would make any version of the code look correct.

With `glances/plugins/connections/__init__.py` reverted, the first two fail (3 reads / 3 calls instead of 1) and the guard passes. `pytest tests/test_connections_states.py tests/test_core.py tests/test_plugin_ports.py` → 75 passed, 6 skipped. `ruff check` and `ruff format --check` clean.

## Fixed tickets

None open; I did not find an issue for this.
