### PR TITLE
refactor(main): reduce cyclomatic complexity of init_plugins

### DIFF
--- a/glances/main.py
+++ b/glances/main.py
@@ -729,12 +729,22 @@ Examples of use:
 
     def init_plugins(self, args):
         """Init Glances plugins"""
-        # Allow users to disable plugins from the glances.conf (issue #1378)
+        self._disable_plugins_from_config(args)
+        self._apply_plugin_args(args)
+        self._activate_exporters(args)
+        self._init_display_defaults(args)
+        self._sync_process_plugins(args)
+        self._init_export_process_filter(args)
+
+    def _disable_plugins_from_config(self, args):
+        """Allow users to disable plugins from the glances.conf (issue #1378)."""
         for s in self.config.sections():
             if self.config.has_section(s) and (self.config.get_bool_value(s, 'disable', False)):
                 disable(args, s)
                 logger.debug(f'{s} disabled by the configuration file')
-        # The configuration key can be overwrite from the command line
+
+    def _apply_plugin_args(self, args):
+        """The configuration key can be overwrite from the command line."""
         if args and args.disable_plugin and 'all' in args.disable_plugin.split(','):
             if not args.enable_plugin:
                 logger.critical("'all' key in --disable-plugin needs to be used with --enable-plugin")
@@ -750,11 +760,14 @@ Examples of use:
             for p in args.enable_plugin.split(','):
                 enable(args, p)
 
-        # Exporters activation
+    def _activate_exporters(self, args):
+        """Exporters activation."""
         if args.export is not None:
             for p in args.export.split(','):
                 setattr(args, 'export_' + p, True)
 
+    def _init_display_defaults(self, args):
+        """Set the default display options."""
         # By default help is hidden
         args.help_tag = False
 
@@ -762,14 +775,16 @@ Examples of use:
         args.network_sum = False
         args.network_cumul = False
 
-        # Processlist is updated in processcount
+    def _sync_process_plugins(self, args):
+        """Processlist is updated in processcount."""
         if getattr(args, 'disable_processcount', False):
             logger.warning('Processcount is disable, so processlist (updated by processcount) is also disable')
             disable(args, 'processlist')
         elif getattr(args, 'enable_processlist', False) or getattr(args, 'enable_programlist', False):
             enable(args, 'processcount')
 
-        # Set a default export_process_filter (with all process) when using the stdout mode
+    def _init_export_process_filter(self, args):
+        """Set a default export_process_filter (with all process) when using the stdout mode."""
         if getattr(args, 'stdout', True) and args.process_filter is None:
             setattr(args, 'export_process_filter', '.*')
 


### PR DESCRIPTION
## Summary

Related to #3460 — takes on `GlancesMain.init_plugins` (glances/main.py), currently the highest-complexity function in the codebase (19, grade C per radon).

The method mixes six independent concerns in one body; each is extracted into a focused helper, and `init_plugins` becomes a plain sequence:

- `_disable_plugins_from_config` — plugins disabled via glances.conf (issue #1378)
- `_apply_plugin_args` — `--disable-plugin` / `--enable-plugin` handling, including the `all` guard
- `_activate_exporters` — `--export` activation
- `_init_display_defaults` — help/network display flags
- `_sync_process_plugins` — processcount/processlist coupling
- `_init_export_process_filter` — default export process filter in stdout mode

## Complexity

| Function | Before | After |
|---|---|---|
| `init_plugins` | 19 (C) | 1 (A) |
| `_apply_plugin_args` | — | 9 (B) |
| `_disable_plugins_from_config` | — | 4 (A) |
| `_sync_process_plugins` | — | 4 (A) |
| `_activate_exporters` | — | 3 (A) |
| `_init_export_process_filter` | — | 3 (A) |
| `_init_display_defaults` | — | 1 (A) |

## Verification

- **No behaviour change**: a differential harness ran the previous implementation and this one side by side on identical `args` across **1536 combinations** of disable/enable plugin lists (including the `all` + `SystemExit` paths) × export lists × processcount/processlist/programlist flags × stdout mode × process filter × config-disabled sections — resulting `args` state and exit behaviour are identical in every case
- Full test suite: 593 passed, 16 skipped (same as baseline)
- `ruff check` and `ruff format --check` clean
